### PR TITLE
Fix messages background for the latest Slack version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2018-04-17
+* Fixed background color for messages panel
 
 ## 2018-02-09
 * Support for new mention classes ([#141](https://github.com/laCour/slack-night-mode/issues/141))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,33 @@ Unfortunately, if you're using the desktop version of Slack, you will not** be a
 
 ** However you can still use this theme using this little hack: https://github.com/laCour/slack-night-mode/issues/73#issuecomment-242707078
 
+#### Instructions for macOS
+- Open `/Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js`
+- Add this snippet to the bottom of that file
+- Replace `/absolute/path/to` with path to your `black.css`
+- You will have to re-add this everytime Slack update itself.
+```js
+document.addEventListener('DOMContentLoaded', function() {
+  var fs = require('fs'),
+  filePath = '/absolute/path/to/black.css';
+
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+    if (err) {
+        console.log(err);
+        return
+    }
+      var css = document.createElement('style');
+      css.type = "text/css";
+      if (css.styleSheet){
+        css.styleSheet.cssText = data;
+      } else {
+        css.appendChild(document.createTextNode(data));
+      }
+      document.getElementsByTagName('head')[0].appendChild(css);
+  })
+});
+```
+
 ## Themes
 
 ### Supported

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unfortunately, if you're using the desktop version of Slack, you will not** be a
 - Open `/Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js`
 - Add this snippet to the bottom of that file
 - Replace `/absolute/path/to` with path to your `black.css`
-- You will have to re-add this everytime Slack update itself.
+- You will have to re-add this every time Slack updates itself.
 ```js
 document.addEventListener('DOMContentLoaded', function() {
   var fs = require('fs'),

--- a/css/black.css
+++ b/css/black.css
@@ -647,7 +647,7 @@
   .inline_color_block { border-color: #545454; }
   .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #222; border-bottom: 1px solid #222; }
   .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { box-shadow: 0 32px #222; }
-  .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background-color:#222; }
+  .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar), .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background-color:#222; }
   .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #e6e6e6; }
   .p-message_pane__unread_banner__banner { background: #545454; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   .messages_banner { color: #e6e6e6; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }

--- a/css/black.css
+++ b/css/black.css
@@ -1,4 +1,4 @@
-@-moz-document regexp("https://[^./]*\\.slack\\.com/(?!pricing)(?!security).*") { body { background: #222; color: #e6e6e6; }
+  body { background: #222; color: #e6e6e6; }
   a { color: #949494; }
   a:link, a:visited { color: #949494; }
   a:hover, a:active, a:focus { color: #c7c7c7; }
@@ -645,8 +645,9 @@
   ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #949494; }
   ts-message .reply_bar:hover { background: #222; border-color: #000; }
   .inline_color_block { border-color: #545454; }
-  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background: #222; border-bottom: 1px solid #222; }
-  .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #222; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #222; border-bottom: 1px solid #222; }
+  .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { box-shadow: 0 32px #222; }
+  .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background-color:#222; }
   .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #e6e6e6; }
   .p-message_pane__unread_banner__banner { background: #545454; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   .messages_banner { color: #e6e6e6; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
@@ -1988,4 +1989,4 @@
   .para_menu .options a.active span { filter: grayscale(2) brightness(2); }
   .para_menu .options a span { filter: grayscale(2) brightness(5); }
   .para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
-  .para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); } }
+  .para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); }

--- a/css/raw/black.css
+++ b/css/raw/black.css
@@ -1289,9 +1289,11 @@ ts-message .reply_bar:hover { background: #222; border-color: #000; }
 
 .inline_color_block { border-color: #545454; }
 
-.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background: #222; border-bottom: 1px solid #222; }
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #222; border-bottom: 1px solid #222; }
 
-.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #222; }
+.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { box-shadow: 0 32px #222; }
+
+.p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background-color:#222; }
 
 .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #e6e6e6; }
 

--- a/css/raw/black.css
+++ b/css/raw/black.css
@@ -1291,7 +1291,7 @@ ts-message .reply_bar:hover { background: #222; border-color: #000; }
 
 .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #222; border-bottom: 1px solid #222; }
 
-.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { box-shadow: 0 32px #222; }
+.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar), .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { box-shadow: 0 32px #222; }
 
 .p-message_pane .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { background-color:#222; }
 

--- a/scss/modules/messaging/_banners.scss
+++ b/scss/modules/messaging/_banners.scss
@@ -12,7 +12,7 @@
   }
 
   .c-message_list:not(.c-virtual_list--scrollbar):before,
-  .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
+  .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before {
     background-color: $color-base;
   }
 

--- a/scss/modules/messaging/_banners.scss
+++ b/scss/modules/messaging/_banners.scss
@@ -1,5 +1,5 @@
 .p-message_pane {
-  .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
+  .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider {
     background: $color-base;
     border-bottom: 1px solid $color-base;
   }
@@ -7,10 +7,13 @@
   .p-message_pane__top_banners:not(:empty) + div .c-message_list {
     &:not(.c-virtual_list--scrollbar),
     &.c-virtual_list--scrollbar > .c-scrollbar__hider {
-      &:before {
-        box-shadow: 0 32px $color-base;
-      }
+      box-shadow: 0 32px $color-base;
     }
+  }
+
+  .c-message_list:not(.c-virtual_list--scrollbar):before,
+  .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before {
+    background-color: $color-base;
   }
 
   &__foreword__description,


### PR DESCRIPTION
I had to remove `@-moz-document regexp("https://[^./]*\\.slack\\.com/(?!pricing)(?!security).*") {}`  in built css for styles to work inside Slack app.