### PR TITLE
correct color on file attachment titles

### DIFF
--- a/scss/modules/messaging/_attachments.scss
+++ b/scss/modules/messaging/_attachments.scss
@@ -440,6 +440,10 @@
       color: $base-font-color;
     }
   }
+
+  .c-file__title {
+    color: $base-font-color;
+  }
 }
 
 .message--focus .file_container .preview_show.preview_show_less .preview_show_btn {


### PR DESCRIPTION
Before: https://cl.ly/1v392c1w1z1d
After: https://cl.ly/3h3O012p2T39

Test Plan:
- Post a link or a file to a channel such that it renders similar to the
  above screenshots
- Verify that the title of the file is light and readable