### PR TITLE
correct color on team member and user listings

### DIFF
--- a/scss/modules/flexpane/_team.scss
+++ b/scss/modules/flexpane/_team.scss
@@ -167,3 +167,11 @@
     background: $color-shade-light;
   }
 }
+
+.c-unified_member__display-name,
+.c-unified_member__secondary-name,
+.c-unified_member__title,
+.c-unified_member__other-names,
+.c-unified_member__other-names {
+  color: $base-font-color !important;
+}


### PR DESCRIPTION
Before:
https://cl.ly/0V06423J1T3a
https://cl.ly/1V0E0r3Q303g

After:
https://cl.ly/1B302e083C00
https://cl.ly/3t2Y0w071x2b

The colors for user names in several contexts were not being styled
correctly due to new class selectors being used in Slack. This commit
adds those selectors to the theme and sets them to the base-font-color.

Test Plan:
- View the members of a Group or Channel, verify that their names appear
  light on dark
- Using <CMD>+K, search for a user to begin a Direct Message with,
  verify that the names in the results appear light on dark