### PR TITLE
correct colors on user and channel tokens in search results

### DIFF
--- a/scss/modules/menu/_autocomplete.scss
+++ b/scss/modules/menu/_autocomplete.scss
@@ -139,6 +139,11 @@
         .text {
           color: $base-font-color;
         }
+
+        .token {
+          background-color: $color-shade-mid;
+          color: $base-font-color;
+        }
       }
     }
 


### PR DESCRIPTION
Before: https://cl.ly/1b2y0y1M010l
After: https://cl.ly/3I1B0i01400u

Test Plan:
  - Using the Search input in the top-right of slack attempt to find messages from someone by entering "from:"
  - Notice the suggested results, and verify that the background and foreground colors of the user mentions better match the theme