### PR TITLE
Make apps page dark when adding new app

### DIFF
--- a/scss/modules/pages/_apps.scss
+++ b/scss/modules/pages/_apps.scss
@@ -218,6 +218,15 @@ a.splash_interactive__window_link {
   .app_desc_expand_showing .app_profile_desc_fade {
     background: linear-gradient(180deg, rgba($color-base, 0) 0, $color-base 100%);
   }
+
+  .service_panel {
+    background-color: $color-shade-dark;
+  }
+  
+  .service_card {
+    background-color: $color-base;
+    border: 1px solid $color-shade-mid;
+  }
 }
 
 .app_card,

--- a/scss/modules/pages/_apps.scss
+++ b/scss/modules/pages/_apps.scss
@@ -222,7 +222,7 @@ a.splash_interactive__window_link {
   .service_panel {
     background-color: $color-shade-dark;
   }
-  
+
   .service_card {
     background-color: $color-base;
     border: 1px solid $color-shade-mid;


### PR DESCRIPTION

![google_calendar-2](https://user-images.githubusercontent.com/828108/41684089-617edf14-7491-11e8-9259-f8fe67925c38.jpg)
The two sections pointed out in this screenshot were light. 
