### PR TITLE
darken colors on mentions and reactions

### DIFF
--- a/scss/modules/emojis/_reactions.scss
+++ b/scss/modules/emojis/_reactions.scss
@@ -18,12 +18,14 @@
     background-color: rgba($color-shade-mid, 0.08);
     border-color: rgba($color-shade-lightest, 0.4) !important;
 
-    .emoji_rxn_count {
+    .emoji_rxn_count,
+    .c-reaction__count {
       color: $base-font-color;
     }
   }
 
-  .emoji_rxn_count {
+  .emoji_rxn_count,
+  .c-reaction__count {
     color: $base-font-color;
   }
 

--- a/scss/modules/emojis/_reactions.scss
+++ b/scss/modules/emojis/_reactions.scss
@@ -1,17 +1,20 @@
-.rxn {
-  background: $color-shade-darkest;
+.rxn,
+.c-reaction,
+.c-reaction_add,
+.c-member_slug {
+  background: $color-shade-dark;
   border: 1px solid $color-shade-light;
 
   &.active,
   &:hover {
-    border-color: $color-shade-mid;
+    background: $color-shade-mid;
 
     .emoji_rxn_count {
       color: $base-font-color;
     }
   }
 
-  &.user_reacted {
+  &.c-reaction--reacted {
     background-color: rgba($color-shade-mid, 0.08);
     border-color: rgba($color-shade-lightest, 0.4) !important;
 

--- a/scss/modules/flexpane/_mentions.scss
+++ b/scss/modules/flexpane/_mentions.scss
@@ -17,13 +17,15 @@
   color: $base-link-color;
 }
 
-a.c-member_slug {
+a.c-member_slug,
+.c-mrkdwn__subteam--link {
   background: $color-shade-dark;
   border: 1px solid $color-shade-light;
   color: $base-font-color;
 
   &.active,
   &:hover {
+    color: $base-font-color;
     background: $color-shade-mid;
   }
 }

--- a/scss/modules/flexpane/_mentions.scss
+++ b/scss/modules/flexpane/_mentions.scss
@@ -17,7 +17,7 @@
   color: $base-link-color;
 }
 
-.c-member_slug,
+a.c-member_slug,
 .c-member_slug--link,
 .c-mrkdwn__subteam--link {
   background: $color-shade-dark;

--- a/scss/modules/flexpane/_mentions.scss
+++ b/scss/modules/flexpane/_mentions.scss
@@ -16,3 +16,14 @@
 #member_mentions h3 a {
   color: $base-link-color;
 }
+
+a.c-member_slug {
+  background: $color-shade-dark;
+  border: 1px solid $color-shade-light;
+  color: $base-font-color;
+
+  &.active,
+  &:hover {
+    background: $color-shade-mid;
+  }
+}

--- a/scss/modules/flexpane/_mentions.scss
+++ b/scss/modules/flexpane/_mentions.scss
@@ -17,7 +17,8 @@
   color: $base-link-color;
 }
 
-a.c-member_slug,
+.c-member_slug,
+.c-member_slug--link,
 .c-mrkdwn__subteam--link {
   background: $color-shade-dark;
   border: 1px solid $color-shade-light;
@@ -25,7 +26,7 @@ a.c-member_slug,
 
   &.active,
   &:hover {
-    color: $base-font-color;
     background: $color-shade-mid;
+    color: $base-font-color;
   }
 }


### PR DESCRIPTION
Fixes #162, #132 

- Mentions & Reactions
  - Before: https://cl.ly/1r2I383m0o3u
  - After: https://cl.ly/1O3U0C1j1a1s
- Group Mentions
  - Before: https://cl.ly/1q032D19381c
  - After: https://cl.ly/323d3C034012
- Mentions in Editor
  - Before: https://cl.ly/1t0q370u0F3m
  - After: https://cl.ly/3c3Z0d0T3c1y

This commit attempts to restore some themed colors to the new class
selectors for reactions and user mentions. I tweaked the styles a tad to
make the background stand out a bit more from the base background of the
channel.

Test Plan:
  - Using the mouse, react to a message in a channel
  - Verify that both the button for adding a reaction and the reactions themselves matches the theme
  - Mention someone in a channel, verify that the mention link matches the theme
  - Mention a Slack Group in a channel, verify that the mention link matches the theme
