### PR TITLE
correct background-color of message--editing element

### DIFF
--- a/scss/modules/inputs/_messaging.scss
+++ b/scss/modules/inputs/_messaging.scss
@@ -173,6 +173,12 @@
 }
 
 .c-message {
+  &--editing {
+    background: $color-shade-dark;
+    border-color: $color-shade-dark;
+    color: $base-font-color;
+  }
+
   &__editor {
     &__input {
       background: $color-shade-light;


### PR DESCRIPTION
Fixes #164

Before: https://cl.ly/3a3f0O0z2A1F
After:  https://cl.ly/3v03280i3M14

This updates the background color and border of the div responsible for
editing an existing message.

Test Plan:
- Send a message to a Channel or Direct Message
- Edit your own message (press the up arrow, or use the hover menu on
  the message)
- Verify that the background color of the editing element is grey
  instead of yellow