### PR TITLE
Fix topic message and user mentions colors

### DIFF
--- a/css/black.css
+++ b/css/black.css
@@ -454,7 +454,7 @@
   ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #949494 !important; }
   ts-message .pinned_item_message_header { color: #949494; }
   ts-message .mention { background: #545454 !important; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
-  ts-message .internal_member_link { background: #222 !important; color: #949494 !important; border: 0px; }
+  ts-message .internal_member_link { background: #222 !important; border: 0; color: #949494 !important; }
   ts-message .internal_member_link:hover { color: #c7c7c7 !important; }
   ts-message.show_recap:not(.is_pinned) { background: rgba(0, 0, 0, 0.15); }
   ts-message.show_recap:not(.is_pinned):hover { background: rgba(0, 0, 0, 0.15); }

--- a/css/black.css
+++ b/css/black.css
@@ -378,6 +378,9 @@
   #recent_mentions_toggle:hover { color: #bf360c; }
   #rxn_toast_div { background: #000; border: 1px solid #545454; }
   .presence { color: #949494; }
+  #channel_topic_text { background: #222; }
+  #edit_topic_container:hover { overflow: hidden !important; }
+  #edit_topic_trigger { color: #949494; }
   #banner { background: #000; }
   #banner a { color: #949494; }
   .banner_content { color: #e6e6e6; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
@@ -450,7 +453,9 @@
   ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #949494 !important; }
   ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #949494 !important; }
   ts-message .pinned_item_message_header { color: #949494; }
-  ts-message .mention { background: #545454; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
+  ts-message .mention { background: #545454 !important; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
+  ts-message .internal_member_link { background: #222 !important; color: #949494 !important; border: 0px; }
+  ts-message .internal_member_link:hover { color: #c7c7c7 !important; }
   ts-message.show_recap:not(.is_pinned) { background: rgba(0, 0, 0, 0.15); }
   ts-message.show_recap:not(.is_pinned):hover { background: rgba(0, 0, 0, 0.15); }
   ts-mention { background: rgba(130, 130, 130, 0.1); color: #e6e6e6; }

--- a/css/raw/black.css
+++ b/css/raw/black.css
@@ -758,6 +758,12 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .presence { color: #949494; }
 
+#channel_topic_text { background: #222; }
+
+#edit_topic_container:hover { overflow: hidden !important; }
+
+#edit_topic_trigger { color: #949494; }
+
 #banner { background: #000; }
 
 #banner a { color: #949494; }
@@ -902,7 +908,11 @@ ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_i
 
 ts-message .pinned_item_message_header { color: #949494; }
 
-ts-message .mention { background: #545454; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
+ts-message .mention { background: #545454 !important; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
+
+ts-message .internal_member_link { background: #222 !important; color: #949494 !important; border: 0px; }
+
+ts-message .internal_member_link:hover { color: #c7c7c7 !important; }
 
 ts-message.show_recap:not(.is_pinned) { background: rgba(0, 0, 0, 0.15); }
 

--- a/css/raw/black.css
+++ b/css/raw/black.css
@@ -910,7 +910,7 @@ ts-message .pinned_item_message_header { color: #949494; }
 
 ts-message .mention { background: #545454 !important; border: 1px solid #828282; border-radius: 3px; color: #e6e6e6; padding: 0 3px; }
 
-ts-message .internal_member_link { background: #222 !important; color: #949494 !important; border: 0px; }
+ts-message .internal_member_link { background: #222 !important; border: 0; color: #949494 !important; }
 
 ts-message .internal_member_link:hover { color: #c7c7c7 !important; }
 

--- a/scss/modules/header/_base.scss
+++ b/scss/modules/header/_base.scss
@@ -137,3 +137,17 @@
 .presence {
   color: $color-highlight;
 }
+
+#channel_topic_text {
+  background: $color-base;
+}
+
+#edit_topic_container {
+  &:hover {
+    overflow: hidden !important;
+  }
+}
+
+#edit_topic_trigger {
+  color: $base-link-color;
+}

--- a/scss/modules/messaging/_base.scss
+++ b/scss/modules/messaging/_base.scss
@@ -167,15 +167,15 @@ ts-message {
     padding: 0 3px;
   }
 
-.internal_member_link {
-  background: $color-base !important;
-  color: $base-link-color !important;
-  border: 0px;
+  .internal_member_link {
+    background: $color-base !important;
+    border: 0;
+    color: $base-link-color !important;
 
-  &:hover {
-    color: $base-link-color-active !important;
+    &:hover {
+      color: $base-link-color-active !important;
+    }
   }
-}
 
   &.show_recap:not(.is_pinned) {
     background: rgba($color-shade-darkest, 0.15);

--- a/scss/modules/messaging/_base.scss
+++ b/scss/modules/messaging/_base.scss
@@ -160,12 +160,22 @@ ts-message {
   }
 
   .mention {
-    background: $color-shade-light;
+    background: $color-shade-light !important;
     border: 1px solid $color-shade-lightest;
     border-radius: 3px;
     color: $base-font-color;
     padding: 0 3px;
   }
+
+.internal_member_link {
+  background: $color-base !important;
+  color: $base-link-color !important;
+  border: 0px;
+
+  &:hover {
+    color: $base-link-color-active !important;
+  }
+}
 
   &.show_recap:not(.is_pinned) {
     background: rgba($color-shade-darkest, 0.15);


### PR DESCRIPTION
After an update made by Slack team over the last few days, the color of channel topics and mentions have broken. Fixes #119.

- Topic message
  - Before
![topic-before](https://user-images.githubusercontent.com/10513251/30437028-049e582a-9944-11e7-9fff-94220909fcc7.PNG)
  - After
![topic-after](https://user-images.githubusercontent.com/10513251/30437253-8482a8f2-9944-11e7-9f22-138753eb4462.PNG)

- User mentions
  - Before
![user-mention-before](https://user-images.githubusercontent.com/10513251/30437283-96e6b682-9944-11e7-8e1c-a2f49b60ab9e.PNG)
  - After
![user-mention-after](https://user-images.githubusercontent.com/10513251/30437292-9b032b88-9944-11e7-98ab-5f2aaf79a664.PNG)

- Channel mentions
  - Before
![channel-mention-before](https://user-images.githubusercontent.com/10513251/30437302-a370d6bc-9944-11e7-9fbd-9f2a35d7be6c.PNG)
  - After
![channel-mention-after](https://user-images.githubusercontent.com/10513251/30437308-a76bd99c-9944-11e7-8eba-5a33255237ce.PNG)

If there is anything wrong with my changes or something that can be improved, please let me know!
