### PR TITLE
Fix thread message box input color

### DIFF
--- a/css/raw/black.css
+++ b/css/raw/black.css
@@ -360,7 +360,29 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #msg_input.disabled, #msg_input.ql-disabled { background-color: #363636; border-color: #363636; color: #949494; }
 
-#msg_input_message { background-color: #363636; color: #e6e6e6; }
+#message_input { background: #545454; border-color: #424242; color: #e6e6e6; }
+
+#message_input::-webkit-input-placeholder { color: #e6e6e6 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+#message_input::-moz-placeholder { color: #e6e6e6 !important; filter: none; opacity: 0.5; }
+
+#message_input::placeholder { color: #e6e6e6 !important; filter: none; opacity: 0.5; }
+
+#message_input[data-placeholder]:empty::before { color: #e6e6e6 !important; }
+
+#message_input:focus, #message_input.focus { border-color: #363636; }
+
+#message_input:focus + #primary_file_button:not(:hover):not(.active), #message_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #363636; }
+
+#message_input + #primary_file_button:not(:hover):not(.active) { border-color: #424242; }
+
+#message_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #424242; }
+
+#message_input.offline:not(.pretend-to-be-online) { background-color: #363636 !important; color: #949494; }
+
+#message_input.disabled, #message_input.ql-disabled { background-color: #363636; border-color: #363636; color: #949494; }
+
+#message_input_message { background-color: #363636; color: #e6e6e6; }
 
 #primary_file_button { background: padding-box #545454; border-color: #424242; color: #949494; }
 


### PR DESCRIPTION
we saw that in the threads, the message input has the `message_input` class instead of the `msg_input` class, so the style for the black theme is not correctly displayed. We added those custom classes to fix this.

![image](https://user-images.githubusercontent.com/1013633/45109367-f862a500-b104-11e8-8249-b3d84ec96818.png)
