### PR TITLE
WIP: Revert or Fix "Brighten style of channel purpose"

### DIFF
--- a/scss/modules/modals/_channels.scss
+++ b/scss/modules/modals/_channels.scss
@@ -35,10 +35,6 @@
   .channel_browser_sort_container::after {
     color: $base-font-color;
   }
-
-  .channel_browser_channel_purpose {
-    color: $base-font-color;
-  }
 }
 
 .channel_invite_member .add_icon,


### PR DESCRIPTION
Reverts laCour/slack-night-mode#171

Creating this PR because this change didn't do what it was supposed to. The style is being overridden by the .sk_black class. When working on this I did a quick test by modifying the css in the page but I think I must have modified it in the wrong place. Next time ill test this in stylish first. 

I've thought of two options so far... Welcome to feedback.

We could override this and make it just inherit. This would fix this and maybe make other styling easier. 
`.sk_black { color: inherit; }`
Fully define the selector but I don't like this for maintainability.
`div.channel_browser_channel_purpose.sk_black.margin_bottom_25 { color: $base-font-color; }`