### PR TITLE
Add solarized dark+light themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This is based on Slack's aubergine/maroon style. It's the original theme.
 * **Arc ([source](scss/themes/_arc-dark.scss) - [build](css/variants/arc-dark.css))** _by [@Lemmmy](https://github.com/Lemmmy)_
 * **Midnight Blue ([source](scss/themes/_midnight-blue.scss) - [build](css/variants/midnight-blue.css))** _by [@matt-h](https://github.com/matt-h)_
 * **Tomorrow Dark (base16) ([repository](https://github.com/danarnold/slack-night-mode))** _by [@danarnold](https://github.com/danarnold)_
+* **Solarized Dark ([source](scss/themes/_solarized-dark.scss) - [build](css/variants/solarized-dark.css))** _by [@glostis](https://github.com/glostis)_
+* **Solarized Light ([source](scss/themes/_solarized-light.scss) - [build](css/variants/solarized-light.css))** _by [@glostis](https://github.com/glostis)_
 
 ### Extensions
 

--- a/css/raw/variants/solarized-dark.css
+++ b/css/raw/variants/solarized-dark.css
@@ -1,0 +1,4066 @@
+body { background: #002b36; color: #a1adad; }
+
+a { color: #268bd2; }
+
+a:link, a:visited { color: #268bd2; }
+
+a:hover, a:active, a:focus { color: #dc322f; }
+
+hr { border-bottom: 1px solid #002b36; border-top: 1px solid #002b36; }
+
+h1, h2, h3, h4 { color: #a1adad; }
+
+h1 a { color: #a1adad; }
+
+h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #a1adad; }
+
+.bordered { border: 1px solid #00232c; }
+
+.top_border { border-top: 1px solid #00232c; }
+
+.bottom_border { border-bottom: 1px solid #00232c; }
+
+.left_border { border-left: 1px solid #00232c; }
+
+.right_border { border-right: 1px solid #00232c; }
+
+.bullet { color: #2aa198; }
+
+.alert, .c-alert, .c-alert--boxed { background-color: #00232c; border-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.alert h4, .c-alert h4, .c-alert--boxed h4 { color: #a1adad; }
+
+.alert-info { background-color: #00232c; border-color: #00171d; color: #a1adad; }
+
+.alert-info h4 { color: #a1adad; }
+
+::-webkit-scrollbar-track { background: #00232c !important; border-left-color: #00232c !important; border-right-color: #00232c !important; color: #00232c !important; }
+
+::-webkit-scrollbar-thumb { background: #003340 !important; border-left-color: #00232c !important; border-right-color: #00232c !important; color: #002b36 !important; }
+
+::-webkit-scrollbar-corner { background: #002b36 !important; }
+
+.supports_custom_scrollbar #messages_container::after { background: none !important; }
+
+.monkey_scroll_bar { background: #002b36; }
+
+.monkey_scroll_handle_inner { background: #003340; border: 1px solid #003f50; }
+
+.monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+
+#client-ui .monkey_scroll_bar { background: #002b36; }
+
+#client-ui .monkey_scroll_handle_inner { background: #003340; border: 3px solid #002b36; }
+
+.c-scrollbar--monkey .c-scrollbar__track { background: #002b36; }
+
+.c-scrollbar--monkey .c-scrollbar__bar { background: #003340; box-shadow: 0 3px 0 #002b36, 0 -3px 0 #002b36; }
+
+.client_channels_list_container { background-color: #00232c; border-right-color: #002b36; }
+
+#col_channels { color: #a1adad; }
+
+.p-channel_sidebar { background-color: #00232c; color: #a1adad; }
+
+.p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(161, 173, 173, 0.8) !important; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #a1adad; }
+
+.p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #002b36 !important; }
+
+.p-channel_sidebar__header { color: #a1adad !important; }
+
+.p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #a1adad; }
+
+.p-channel_sidebar__channel--im .c-presence--away { color: #2aa198; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #003340 !important; }
+
+.p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #003340 !important; }
+
+.p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #a1adad; }
+
+.p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #a1adad; }
+
+.p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #dc322f; }
+
+.p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #003340; }
+
+.p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #b1bbbb !important; }
+
+.p-channel_sidebar__close_container:hover { background: #00171d; }
+
+.p-channel_sidebar__jumper { background: transparent !important; }
+
+.channels_list_holder h2 { color: #a1adad !important; }
+
+.channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #a1adad; opacity: 0.8; }
+
+.channels_list_holder ul { color: #a1adad !important; }
+
+.channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #00232c; color: rgba(161, 173, 173, 0.8) !important; }
+
+.channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #002b36 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+
+.channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #002b36; }
+
+.channels_list_holder ul li.mention a { color: #a1adad; }
+
+.channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #b1bbbb !important; }
+
+.channels_list_holder ul li.unread .prefix { color: #a1adad !important; opacity: 1; }
+
+.channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #268bd2 !important; }
+
+.channels_list_holder .unread_highlights { background: #dc322f; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder .unread_msgs { background: #002b36; color: #a1adad; }
+
+#channel_list_invites_link { border-bottom: 1px dotted #268bd2; color: #268bd2 !important; font-size: 0.9rem; }
+
+#channel_list_invites_link:hover { border-bottom: 1px solid #268bd2; }
+
+#quick_switcher_btn { background: #00232c; border-top: 2px solid #00232c; }
+
+#quick_switcher_btn > i { color: #2aa198; }
+
+#quick_switcher_btn:active, #quick_switcher_btn:hover { background: #002b36; border-color: #002b36; }
+
+#quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #268bd2; }
+
+#quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #268bd2; }
+
+#quick_switcher_label { color: #2aa198; }
+
+.loading #loading-zone { background: #002b36; }
+
+#loading_welcome { background-image: none; }
+
+#loading_message p { color: #a1adad; }
+
+#loading_message #loading_message_attribution { color: #2aa198; }
+
+#loading_team_menu_bg, #loading_user_menu_bg { background: #002b36; border: none; }
+
+.infinite_spinner_bg, .infinite_spinner_blue { stroke: #a1adad; }
+
+body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #00232c; }
+
+.p-degraded_list__loading { background-color: #002b36; color: #a1adad; }
+
+input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #003340; border-color: #00171d; color: #a1adad; }
+
+input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(0, 35, 44, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+
+input[type=file]:focus { outline: #a1adad dotted thin; }
+
+input[type=radio]:focus, input[type=checkbox]:focus { outline: #a1adad dotted thin; }
+
+select { background: #003340; }
+
+select, textarea { border: 1px solid #00171d; color: #a1adad; }
+
+select:active, select:focus, textarea:active, textarea:focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 63, 80, 0.15); }
+
+input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #002b36 !important; }
+
+.no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #00232c; }
+
+.no_touch label.select:hover select { border-color: #00232c; }
+
+.no_touch label.select:not(.disabled):hover::after { color: #00232c; }
+
+label.disabled { color: #a1adad; }
+
+legend { border-bottom: 1px solid #003f50; }
+
+legend small { color: #2aa198; }
+
+.uneditable-input, .uneditable-textarea { background-color: #002b36; border: 1px solid #00171d; color: #a1adad; }
+
+.uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(0, 63, 80, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+
+textarea { background-color: #003340; border: 1px solid #00171d; color: #a1adad; }
+
+textarea:focus { border-color: rgba(0, 63, 80, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+
+::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+[data-placeholder]:empty::before { color: #a1adad !important; }
+
+input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+input::-moz-placeholder, textarea::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+input::placeholder, textarea::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #a1adad !important; }
+
+input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #003340 !important; }
+
+.form-actions { background-color: #002b36; border-top: 1px solid #00232c; }
+
+.help-block, .help-inline { color: #2aa198; }
+
+.input-append .add-on, .input-prepend .add-on { background-color: #003f50; border: 1px solid #003340; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.btn { background-color: #003340; color: #a1adad !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #003340; color: #a1adad; }
+
+.btn.btn_border { border: 2px solid #002b36; }
+
+.btn.disabled, .btn:disabled { background-color: #00171d !important; }
+
+.btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #00171d !important; }
+
+.btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #dc322f !important; color: #a1adad !important; }
+
+.btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #002b36 !important; border-color: #dc322f !important; color: #dc322f !important; }
+
+.btn.btn_outline.disabled { background: #002b36 !important; color: #268bd2 !important; }
+
+.btn.btn_outline.disabled:hover { background: #002b36 !important; color: #268bd2 !important; }
+
+.btn.btn_attachment { border-color: #003340; }
+
+.btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #00232c; border-color: #003f50; }
+
+.btn.btn_attachment.btn_danger { border-color: #dc322f; }
+
+.btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e35d5b; }
+
+.btn.btn_attachment.btn_primary { border-color: #003f50; }
+
+.btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: #006883; }
+
+.btn_basic:focus, .btn_basic:hover { color: #a1adad; }
+
+.btn_outline { background: #002b36; color: #268bd2 !important; }
+
+.btn_outline::after { border: 1px solid #002b36; }
+
+.btn_outline.btn_transparent { color: rgba(0, 51, 64, 0.9) !important; }
+
+.btn_outline.btn_transparent::after { border: 1px solid rgba(0, 43, 54, 0.5); }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(0, 51, 64, 0.9) !important; color: #dc322f !important; }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(0, 51, 64, 0.8) !important; }
+
+.btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #002b36; color: #dc322f !important; }
+
+.btn_outline:active { color: #dc322f; }
+
+.btn_outline.active { color: #dc322f !important; }
+
+.btn_link { color: #268bd2; }
+
+.btn_link:hover, .btn_link:focus { color: #dc322f; }
+
+.btn-group.open .btn.dropdown-toggle { background-color: #003340; }
+
+.btn-group.open .btn-primary.dropdown-toggle { background-color: #002b36; }
+
+.btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+
+.btn_info, .btn.btn_success { background-color: #002b36 !important; }
+
+.btn_warning, .btn_danger { background-color: #dc322f !important; }
+
+.btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #a1adad; border-top-color: #a1adad; }
+
+.input_note { color: #a1adad; }
+
+.c-enhanced_text_input { background-color: #003340; border-color: #00232c; color: #2aa198; }
+
+.c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #003340; }
+
+.lazy_filter_select.disabled { background: #00232c; }
+
+.lazy_filter_select.disabled input.lfs_input { background: #003f50; }
+
+.lazy_filter_select .lfs_input_container { background-color: #003340; border-color: #00171d; }
+
+.lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #00232c; }
+
+.lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(0, 43, 54, 0.15); }
+
+.lazy_filter_select .lfs_list_container { background: #002b36; border-color: #00171d; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+
+.lazy_filter_select .lfs_list .lfs_item.selected { color: #a1adad; }
+
+.lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #a1adad !important; }
+
+.lazy_filter_select .lfs_list .lfs_item.disabled { color: #2aa198; }
+
+.lazy_filter_select .lfs_list .lfs_item.active { background-color: #00171d; border-color: #00232c; color: #a1adad; }
+
+.lazy_filter_select .lfs_token { background: #002b36; border: 1px solid #00171d; color: #a1adad; }
+
+.lazy_filter_select .lfs_token::after { color: #a1adad; }
+
+.lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #a1adad; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #a1adad !important; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item { color: #2aa198 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+
+#message_edit_form .emo_menu { color: rgba(161, 173, 173, 0.3); }
+
+#message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #003f50; }
+
+#message_edit_form.focus .emo_menu { color: rgba(161, 173, 173, 0.6); }
+
+#message_edit_form.focus #primary_file_button:not(:hover) { border-color: #00232c; }
+
+#message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #00232c !important; }
+
+#message_edit_form.offline #primary_file_button { border-color: #002b36; color: #2aa198; }
+
+#msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #00232c; }
+
+#msg_form #msg_input { background: padding-box #003340; border-color: #002b36; border-left: 0; color: #a1adad; }
+
+#msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #a1adad; }
+
+#msg_form .msg_mentions_button { color: #2aa198; }
+
+#msg_form .msg_mentions_button:hover { color: #a1adad; }
+
+#msg_input { background: #003340; border-color: #002b36; color: #a1adad; }
+
+#msg_input::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+#msg_input::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+#msg_input::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+
+#msg_input[data-placeholder]:empty::before { color: #a1adad !important; }
+
+#msg_input:focus, #msg_input.focus { border-color: #00232c; }
+
+#msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #00232c; }
+
+#msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #002b36; }
+
+#msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #002b36; }
+
+#msg_input.offline:not(.pretend-to-be-online) { background-color: #00232c !important; color: #2aa198; }
+
+#msg_input.disabled, #msg_input.ql-disabled { background-color: #00232c; border-color: #00232c; color: #2aa198; }
+
+#msg_input_message { background-color: #00232c; color: #a1adad; }
+
+#primary_file_button { background: padding-box #003340; border-color: #002b36; color: #2aa198; }
+
+#primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #002b36; border-color: #00232c; color: #a1adad; }
+
+#footer, #footer.footer_msg_input { background: #002b36; box-shadow: inset 1px 0 0 0 #002b36; }
+
+#footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #00232c !important; border-color: #00232c !important; }
+
+#footer_archives_table { color: #2aa198; }
+
+#typing_text { color: #2aa198; filter: none; }
+
+#notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+
+#special_formatting_text { color: #2aa198; }
+
+#message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.inline_message_input_container .ql-container { border-color: #003340; }
+
+.inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #003f50; }
+
+.c-message--editing { background: #00232c; border-color: #00232c; color: #a1adad; }
+
+.c-message__editor__input { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.c-message__editor__input.focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-message__editor__warning { color: #dc322f; }
+
+#message_edit_container .message_input { background: #003340; border-color: #00232c; color: #a1adad; }
+
+#message_edit_container .message_input.focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 51, 64, 0.5); color: #002b36; }
+
+.ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 51, 64, 0.8); }
+
+.ql-placeholder, .texty_legacy .ql-placeholder { color: #a1adad; filter: none; }
+
+.ql-container.texty_single_line_input { background: #003340; border: 1px solid #00232c; color: #a1adad; }
+
+.ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-input_select { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #a1adad; }
+
+.c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.c-input_select_options_list__option { color: #a1adad; }
+
+.menu { background: #00232c; border: 1px solid #002b36; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #a1adad; }
+
+.menu .menu_content { background: #00232c !important; }
+
+.menu .menu_filter_container { background: #002b36; }
+
+.menu .menu_filter_container input.menu_filter { border: 1px solid #002b36; }
+
+.menu .menu_filter_container input.menu_filter:focus { border-color: #003340; }
+
+.menu .menu_filter_container .icon_search { color: #2aa198; }
+
+.menu .menu_filter_container .icon_close { color: #2aa198 !important; }
+
+.menu #menu_header .menu_simple_header { background: #00171d; border-color: #00232c; color: #a1adad; }
+
+.menu #menu_header .menu_simple_header a { color: #268bd2; }
+
+.menu #menu_header .menu_simple_header a:hover { color: #dc322f; }
+
+.menu #menu_header .menu_close { color: #a1adad; }
+
+.menu .section_header .header_label { background-color: #00232c; color: #2aa198; }
+
+.menu .section_header > div.header_label_container { color: #2aa198; }
+
+.menu ul li a { background: #00232c; border-bottom: 0; color: #a1adad; }
+
+.menu ul li a.delete_link { color: #dc322f; }
+
+.menu ul li a:not(.inline_menu_link) { color: #a1adad; }
+
+.menu ul li.highlighted a { background: #002b36; border-bottom-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #a1adad; }
+
+.menu ul li.highlighted a.delete_link { color: #dc322f; }
+
+.menu ul li.disabled a { color: #2aa198; }
+
+.menu ul li i { color: #2aa198; }
+
+.menu ul li.divider { border-bottom-color: #002b36; }
+
+.menu ul li .menu_item_details { color: #2aa198; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #002b36; border-bottom-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #a1adad; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #dc322f; }
+
+.menu input { background: #00232c; border: 1px solid #003340; }
+
+.menu textarea { background: #00232c; border: 1px solid #003340; }
+
+.menu #menu_footer .menu_footer { background: #00171d; border-top: 1px solid #00232c; }
+
+.menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #00232c; }
+
+.menu #menu_list_container #menu_list .menu_list_item a { color: #a1adad; }
+
+.menu #menu_list_container #menu_list .menu_list_item.active a { background: #003340; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu { color: #a1adad; }
+
+#autocomplete_menu header { background-color: #002b36; }
+
+#autocomplete_menu header .header_label { color: #2aa198; }
+
+#autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #00171d; }
+
+#autocomplete_menu h2 { color: #a1adad; }
+
+#autocomplete_menu .no_results { color: #a1adad; }
+
+#autocomplete_menu .keyword_match .modifier { color: #2aa198; }
+
+#autocomplete_menu .boxed { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu .pickmeup { border-bottom: 1px solid #00232c; }
+
+#autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #003340; }
+
+#autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #a1adad; }
+
+#autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #00232c; }
+
+#autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+
+#autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #a1adad; }
+
+#autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #00232c; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #a1adad; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #268bd2; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #dc322f; }
+
+#autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #00232c; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #a1adad; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #268bd2; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #dc322f; }
+
+#autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #00232c; }
+
+#autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #a1adad; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #a1adad; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #002b36; color: #a1adad; }
+
+#autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+
+#autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(0, 51, 64, 0.25); border: #003f50; }
+
+#autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #00232c; border: 1px solid #00171d; }
+
+.search_light_grey { color: #a1adad !important; }
+
+.highlighter_underlay .keyword::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+
+.highlighter_underlay .modifier::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+
+.highlighter_underlay .modifier.incomplete::before { background: #00232c; border: 1px solid #00171d; }
+
+.highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(0, 63, 80, 0.25); border: #003340; }
+
+.highlighter_underlay .ghost_text { color: #a1adad; }
+
+.pickmeup { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+
+.pickmeup .pmu-instance .pmu-button { color: #a1adad; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #00232c !important; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #003f50; color: #a1adad !important; }
+
+.pickmeup .pmu-instance .pmu-today-border { border: 2px solid #003340 !important; color: #003f50 !important; }
+
+.pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #003340; color: #a1adad; }
+
+.pickmeup .pmu-instance .pmu-not-in-month { background: #002b36; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #003340; }
+
+.pickmeup .pmu-instance .pmu-disabled { background: #002b36; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-disabled:hover { background: #002b36; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-selected { background: #003340; color: #a1adad; }
+
+.pickmeup .pmu-instance nav { color: #268bd2; }
+
+.pickmeup .pmu-instance nav :first-child :hover { color: #dc322f; }
+
+.pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #00232c; }
+
+.pickmeup .pmu-instance .pmu-day-of-week { color: #a1adad; }
+
+.pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #00232c; }
+
+.pickmeup .pmu-instance .pmu-days * { border: 1px solid #00232c; }
+
+.p-block_kit_date_picker_calendar_wrapper { background: #00232c; border-color: #003340; color: #a1adad; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #003340; color: #003f50; }
+
+#menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #003340; }
+
+#menu.date_picker li.date_picker_item a { color: #a1adad; }
+
+#menu.date_picker li.date_picker_item a:hover { color: #a1adad; }
+
+#menu.date_picker li.date_picker_item.highlighted a { color: #2aa198; }
+
+#file_member_filter { background: #00171d; }
+
+#client-ui .member_filter { border: 1px solid #003340; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #002b36; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #a1adad; }
+
+#client-ui #team_list_container #team_filter .member_filter { background-color: #002b36; border-left: 1px solid #00171d; }
+
+#client-ui #file_member_filter { border-color: #003340; }
+
+#client-ui #file_member_filter .member_filter { border-color: #003340; }
+
+#client-ui .team_tabs_container { border-bottom: 1px solid #00171d; }
+
+#team_filter .icon_search { color: #2aa198; }
+
+#team_filter a.icon_close { color: #268bd2; }
+
+#team_filter a.icon_close:hover { color: #dc322f; }
+
+.filter_header { background-color: #002b36; }
+
+.popover_menu { background-color: #002b36; border-top: 1px solid #003340; }
+
+.popover_menu .arrow::after { background-color: #00171d; }
+
+.popover_menu .arrow_shadow::after { background-color: #002b36; box-shadow: 0 0 0 1px #003340, 0 0 3px rgba(0, 0, 0, 0.08); }
+
+.popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #002b36 !important; }
+
+.popover_menu .content { background-color: #002b36; }
+
+.tab_complete_ui { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+
+.tab_complete_ui .tab_complete_ui_header { background: padding-box #00171d; border-bottom: 1px solid #00232c; color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui ul.type_emoji li { color: #a1adad; }
+
+.tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #a1adad; }
+
+.tab_complete_ui ul.type_members .unify_broadcast { color: #a1adad; }
+
+.tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #2aa198; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #a1adad !important; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #00232c; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #2aa198; }
+
+.tab_complete_ui ul.type_cmds .cmdname { color: #a1adad; }
+
+.tab_complete_ui ul.type_cmds .cmddesc { color: #2aa198; }
+
+.tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #00232c; }
+
+.tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #003340; border-bottom-color: #00232c; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #a1adad !important; }
+
+.tab_complete_ui .not_in_channel { color: #2aa198; }
+
+#team_menu { background: #00232c; border-bottom: 2px solid #00232c; color: #a1adad; }
+
+#team_menu.active, #team_menu:hover { background: #00232c !important; border-bottom-color: #00232c !important; }
+
+#team_menu.active i, #team_menu:hover i { color: #a1adad; }
+
+#team_menu i { color: #2aa198; }
+
+#team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+#team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #a1adad !important; }
+
+#team_menu_user { color: #2aa198; }
+
+#team_menu_user_name, #team_menu_user_details { color: #a1adad !important; opacity: 0.75; }
+
+.slack_menu_section::before { border-top-color: #002b36; }
+
+.slack_menu_header_secondary { color: #2aa198; }
+
+.slack_menu_download { background-color: #00232c; }
+
+.slack_menu_download ts-icon { color: #2aa198; }
+
+#menu_items_scroller::-webkit-scrollbar-track { background: #002b36 !important; }
+
+#limit_meter:hover #limit_meter_message_body { color: #a1adad; }
+
+#limit_meter_message_body { color: #2aa198; }
+
+.channel_header { background: #002b36; box-shadow: inset 1px 0 0 0 #002b36; }
+
+.channel_header .blue_on_hover:hover { color: #a1adad; }
+
+#client_body:not(.onboarding)::before { background: #002b36; border-bottom: 1px solid #00232c; box-shadow: inset 1px 0 0 0 #002b36; }
+
+.messages_header { color: #a1adad; }
+
+.channel_title .channel_name_container .channel_name { color: #a1adad; }
+
+.channel_title .channel_name_container .channel_name.muted { color: #2aa198; }
+
+.channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #2aa198; }
+
+.channel_title .channel_name_container .muted_icon { color: #2aa198; }
+
+.channel_title .channel_name_container .muted_icon:hover { color: #dc322f; }
+
+#im_title.away { color: #2aa198; }
+
+.channel_header_info button { color: #268bd2; }
+
+.channel_header_icon { color: #a1adad; }
+
+.channel_calls_button .call_icon.call_window_offline { color: #2aa198; }
+
+.channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #a1adad; }
+
+#flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #a1adad; }
+
+#flex_menu_toggle .flex_menu_download_circle { background: #002b36; }
+
+#flex_menu_toggle .flex_menu_download_circle canvas { background: #002b36; }
+
+#flex_menu_toggle.unread #help_icon_circle_count { background-color: #dc322f; color: #fff; }
+
+#flex_menu_toggle.open #help_icon_circle_count { background-color: #00171d; color: #a1adad; }
+
+#canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #00232c; color: #a1adad; }
+
+#canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #003340; color: #a1adad; }
+
+#recent_mentions_toggle:hover { color: #dc322f; }
+
+#rxn_toast_div { background: #00171d; border: 1px solid #003340; }
+
+.presence { color: #2aa198; }
+
+#edit_topic_inner:not(.unable_to_post)::before { background: #002b36; border-color: #00232c; }
+
+#edit_topic_trigger { color: #268bd2; }
+
+.c-message_list__day_divider__label { color: #2aa198; }
+
+.c-message_list__day_divider__label__pill { background: #002b36; position: relative; }
+
+.c-message_list__day_divider__line { border-top-color: #00232c; }
+
+.day_divider, .mention_day_container_div .day_divider { background: #002b36; color: #2aa198; }
+
+.day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #00232c; }
+
+.day_divider .day_divider_label { background: #002b36; }
+
+.day_container .day_msgs { border-top: 1px solid #00232c; }
+
+.day_container.unread_day_container .day_msgs { border-color: #003f50; }
+
+.day_container .day_divider { background: none; color: #2aa198; }
+
+.day_container .day_divider .day_divider_label { background: #002b36; }
+
+.search_form { border-color: #003340; }
+
+.search_form .search_input { background: transparent; }
+
+.search_form:hover { border-color: #003f50; }
+
+.search_focused .search_form { border-color: #003f50; }
+
+.search_clear_icon .ts_icon_times_circle { color: #2aa198; }
+
+#search_spinner { color: #a1adad; }
+
+#search_container .search_input { background: transparent; }
+
+#search_container .icon_search { color: #2aa198; }
+
+#search_container .icon_close { color: #268bd2; }
+
+#team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #2aa198; }
+
+#team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #268bd2; }
+
+#team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #dc322f; }
+
+.c-search { background: transparent; }
+
+.c-search_message__body { color: #a1adad; }
+
+.p-search_filter__more_link { color: #a1adad; }
+
+.p-search_filter__title_text { background: #00232c; color: #a1adad; }
+
+.p-search_filter__datepicker_trigger { background: #00232c; border-color: #003340; color: #a1adad; }
+
+.p-search_filter__datepicker_trigger:hover { color: #2aa198; }
+
+.c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #00232c; border-color: #003340; color: #a1adad; }
+
+.c-search_autocomplete footer { background: #00232c; border-color: #003340; color: #a1adad; }
+
+.c-search_autocomplete__suggestion_item { color: #a1adad; }
+
+.c-search_autocomplete__suggestion_item--selected { background-color: #002b36; }
+
+.c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #a1adad; }
+
+.c-search__input_and_close { border-bottom-color: #00171d; }
+
+.c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #a1adad; }
+
+#msgs_overlay_div { background: #002b36; }
+
+#col_messages { box-shadow: inset 1px 0 0 0 #002b36; }
+
+.c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #2aa198 !important; }
+
+.c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(0, 23, 29, 0.1); }
+
+.c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #2aa198; }
+
+.c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #2aa198; }
+
+.c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(0, 23, 29, 0.1); }
+
+.c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(0, 23, 29, 0.2); }
+
+.c-message--custom_response { background: rgba(0, 23, 29, 0.15); }
+
+.c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(0, 23, 29, 0.1); }
+
+.c-message--pinned .c-message__label__icon { color: #dc322f; }
+
+.c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #a1adad; }
+
+.c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #2aa198; }
+
+.c-message--sli_highlight_negative .c-message__label { background: rgba(0, 23, 29, 0.1); }
+
+.c-message--resend .c-message__body { color: #2aa198; }
+
+.c-message--deleting { background: rgba(220, 50, 47, 0.6); }
+
+.c-message--standalone { border-color: rgba(0, 51, 64, 0.1); }
+
+.c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+
+.c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message__sender { color: #a1adad; }
+
+.c-message__sender a { color: #a1adad; }
+
+.c-message__sender .c-emoji__text_mode_icon { color: #2aa198; }
+
+.c-message__body { color: #a1adad; }
+
+.c-message__body--unknown { background: rgba(0, 51, 64, 0.1); }
+
+.c-message__body--automated { color: #2aa198; }
+
+.c-message__body--tombstone { color: #2aa198; }
+
+.c-message__label { color: #2aa198; }
+
+.c-message__label__highlight_title { color: #a1adad; }
+
+.c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #2aa198; }
+
+.c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #a1adad; }
+
+.c-message__resend_controls { color: #2aa198; }
+
+.c-message__resend_column { background-color: rgba(0, 51, 64, 0.1); }
+
+.c-message__resend, .c-message__cancel { color: #a1adad; }
+
+.c-message__edited_label { color: #2aa198; }
+
+.c-message__tombstone_icon { background: rgba(0, 51, 64, 0.1); color: #2aa198; }
+
+.c-message__bot_label { background: rgba(0, 51, 64, 0.1); color: #2aa198; }
+
+.c-message__comment:before { color: #2aa198; }
+
+.c-message__call_attachment { background: #002b36; border-color: rgba(0, 51, 64, 0.1); }
+
+.c-message__call_icon { color: #a1adad; }
+
+.c-message__call--ended .c-message__call_icon { color: #2aa198; }
+
+.c-message__call_info { color: #a1adad; }
+
+.c-message__call_name--linked { color: #a1adad; }
+
+.c-message__call_name + .c-message__call_description::before { color: #2aa198; }
+
+.c-message__call_sub { color: #2aa198; }
+
+.c-message_actions__container { background: #002b36; border-color: #00232c; }
+
+.c-message_actions__container:hover { border-color: #003340; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+.c-message_actions__button { border-right-color: #00232c; color: #268bd2; }
+
+.c-message_actions__button:hover { color: #a1adad; }
+
+.c-message_actions__button:active { background: #00232c; }
+
+.c-message_group { background-color: #002b36; border-color: #00232c; }
+
+.c-message_group:hover .c-message_group__header { color: #2aa198; }
+
+.c-message_group__header { color: #a1adad; }
+
+.c-message_group__divider_text { background-color: #002b36; color: #a1adad; }
+
+.c-message_list__unread_divider__separator { border-color: #003340; }
+
+.c-message_list__unread_divider__label { background: #002b36; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #003340; }
+
+.c-message_list__spinner { color: #2aa198; }
+
+.c-message_list .c-scrollbar__bar { background: #002b36; }
+
+.c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(0, 63, 80, 0.8); }
+
+ts-message { color: #a1adad; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(0, 23, 29, 0.1); box-shadow: inset 1px 0 0 0 #002b36; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(0, 23, 29, 0.2); }
+
+ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #2aa198; }
+
+ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #2aa198 !important; }
+
+ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+
+ts-message.is_pinned { background: rgba(0, 23, 29, 0.15); }
+
+ts-message .timestamp { color: #268bd2; }
+
+ts-message .temp_msg_controls { color: #2aa198; }
+
+ts-message .edited { color: rgba(42, 161, 152, 0.8); }
+
+ts-message:hover .edited { color: #2aa198; }
+
+ts-message .only_visible_to_user { color: #2aa198; }
+
+ts-message.ephemeral { color: #a1adad; }
+
+ts-message .bot_label { background: #00171d; color: #2aa198; }
+
+ts-message .in_reply_to { background: #00171d; color: #2aa198; }
+
+ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #00232c; }
+
+ts-message.unprocessed { color: rgba(161, 173, 173, 0.75); }
+
+ts-message.highlight { background: rgba(220, 50, 47, 0.4); }
+
+ts-message.highlight:hover { background: rgba(220, 50, 47, 0.4); }
+
+ts-message .is_highlights_holder { color: #2aa198; }
+
+ts-message .is_highlights_holder ts-icon { color: #2aa198; }
+
+ts-message .is_highlights_holder .highlights_feedback_link { color: #2aa198; }
+
+ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #a1adad; }
+
+ts-message .recap_highlight { background: rgba(220, 50, 47, 0.4); }
+
+ts-message .recap_highlight a { color: #a1adad; }
+
+ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(220, 50, 47, 0.75); }
+
+ts-message.automated .message_body { color: rgba(161, 173, 173, 0.8); }
+
+ts-message .action_hover_container { border: 1px solid #00232c; }
+
+ts-message .action_hover_container:hover { border-color: #003340; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+ts-message .action_hover_container:hover a { background: #00232c; border-right: 1px solid #003340; }
+
+ts-message .action_hover_container .btn_msg_action { background: #002b36; border-right: 1px solid #00232c; color: #268bd2; }
+
+ts-message .action_hover_container .btn_msg_action:hover { color: #a1adad; }
+
+ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #00232c; color: #a1adad; }
+
+ts-message.selected { background: #002b36; }
+
+ts-message.selected:not(.delete_mode) { background: #002b36; }
+
+ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+
+ts-message .meta { color: #2aa198; }
+
+ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #268bd2 !important; }
+
+ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+
+ts-message .pinned_item_message_header { color: #2aa198; }
+
+ts-message .mention { background: #003f50 !important; color: #a1adad !important; }
+
+ts-message .internal_member_link { background: #002b36 !important; border: 0; color: #268bd2 !important; }
+
+ts-message .internal_member_link:hover { color: #dc322f !important; }
+
+ts-message.show_recap:not(.is_pinned) { background: rgba(0, 23, 29, 0.15); }
+
+ts-message.show_recap:not(.is_pinned):hover { background: rgba(0, 23, 29, 0.15); }
+
+.ephemeral.message .message_content { color: #a1adad; }
+
+ts-mention { background: rgba(0, 63, 80, 0.1) !important; color: #a1adad !important; }
+
+.selecting_messages ts-message:hover { background: #00171d; }
+
+.selecting_messages ts-message.multi_delete_mode:hover { background: rgba(220, 50, 47, 0.75); }
+
+#convo_container { background-color: #002b36; }
+
+#convo_container #message_edit_container { border-bottom: 1px solid #003340; border-top: 1px solid #003340; }
+
+#convo_container ts-conversation::after { background: rgba(0, 23, 29, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(0, 23, 29, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(0, 23, 29, 0.08) 100%); }
+
+#convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(0, 23, 29, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(0, 23, 29, 0.08) 0, transparent 100%); }
+
+#convo_container ts-conversation ts-message.selected { background: #002b36; }
+
+#convo_container ts-conversation ts-relatives::after { background: #003340; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #003340; color: #2aa198; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #a1adad; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #002b36; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #003f50; }
+
+#msgs_div .unread_divider hr { border-top: 1px solid #003340; }
+
+#msgs_div .unread_divider .divider_label { background: #002b36; color: #003340; }
+
+#msgs_div .unread_divider.no_unreads hr { border-top-color: #00232c; }
+
+#msgs_div .unread_divider.no_unreads .divider_label { color: #2aa198; }
+
+.channel_archive_messages.card .col:first-child { border-right: 1px solid #003340; }
+
+.star { color: #2aa198; }
+
+.star_item { border-bottom: 1px solid #00171d; }
+
+.star_item .star_meta { color: #2aa198; }
+
+.bot_message .message_sender { color: #a1adad; }
+
+.bot_message .message_sender a { color: #a1adad; }
+
+.color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #a1adad; }
+
+#msgs_scroller_div #end_display_div #end_display_status { color: #2aa198; }
+
+#msgs_scroller_div #end_display_div #end_display_meta { color: #2aa198; }
+
+#msgs_scroller_div #end_display_div #end_display_meta h1 { color: #a1adad; }
+
+#msgs_scroller_div #end_display_div p { color: #a1adad; }
+
+.member_mentions_options { background-color: #00171d; border-top: 1px solid #00232c; }
+
+.dm_badge .dm_badge_meta { color: #a1adad; }
+
+.dm_badge a { color: #268bd2; }
+
+.dm_badge a.member_preview_link { color: #268bd2; }
+
+.dm_badge .dm_badge:hover a { color: #268bd2; }
+
+.dm_badge .hint { color: #2aa198; }
+
+#toggle-subscription-status .subscription_desc { color: #2aa198; }
+
+.bot_label { background: #00171d; color: #2aa198; }
+
+@keyframes to-grey { 0% { color: inherit; }
+  100% { color: #2aa198; } }
+
+@keyframes fade-background-highlight { 0% { background: #003340; }
+  100% { background: transparent; } }
+
+@keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #003340, 0 0 0 0.5px #003f50; }
+  100% { box-shadow: 0 0 4px 0 #003340, 0 0 0 0 #003f50; } }
+
+.c-message_attachment { color: #a1adad; }
+
+.c-message_attachment__border { background-color: #003340; }
+
+.c-message_attachment__delete { color: #268bd2; }
+
+.c-message_attachment__delete:hover { color: #dc322f; }
+
+.c-message_attachment__pretext { color: #a1adad; }
+
+.c-message_attachment__part + .c-message_attachment__part::before { color: #003340; }
+
+.c-message_attachment__author .c-message_attachment__autor--distinct { color: #268bd2; }
+
+.c-message_attachment__author_link + .c-message_attachment__author_link { color: #268bd2; }
+
+.c-message_attachment__title_link span { color: #a1adad; }
+
+.c-message_attachment__text_expander { color: #268bd2; }
+
+.c-message_attachment__footer { color: #268bd2; }
+
+.c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(0, 23, 29, 0.1) inset; }
+
+.c-message_attachment__video_html { background-color: rgba(0, 43, 54, 0.4); }
+
+.c-message_attachment__video_buttons { background: rgba(0, 23, 29, 0.4); }
+
+.c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #a1adad; }
+
+.c-message_attachment__video_play, .c-message_attachment__video_link { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+
+.c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #a1adad; }
+
+.c-message_attachment__media_trigger .c-expandable_trigger { color: #268bd2; }
+
+.c-message_attachment__media_trigger--too_large { color: #268bd2; }
+
+.c-message_attachment__select { border-color: #00171d; }
+
+.c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #003340; }
+
+.c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #002b36; border-color: #00171d; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #2aa198; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #003340; }
+
+.c-message__reply_bar_description { color: #2aa198; }
+
+.c-message__file_meta { color: #2aa198; }
+
+.c-message__image_container { background: rgba(0, 23, 29, 0.1); }
+
+.c-message__image_wrapper:after { border-color: transparent; }
+
+.attachment_group.has_container { background: #002b36; border: 1px solid #00232c; }
+
+.attachment_group.has_container .inline_attachment::after { background-color: #00232c; }
+
+.attachment_group.has_container.has_link:hover { border-bottom-color: #00232c; border-left-color: #00232c; border-right-color: #00232c; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.attachment_group .media_caret { color: #2aa198; }
+
+.attachment_group .attachment_source span { color: #2aa198 !important; }
+
+.attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #2aa198; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #2aa198; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #00232c; }
+
+.attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #2aa198; }
+
+.attachment_group .attachment_title a { color: #a1adad; }
+
+.attachment_group .attachment_footer_text + .attachment_ts::before { color: #2aa198; }
+
+.attachment_group .delete_attachment_link ts-icon::before { color: #268bd2; }
+
+.attachment_group .delete_attachment_link:hover ts-icon::before { color: #dc322f; }
+
+.attachment_still_pending ts-inline-saver { color: #2aa198; }
+
+.msg_inline_attachment_column.column_border { background-color: #003340; }
+
+.msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #00171d; }
+
+.msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #268bd2; }
+
+.msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #dc322f; }
+
+.msg_inline_img { background: #003340; }
+
+.msg_inline_room_preview_collapser { color: #2aa198; }
+
+.msg_inline_room_preview_collapser:hover { color: #2aa198; }
+
+.inline_attachment span.attachment_author_name { color: #268bd2; }
+
+.inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #268bd2; }
+
+.inline_attachment a span:active, .inline_attachment a span:hover { color: #dc322f !important; }
+
+.inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #268bd2; }
+
+.inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #268bd2; }
+
+.inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #dc322f !important; }
+
+.inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #dc322f !important; }
+
+.inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #00171d; }
+
+.meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #268bd2 !important; }
+
+.meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #268bd2 !important; }
+
+.meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #dc322f !important; }
+
+.meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #dc322f !important; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #a1adad; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #2aa198; }
+
+.meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #268bd2 !important; }
+
+.delete_attachment_link { color: #268bd2; }
+
+.delete_attachment_link:hover { color: #dc322f; }
+
+.file_container, .c-file_container { background: #00171d; border: 1px solid #00232c; color: #a1adad; }
+
+.file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #00232c; border-left-color: #00232c; border-right-color: #00232c; }
+
+.file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: -moz-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: -o-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+
+.file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #002b36; box-shadow: 0 0 0 3px #002b36; color: #a1adad; }
+
+.file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #00232c; }
+
+.file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #00171d; color: #a1adad; }
+
+.file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #2aa198; }
+
+.file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #00171d; }
+
+.file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #00232c; color: #a1adad !important; }
+
+.file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #00171d; }
+
+.file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(0, 63, 80, 0.9); color: #a1adad !important; }
+
+.file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #00171d; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #00232c; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #00232c; }
+
+.file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #002b36; }
+
+.file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(0, 63, 80, 0.9); }
+
+.file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #00232c; }
+
+.file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(0, 63, 80, 0.9); border: 1px solid rgba(0, 23, 29, 0.1); }
+
+.file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(0, 51, 64, 0.8), rgba(0, 51, 64, 0.8)), linear-gradient(rgba(0, 63, 80, 0.3), rgba(0, 63, 80, 0.3)); color: #a1adad; }
+
+.file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(0, 51, 64, 0.8); color: #a1adad; }
+
+.file_container .c-file__title, .c-file_container .c-file__title { color: #a1adad; }
+
+.message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #003340; color: #a1adad; }
+
+.msg_inline_video_buttons_div { background-color: rgba(0, 43, 54, 0.4); }
+
+.msg_inline_video_buttons_div a { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+
+.msg_inline_video_buttons_div a:visited { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+
+.post_body ul.checklist { background-color: #00232c; }
+
+.post_body ul.checklist li::before { background: #00232c; }
+
+.post_body ul.checklist li.checked { color: #2aa198; }
+
+.post_body ul.list.checklist li { border-bottom: 1px solid #003340; }
+
+.post_body ul.list.checklist li.checked { color: #2aa198; }
+
+.post_body .message { background-color: #a1adad; }
+
+.post_body code, .post_body pre { background: #00232c; }
+
+ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #2aa198; }
+
+ts-message .reply_bar:hover { background: #002b36; border-color: #00171d; }
+
+.inline_color_block { border-color: #003340; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #002b36; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #002b36; border-bottom: 1px solid #002b36; }
+
+.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #002b36; }
+
+.p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #a1adad; }
+
+.p-message_pane__limited_history_foreword { background: #00232c; background-image: none; color: #a1adad; }
+
+.p-message_pane__unread_banner__banner { background: #003340; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner { color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner a { color: #a1adad; }
+
+.messages_banner a:hover { color: #a1adad; }
+
+#connection_div { background: #dc322f; }
+
+#archives_return { background: padding-box #003f50; color: #a1adad; }
+
+#archives_return.warning { background: #dc322f; }
+
+#archives_return a { color: #a1adad; }
+
+#archives_return a:hover { color: rgba(161, 173, 173, 0.8); }
+
+#messages_unread_status { background: #003340; }
+
+#messages_unread_status:hover { background: #003f50; }
+
+#messages_unread_status:hover .clear_unread_messages { background: #003f50; }
+
+#messages_unread_status:hover .clear_unread_messages:hover { background: #003340; }
+
+#messages_unread_status.quiet { background: #003f50; color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#messages_unread_status.quiet a { color: #a1adad; }
+
+.clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+
+#messages_container.has_top_messages_banner::before { background: none; }
+
+.end_div_msg_lim { background-color: #00232c; background-image: none; }
+
+#archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #a1adad; }
+
+#archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(161, 173, 173, 0.8); }
+
+code { background-color: #00171d; border: 1px solid #00232c; color: #a1adad; }
+
+.file_list_item.snippet .snippet_preview { background: #00171d; }
+
+.snippet_preview, .snippet_body { background: #00171d; }
+
+.snippet_preview pre, .snippet_body pre { color: #a1adad !important; }
+
+.file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #00232c; border-right: 1px solid #00232c; color: #2aa198; }
+
+.c-snippet .c-file_container { background-color: #002b36; }
+
+.c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #002b36); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+
+.CodeMirror { background: #00171d; border: 1px solid #00232c; color: #a1adad !important; }
+
+.CodeMirror pre { background: transparent !important; }
+
+.CodeMirror div.CodeMirror-cursor { border-left: 1px solid #a1adad; }
+
+.CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #a1adad; }
+
+.CodeMirror .CodeMirror-gutters { background-color: #00232c; border-right: 1px solid #002b36; }
+
+.CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #00232c; }
+
+.CodeMirror-linenumber { color: #2aa198 !important; }
+
+.CodeMirror-guttermarker { color: #2aa198; }
+
+.CodeMirror-guttermarker-subtle { color: #2aa198; }
+
+.CodeMirror-ruler { border-left: 1px solid #003f50; }
+
+.cm-s-default .cm-keyword { color: #ce93d8; }
+
+.cm-s-default .cm-atom { color: #9fa8da; }
+
+.cm-s-default .cm-number { color: #a5d6a7; }
+
+.cm-s-default .cm-def { color: #536dfe; }
+
+.cm-s-default .cm-variable-2 { color: #9fa8da; }
+
+.cm-s-default .cm-variable-3 { color: #c5e1a5; }
+
+.cm-s-default .cm-comment { color: #ffcc80; }
+
+.cm-s-default .cm-string { color: #ef9a9a; }
+
+.cm-s-default .cm-string-2 { color: #ffab91; }
+
+.cm-s-default .cm-meta { color: #eee; }
+
+.cm-s-default .cm-qualifier { color: #eee; }
+
+.cm-s-default .cm-builtin { color: #b39ddb; }
+
+.cm-s-default .cm-bracket { color: #e6ee9c; }
+
+.cm-s-default .cm-tag { color: #a5d6a7; }
+
+.cm-s-default .cm-attribute { color: #40c4ff; }
+
+.cm-s-default .cm-header { color: #80cbc4; }
+
+.cm-s-default .cm-quote { color: #b0bec5; }
+
+.cm-s-default .cm-hr { color: #00232c; }
+
+.cm-s-default .cm-link { color: #268bd2; }
+
+.cm-negative { color: #dc322f; }
+
+.cm-positive { color: #859900; }
+
+.cm-invalidchar, .cm-s-default .cm-error { color: #dc322f; }
+
+div.CodeMirror span.CodeMirror-matchingbracket { color: #859900; }
+
+div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #dc322f; }
+
+.CodeMirror-matchingtag { background: #00171d; }
+
+.CodeMirror-activeline-background { background: #003f50; }
+
+.CodeMirror-selected { background: #003f50; }
+
+.CodeMirror-focused .CodeMirror-selected { background: #003f50; }
+
+.cm-searching { background: #003f50; }
+
+.sssh-keyword { color: #ce93d8; }
+
+.sssh-atom { color: #9fa8da; }
+
+.sssh-number { color: #a5d6a7; }
+
+.sssh-def { color: #536dfe; }
+
+.sssh-variable { color: #9fa8da; }
+
+.sssh-variable-2 { color: #c5e1a5; }
+
+.sssh-variable-3 { color: #c1a5e1; }
+
+.sssh-operator { color: #a1adad; }
+
+.sssh-property { color: #a1adad; }
+
+.sssh-comment { color: #ffcc80; }
+
+.sssh-string { color: #ef9a9a; }
+
+.sssh-string-2 { color: #ffab91; }
+
+.sssh-meta { color: #eee; }
+
+.sssh-error { color: #dc322f; }
+
+.sssh-qualifier { color: #eee; }
+
+.sssh-builtin { color: #b39ddb; }
+
+.sssh-bracket { color: #e6ee9c; }
+
+.sssh-tag { color: #a5d6a7; }
+
+.sssh-attribute { color: #40c4ff; }
+
+.sssh-header { color: #80cbc4; }
+
+.sssh-quote { color: #b0bec5; }
+
+.sssh-hr { color: #00232c; }
+
+.sssh-link { color: #268bd2; }
+
+.c-message--dense .c-timestamp__label { color: #268bd2; }
+
+.c-message--dense .c-message__content_header .c-custom_status { border-color: #00232c; }
+
+.dense_theme ts-message { color: #a1adad; }
+
+.dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #268bd2; }
+
+.dense_theme ts-message .message_content .message_current_status { border-color: #00232c; }
+
+.c-message--light .c-message__sender .c-message__sender_link { color: #a1adad; }
+
+.light_theme ts-message { color: #a1adad; }
+
+.light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #a1adad !important; }
+
+.light_theme ts-message .comment::before { color: #2aa198; }
+
+.channel_overlay { border-color: #00232c; color: #2aa198; }
+
+.channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #a1adad; }
+
+.channel_overlay.channel_overlay_redesign li { color: #2aa198; }
+
+.channel_overlay_title_wrap { border-color: #00232c; }
+
+.channel_overlay_title_shared { color: #a1adad; }
+
+pre { background: #00171d; border: 1px solid #00232c; color: #a1adad; }
+
+pre span.mention { padding: 2px 0 !important; }
+
+#page pre, body > pre { background: #00171d; color: #a1adad !important; }
+
+body > pre { background: #003f50; }
+
+.special_formatting_quote .quote_bar { background-color: #003340; }
+
+#threads_msgs_scroller_div { background: #002b36; }
+
+#threads_msgs_scroller_div:not(.loading)::before { background: #002b36; }
+
+#threads_msgs_scroller_div.loading::before { color: #2aa198; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #00232c; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #003340; color: #a1adad; }
+
+#threads_msgs_scroller_div.loading { background: none; }
+
+#threads_msgs_scroller_div.loading::before { color: #a1adad; }
+
+#threads_view_banner.messages_banner { background: #00232c; }
+
+#threads_view_banner.messages_banner:hover { background: #003340; }
+
+#threads_view_banner.messages_banner:hover .clear_unread_messages { background: #003340; }
+
+#threads_msgs.new_banner_is_showing::before { background: #002b36; }
+
+ts-thread { background: #002b36; }
+
+ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #00232c; color: #a1adad; }
+
+ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #00232c; border-color: #00232c; }
+
+ts-thread .thread_messages { background: #00232c; border-color: #00232c; }
+
+ts-thread ts-message.new_reply { background: #002b36; }
+
+ts-thread ts-message.new_reply:hover { background: #00232c; }
+
+ts-thread .thread_header .thread_channel_name a { color: #a1adad; }
+
+ts-thread .thread_header .thread_action_btns button { color: #2aa198; }
+
+ts-thread .new_reply_indicator .blue_dot { color: #dc322f; }
+
+#convo_tab .thread_participants, ts-thread .thread_participants { color: #2aa198; }
+
+#convo_loading_indicator { background-image: none; }
+
+.reply_input_container .inline_message_input_container .ql-container { background-color: #003340; border: 1px solid #00232c; }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #a1adad; }
+
+.reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #2aa198; }
+
+#file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #2aa198; }
+
+#unread_msgs_scroller_div::after { background: transparent; }
+
+#unread_msgs_scroller_div.loading { background-image: none; }
+
+#unread_msgs_scroller_div.loading::before { color: #2aa198; }
+
+#unread_msgs_div .day_divider .day_divider_line { border-top-color: #00232c; }
+
+.unread_group.marked_as_read .unread_group_header { background: #002b36; }
+
+.unread_group .unread_group_header { background: #00232c; border-top-color: #003340; color: #a1adad; }
+
+.unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #a1adad; }
+
+.unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #2aa198; }
+
+.unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #002b36; }
+
+.unread_group.active .unread_group_header { background: #00171d; border-top-color: #003340; color: #a1adad; }
+
+.collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #2aa198; }
+
+.mark_as_read_checkmark { color: #2aa198; }
+
+.bottom_mark_all_read { border-top-color: #00232c; }
+
+.unread_group_header_name a { color: #a1adad; }
+
+.unread_group_footer .unread_group_new .unread_group_new_text { color: #2aa198; }
+
+.unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #2aa198; }
+
+.unread_empty_state_message { color: #2aa198; }
+
+.unread_empty_state_undo_inner { background: #00171d; color: #a1adad; }
+
+.unread_empty_state_undo_action { color: #a1adad; }
+
+.unread_empty_state_refresh { background: rgba(0, 43, 54, 0.97); }
+
+.unread_msgs_loading { background: #002b36; background-image: none; }
+
+#col_flex { background: transparent; }
+
+#flex_contents { background: #002b36; }
+
+#flex_contents .heading { background: #00171d; border-bottom-color: #00232c; color: #268bd2; }
+
+#flex_contents .heading a { color: #268bd2; }
+
+#flex_contents .heading a:hover { color: #dc322f; }
+
+#flex_contents .heading a.close_flexpane { color: #268bd2; }
+
+#flex_contents .heading .cancel_link { color: #268bd2; }
+
+#flex_contents .heading .menu_heading:hover { color: #a1adad; }
+
+#flex_contents .heading .menu_icon { color: #268bd2; }
+
+#flex_contents .heading .menu_icon:hover { color: #dc322f; }
+
+#flex_contents .heading_text { color: #268bd2; }
+
+#flex_contents .subheading:not(.empty) { background: #002b36; border-top: 1px solid #00171d; color: #2aa198; }
+
+#flex_contents .subheading:not(.empty) p a { color: #a1adad; }
+
+#flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #2aa198; }
+
+#flex_contents .toolbar_container { background: #002b36; }
+
+#flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #268bd2; }
+
+#flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #00232c; }
+
+#flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #268bd2; }
+
+#flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #00232c; }
+
+#flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #268bd2; }
+
+#flex_contents .help { border-top: 5px solid #00171d; color: #a1adad; }
+
+#flex_contents i.callout { color: #2aa198; }
+
+.close_flexpane { color: #2aa198; }
+
+.close_flexpane:focus, .close_flexpane:hover { color: #a1adad; }
+
+#client-ui.flex_pane_showing #col_flex { border-left-color: #00232c; }
+
+.toolbar_container { background: #002b36; border-bottom: 1px solid #00171d; color: #a1adad; }
+
+.msg_right_link { color: #268bd2; }
+
+.message_location_label { color: #2aa198; }
+
+.p-flexpane_header { background: #00232c; border-color: #003340; color: #a1adad; }
+
+#client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #00232c; }
+
+#details_tab .heading { background: #00171d; }
+
+#details_tab .heading a.close_flexpane { color: #268bd2; }
+
+#details_tab .heading a.close_flexpane:hover { color: #dc322f; }
+
+#details_tab hr { border-top-color: #00232c; }
+
+#details_tab .conversation_details .member_name:hover { color: #2aa198; }
+
+#details_tab .conversation_details .member_username:hover { color: #a1adad; }
+
+#details_tab .conversation_details .member_info_timezone { border-top-color: #003340; }
+
+#details_tab .channel_page_section { background: #002b36; border-top: 1px solid #00232c; }
+
+#details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #dc322f; }
+
+#details_tab .channel_page_section .section_header a { color: #268bd2; }
+
+#details_tab .channel_page_section .section_title { color: #a1adad; }
+
+#details_tab .channel_page_section .disclosure_triangle { color: #268bd2; }
+
+#details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(220, 50, 47, 0.25) !important; }
+
+#details_tab .created_by { color: #a1adad; }
+
+#details_tab .channel_page_member_tabs .icon_member_header { color: #2aa198; }
+
+#details_tab .pinned_item:hover { border-color: #003340; }
+
+#details_tab .channel_page_action .leave_link { color: #268bd2; }
+
+#details_tab .channel_page_action .leave_link:hover { color: #dc322f; }
+
+#details_tab .channel_section_label .ts_icon_info_circle { color: #2aa198; }
+
+#details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #2aa198; }
+
+.channel_page_member_row { color: #a1adad; }
+
+.channel_page_member_row a { color: #268bd2; }
+
+.channel_page_member_row.away { color: #a1adad; }
+
+.channel_page_member_row.away a { color: #268bd2; }
+
+.channel_page_member_row:hover { background-color: #003340; border-color: #00232c; }
+
+.pinned_item { color: #a1adad; }
+
+.pinned_item .pin_file_title { color: #268bd2; }
+
+.pinned_item .pin_member_name a { color: #268bd2 !important; }
+
+.pinned_item .pin_metadata { color: #2aa198; }
+
+.pinned_item .remove_pin { color: #268bd2; }
+
+.pinned_item .remove_pin:hover { color: #dc322f; }
+
+.pinned_item .pinned_message_text .pin_truncate_fade { background: #002b36; }
+
+.pinned_item.delete_mode { border-color: #dc322f !important; }
+
+.c-channel_insights__title { color: #a1adad; }
+
+.c-channel_insights__section:not(.c-channel_insights__section--no_border) { border-color: #003340; }
+
+.c-channel_insights__drawer_title { color: #2aa198; }
+
+.c-channel_insights__item--user .member_preview_link, .c-channel_insights__item--user .message_sender { color: #a1adad !important; }
+
+.c-channel_insights__user_title { color: #2aa198; }
+
+.c-channel_insights__channel .channel_link { color: #a1adad; }
+
+.c-channel_insights__member_count { color: #2aa198; }
+
+.c-channel_insights__member_count .ts_icon_user { color: #2aa198; }
+
+.c-channel_insights .c-member__title { color: #2aa198; }
+
+.c-channel_insights__activity { border-color: #003340; }
+
+.c-channel_insights_activity_bar_container:hover { background-color: rgba(0, 23, 29, 0.05); }
+
+.c-channel_insights_activity_bar_container:hover .c-channel_insights__activity_bar { background-color: #003340; }
+
+.c-channel_insights__activity_bar { background-color: rgba(0, 51, 64, 0.5); }
+
+.c-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #002b36; border-color: #003340; }
+
+.c-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #002b36 90%); }
+
+.c-channel_insights__highlights_description { color: #2aa198; }
+
+.c-channel_insights__date_heading span { background-color: #002b36; color: #a1adad; }
+
+.c-channel_insights__date_heading::before { background-color: #003340; }
+
+#file_list_toggle_users { color: #268bd2; }
+
+#file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #dc322f; }
+
+#file_list_toggle_users.active { color: #2aa198; }
+
+.file_list_item .icon, .file_reference .icon { background: #003f50; border: 1px solid #003340; color: #a1adad !important; }
+
+.filetype_button { background: #003f50; border: 1px solid #003340; color: #a1adad !important; }
+
+.filetype_button:hover { background: #003f50; }
+
+.filetype_button:hover .file_download_label { background: #003340; color: #a1adad; }
+
+.filetype_button .file_title { color: #a1adad; }
+
+.filetype_button .file_download_label { background: #003f50; border-top: 1px solid #003340; }
+
+a.filetype_button_web { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+
+a.filetype_button_web .filetype_icon { background-color: #003340; }
+
+a.file_download_link { color: #268bd2; }
+
+a.file_download_link:hover { color: #dc322f; }
+
+a:hover .file_inline_icon { color: #2aa198; }
+
+a.gsheet img, a.pdf img { background: #002b36 !important; }
+
+html.no_touch a.filetype_button_web:hover { border-color: #003340; }
+
+html.no_touch a.filetype_button_web:hover .file_title { color: #a1adad; }
+
+.file_header_detailed { color: #2aa198; }
+
+.file_header_detailed .member { color: #a1adad !important; }
+
+.file_inline_icon { color: #2aa198; }
+
+.file_header .member { color: #2aa198 !important; }
+
+.file_header .title { color: #a1adad; }
+
+.file_header .title a { color: #268bd2; }
+
+.file_header .title a:hover { color: #dc322f; }
+
+.flexpane_file_title .member, .flexpane_file_title .service_link { color: #268bd2 !important; }
+
+.flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #268bd2; }
+
+.flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #dc322f; }
+
+.file_actions_cog { color: #268bd2 !important; }
+
+.file_actions_cog:hover { color: #dc322f !important; }
+
+.file_list_item { color: #a1adad; }
+
+.file_list_item a { color: #268bd2; }
+
+.file_list_item a.member { color: #dc322f; }
+
+.file_list_item .bullet { color: #2aa198; }
+
+.file_list_item .icon { background: #003f50; border-color: #003340; }
+
+.file_list_item .ts_icon_comment { color: #2aa198; }
+
+.file_list_item .file_comment_link:hover { color: #268bd2; }
+
+.file_list_item .file_comment_link:hover .ts_icon_comment { color: #2aa198; }
+
+.file_list_item .title a { color: #268bd2; }
+
+.file_list_item .share_info .unshare_link { color: #268bd2; }
+
+.file_list_item .share_info .unshare_link:hover { color: #dc322f; }
+
+.file_list_item .actions a, .file_list_item .actions span { background-color: #00232c; border: 1px solid #003f50; color: #268bd2; }
+
+.file_list_item .actions a:hover { background-color: #002b36 !important; border-color: #003f50; color: #dc322f; }
+
+.file_list_item.post .preview, .file_list_item.space .preview { color: #a1adad; }
+
+.file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #00232c; border-color: #003340; }
+
+.file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #268bd2; }
+
+.file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+
+.file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #00232c; }
+
+.unshare_link { color: #268bd2 !important; }
+
+.unshare_link i::before { color: #2aa198 !important; }
+
+.unshare_link i.ts_icon_minus_circle_small:hover::before { color: #dc322f !important; }
+
+.snippet_preview pre { color: #a1adad; }
+
+.file_preview_wrapper .file_preview { background: #002b36; }
+
+.file_preview_wrapper .file_preview:hover { background: #00232c; }
+
+#file_preview_container .file_meta { color: #2aa198; }
+
+.file_page_meta { color: #2aa198; }
+
+#file_page_preview img { background: #002b36; border: 1px solid #00171d; }
+
+#file_page_preview img:hover { background: #00232c; }
+
+.comment_meta { color: #2aa198; }
+
+.comment .special_formatting_quote .content { color: #a1adad; }
+
+.comment .member { color: #a1adad !important; }
+
+.comment_body { color: #a1adad; }
+
+.comment_actions { color: #2aa198; }
+
+.comment_actions:hover { color: #a1adad; }
+
+.icon_quote { color: #a1adad; }
+
+.edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #00232c; }
+
+.tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #002b36; }
+
+.tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #00232c; }
+
+.tab_container .star_item ts-message .timestamp { color: #2aa198; }
+
+.tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #002b36; border-color: #00232c; }
+
+.tab_container .file_list_item .star { color: #2aa198; }
+
+.tab_container .file_list_item .contents .file_comment_link { color: #268bd2; }
+
+.tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #268bd2; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #dc322f; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #dc322f; }
+
+.tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #2aa198; }
+
+.tab_container .file_list_item .filetype_image { background-color: #00171d; }
+
+.active .tab_container .file_list_item { background-color: #002b36; }
+
+.c-file__actions { background: #003340; }
+
+.c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #003340; border-color: #00232c; color: #fff; }
+
+.p-file_details__name, .p-file_details__share_channel { color: #a1adad; }
+
+.p-file_details__meta_container .c-file__action_button { color: #fff; }
+
+.c-pillow_file_container { background: #003340; border-color: #00232c; color: #a1adad; }
+
+.c-pillow_file__description, .c-pillow_file__title { color: #a1adad; }
+
+#user_groups_pane .mention { background: rgba(220, 50, 47, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+
+#user_groups_container .info_panel { background: #002b36; border: 1px solid #003340; }
+
+#user_groups_container .mention { background-color: rgba(220, 50, 47, 0.25) !important; }
+
+#user_groups_header .user_groups_search .icon_search { color: #2aa198; }
+
+#user_groups_header a.icon_close { color: #268bd2; }
+
+#user_groups_header a.icon_close:hover { color: #dc322f; }
+
+.user_group_item { border-bottom: 1px solid #003340; }
+
+.user_group_item a { color: #268bd2; }
+
+#flex_contents .user_group_item:hover { background-color: #002b36; }
+
+#flex_contents .user_group_item:hover h4 { color: #a1adad; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #002b36; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #a1adad; }
+
+.user_group_invite_member_small .add_icon { color: #2aa198; }
+
+#user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #003f50; border-color: #003f50; }
+
+#flex_contents .subheading:not(.empty)#mentions_options { background-color: #002b36; border-bottom-color: #00232c; color: #a1adad; }
+
+.mention_day_container_div .day_divider::before { background: none; border-color: #00232c; }
+
+#member_mentions h3 a { color: #268bd2; }
+
+a.internal_member_link { background: #00232c; color: #a1adad; }
+
+a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #00232c; border: 1px solid #003340; color: #a1adad; }
+
+a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #002b36; color: #a1adad; }
+
+.mention_rxn .mention_rxn_summary { color: #a1adad; }
+
+.mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #2aa198; }
+
+.search_message_result { background: #002b36 !important; border-color: #00232c !important; color: #a1adad !important; }
+
+.search_message_result .search_message_result_meta { color: #2aa198; }
+
+.search_message_result .search_message_result_meta a { color: #268bd2; }
+
+.search_message_result .search_message_result_meta .date_links a { color: #268bd2; }
+
+.search_message_result_text .result_msg_format a { color: #268bd2; }
+
+span.match { background: rgba(220, 50, 47, 0.25); }
+
+#search_filters .tab { background: #002b36; color: #a1adad; }
+
+#search_filters .tab:hover { border-bottom: 4px solid #00232c; }
+
+#search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #00232c; color: #a1adad; }
+
+#search_file_list_toggle_users.active:hover { border: 2px solid #dc322f; color: #dc322f !important; }
+
+.no_results { color: #a1adad; }
+
+#search_results_team .team_results_heading { color: #a1adad; }
+
+#search_results_team .team_result { background-color: #003340; border-color: #003f50; color: #a1adad; }
+
+#search_results_team .team_result a { color: #268bd2; }
+
+#search_results_team .team_result:hover a { color: #dc322f; }
+
+#search_results_team .team_result a:hover { color: #dc322f; }
+
+#search_results_team .member_name { color: #a1adad !important; }
+
+.suggestion { color: #a1adad; }
+
+.suggestion.active, .suggestion:hover { background: #003340; }
+
+#paging_in_options .search_paging { color: #2aa198; }
+
+#search_results_items .search_paging { color: #a1adad; }
+
+.search_paging i.disabled { color: #2aa198; }
+
+.search_paging a { color: #268bd2; }
+
+.search_paging a:hover { color: #dc322f; }
+
+.search_sort_prefix { color: #a1adad; }
+
+.search_segmented_control { border-color: #00232c; color: #268bd2 !important; }
+
+.search_segmented_control:hover { color: #dc322f !important; }
+
+.search_segmented_control.active { background: #00171d; color: #dc322f !important; }
+
+.search_result_with_extract { background: #00232c; border-color: #003340; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+
+.search_result_with_extract:hover { border-color: #003f50; }
+
+.search_result_for_context::after { background: rgba(0, 43, 54, 0.1); }
+
+.extract_expand_text, .extract_expand_icons { color: #268bd2; }
+
+.search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #dc322f; }
+
+.search_module_header { color: #a1adad; }
+
+.search_module_footer { background-color: #00232c; border-bottom-color: #003340; border-left-color: #003340; border-right-color: #003340; }
+
+.search_module_footer p { color: #a1adad; }
+
+.search_module_footer #see_more { color: #a1adad; }
+
+.search_module_footer #see_more a { color: #a1adad; }
+
+.search_module_footer .top_results_feedback a { color: #a1adad; }
+
+.search_module_footer ts-icon { color: #a1adad; }
+
+.top_results_search_message_result { background-color: #00232c; border-bottom-color: #003340; border-left-color: #003340; border-right-color: #003340; }
+
+.top_results_search_message_result.duplicate { background-color: #00232c; }
+
+.top_results_search_message_result .timestamp { color: #2aa198; }
+
+.top_results_search_message_result .channel { color: #2aa198; }
+
+.top_results_search_message_result .channel a { color: #2aa198; }
+
+.top_results_search_message_result .jump { color: #a1adad; }
+
+.top_results_search_message_result:hover { border-color: rgba(0, 63, 80, 0.6) !important; border-top: 2px solid #003340 !important; }
+
+.top_results_search_message_result:first-child { border-top: 2px solid #003340; }
+
+.sli_expert_search { background-color: #002b36; color: #a1adad; }
+
+.sli_expert_search__result { border-color: #003340; }
+
+.sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #a1adad !important; }
+
+.sli_expert_search__fg_face::before { background-color: #002b36; }
+
+.sli_expert_search_cta { border-color: #003340; }
+
+.sli_expert_search_cta:hover { border-color: #003f50; }
+
+.sli_expert_search_cta__text { color: #a1adad; }
+
+.sli_expert_search_cta__text:hover { color: #a1adad; }
+
+.sli_expert_search__plus_sign_overlay { background-color: #00232c; color: #2aa198; }
+
+.sli_expert_search__arrow { color: #2aa198; }
+
+.sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #2aa198; }
+
+.sli_expert_search__partial_terms { color: #2aa198; }
+
+.feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #00232c; color: #a1adad; }
+
+.feature_sli_file_search #search_results .file_list_item { background-color: #002b36; border-color: #003340; }
+
+.feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #002b36; }
+
+.feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #002b36; border-color: #003340; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #003340; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #003340; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #003340; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #003340; }
+
+.feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #a1adad; }
+
+.feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #a1adad; }
+
+.feature_sli_file_search #search_results.all { background-color: #002b36; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #002b36; border-color: #003340; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #003340; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #003f50; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #003f50; }
+
+.feature_sli_file_search #search_results.all .team_result { background-color: #002b36; border-color: #003340; }
+
+.feature_sli_file_search #search_results.files { background-color: #002b36; }
+
+.feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #a1adad; }
+
+.feature_sli_file_search #search_results_loading { background-color: #002b36; }
+
+.feature_sli_file_search #search_results_container #search_options { background-color: #002b36; }
+
+.feature_sli_file_search #search_results_container .heading { background-color: #002b36; }
+
+#client-ui .file_list_item.file_list_item--redesign { border-color: #003340; }
+
+#client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #2aa198; }
+
+#client-ui .file_list_item.file_list_item--redesign .message_sender { color: #2aa198; }
+
+.p-shortcuts_flexpane__shortcut { border-color: #00171d; }
+
+.p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #00171d; }
+
+.p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #a1adad; }
+
+.p-shortcuts_flexpane__shortcut_title { color: #2aa198; }
+
+.p-shortcuts_flexpane__title { color: #a1adad; }
+
+.p-shortcuts_flexpane__tip { color: #2aa198; }
+
+.p-shortcuts_flexpane__section_description { color: #2aa198; }
+
+.p-shortcuts_flexpane__sub_heading { color: #2aa198; }
+
+.c-keyboard_key { background: #003340; border-color: #003f50; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #a1adad; }
+
+.tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #268bd2; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #dc322f; }
+
+#member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #268bd2; }
+
+#member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #dc322f; }
+
+#member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #268bd2 !important; }
+
+#member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #003f50 !important; color: #dc322f !important; }
+
+#member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #a1adad; }
+
+#member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #268bd2 !important; }
+
+#member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #dc322f !important; }
+
+#member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #00171d; color: #2aa198; }
+
+#member_preview_scroller { background-color: #00232c; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #00232c; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(161, 173, 173, 0.35) !important; }
+
+#team_tab #member_preview_scroller { background-color: #002b36; }
+
+#member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #a1adad; }
+
+#member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #a1adad; }
+
+#member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #2aa198; }
+
+#member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #268bd2; }
+
+#member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #dc322f; }
+
+#member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #268bd2; }
+
+#member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #00232c; }
+
+#disabled_members_tab a { color: #268bd2; }
+
+#disabled_members_tab a:hover { background: #002b36; color: #dc322f; }
+
+#disabled_members_tab.active a { color: #268bd2; }
+
+.team_list_item { border-top: 1px solid #003340; color: #268bd2; }
+
+.team_list_item .member_name { color: #a1adad; }
+
+#client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #a1adad !important; }
+
+#client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #00232c !important; }
+
+#client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #003340 !important; }
+
+#client-ui .searchable_member_list .team_list_item { border-bottom-color: #00171d; }
+
+#client-ui .searchable_member_list .team_list_item:hover { background: #003340; }
+
+.c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #a1adad !important; }
+
+#convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #a1adad; }
+
+#convo_tab textarea.message_input { color: #a1adad; }
+
+#reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #00232c; color: #a1adad; }
+
+#reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #00171d; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #a1adad; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #2aa198 !important; }
+
+#reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #002b36; color: #2aa198; }
+
+#convo_container .convo_flexpane_divider { border-top-color: #00232c; color: #2aa198; }
+
+#convo_container .convo_flexpane_divider .reply_count { background: #002b36; }
+
+#convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #268bd2; }
+
+#convo_tab .message_input, #convo_tab textarea#msg_text { color: #a1adad; }
+
+ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+
+ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+
+#whats_new_tab p { color: #a1adad; }
+
+#whats_new_tab .flex_heading_controls label { color: #2aa198; }
+
+.c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #a1adad; }
+
+.c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #a1adad; }
+
+.c-member .external_team_badge { background-color: #003340; box-shadow: 0 0 0 2px #003340; }
+
+.c-member .external_team_badge.default { background-color: #2aa198; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #003340; }
+
+.c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #a1adad; }
+
+.c-member--small .presence { color: #2aa198; }
+
+.c-member--small .team_image.icon_16 { border-color: #00232c; }
+
+.c-member--small .team_image.default { background-color: #2aa198; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member--dark .c-member__current-status { color: #2aa198; }
+
+.c-member--dark .c-member__current-status::before { color: #2aa198; }
+
+.c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #2aa198; }
+
+.c-member--dark .c-member__display-name, .c-member--dark .presence { color: #a1adad; }
+
+.c-member--medium { color: #2aa198; }
+
+.c-member--medium .presence { color: #2aa198; }
+
+.c-member__secondary-name--medium { color: #a1adad; }
+
+.c-member--large { color: #2aa198; }
+
+.c-member__display-name--large, .c-member__title--large { color: #a1adad; }
+
+.c-member__other-names--large { color: #2aa198; }
+
+.c-usergroup--small .c-usergroup__icon { background-color: #2aa198; color: #a1adad; }
+
+.c-usergroup__not-in-channel-context--small { color: #2aa198; }
+
+.p-emoji_picker { background: #00171d !important; color: #a1adad !important; }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #002b36; }
+
+.p-emoji_picker__group_tabs { border-bottom-color: #002b36; }
+
+.p-emoji_picker__group_tab { color: #268bd2; }
+
+.p-emoji_picker__group_tab:hover { background: #00232c; color: #dc322f; }
+
+.p-emoji_picker__group_tab--active { background: #003340; border-bottom-color: #002b36; color: #a1adad; }
+
+.p-emoji_picker__icon_search { color: #2aa198; }
+
+.p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #002b36; border-color: #002b36; }
+
+.p-emoji_picker__skintone_options { background: #002b36; }
+
+.p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #2aa198; }
+
+.p-emoji_picker__tip { color: #a1adad; }
+
+.p-emoji_picker__no_results { color: #2aa198; }
+
+.p-emoji_picker__preview_text { background: #00171d; color: #a1adad; }
+
+.p-emoji_picker__footer { background: #00171d; border-top-color: #00232c; }
+
+.p-emoji_picker__footer .p-emoji_picker__heading { background: #00171d; }
+
+.p-emoji_picker__emoji_deluxe_label { color: #2aa198; }
+
+input[type="text"].p-emoji_picker__input:focus { border-color: #003340; box-shadow: none; }
+
+#message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #2aa198; }
+
+#message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #a1adad; }
+
+#message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #a1adad; }
+
+#message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #a1adad; }
+
+.current_status_emoji_picker { border-right-color: #00232c; }
+
+.current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #00171d; }
+
+.current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #2aa198; }
+
+.rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #00232c; border: 1px solid #003340; }
+
+.rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #002b36; }
+
+.rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #a1adad; }
+
+.rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(0, 43, 54, 0.08); border-color: rgba(0, 63, 80, 0.4) !important; }
+
+.rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #a1adad; }
+
+.rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #a1adad; }
+
+.rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(161, 173, 173, 0.25); }
+
+a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #b58900; color: #00232c; }
+
+.modal { background-color: #002b36; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+.modal .close, .modal label { color: #a1adad; }
+
+.modal_input_note, .modal_input_note_full_width, .input_note_special { color: #2aa198; }
+
+.modal-footer { background: padding-box #002b36; border-top: 1px solid transparent; box-shadow: none; }
+
+.modal-header { background: padding-box #00171d; border-bottom: 1px solid #00232c; color: #a1adad; }
+
+.modal-backdrop { background-color: #002b36; }
+
+.close { color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+#fs_modal_bg { background: #002b36; }
+
+#fs_modal { background: #002b36; }
+
+#fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #a1adad; }
+
+#fs_modal #fs_modal_sidebar a { color: #a1adad; }
+
+#fs_modal #fs_modal_sidebar a:hover { background: #00232c; }
+
+#fs_modal #fs_modal_sidebar a.active { background: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#fs_modal .fs_modal_btn { color: rgba(161, 173, 173, 0.5); }
+
+#fs_modal .fs_modal_btn:hover { background: #003f50; color: #a1adad; }
+
+#fs_modal .fs_modal_btn:active { background: #003f50; color: #a1adad; }
+
+#fs_modal.fs_modal_header .fs_modal_btn:active { color: #a1adad; }
+
+#fs_modal #fs_modal_footer { background-color: #00232c; }
+
+.p-apps_browser__apps_list--loading::before { background-color: #00232c; }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #003340; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #00232c; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+
+.p-apps_browser__category_header { background: #002b36; color: #2aa198; }
+
+.p-apps_browser__app { border-top-color: #003340; }
+
+.p-apps_browser__app--selected { background: #00232c; border-color: #003f50; }
+
+.p-apps_browser__app_info { color: #a1adad; }
+
+.p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #003340; border-color: #003f50; color: #a1adad; }
+
+.p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #003f50; color: #a1adad; }
+
+.p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__app_description { color: #2aa198; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #2aa198; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #a1adad; }
+
+#incoming_call { background-color: rgba(0, 23, 29, 0.97); color: #a1adad; }
+
+#fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #00232c; }
+
+#fs_modal.channel_options_modal .convert_to_shared label { color: #2aa198; }
+
+#fs_modal.channel_options_modal .channel_option_item { border-top-color: #00232c; }
+
+#fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #a1adad; }
+
+#fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(0, 23, 29, 0.75); border-color: #00232c; }
+
+#channel_invite_container .lfs_list_container .lfs_item { border-top-color: #00232c; }
+
+#channel_invite_container .lfs_list_container .lfs_item.active { border-color: #00232c; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #00232c; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #2aa198; }
+
+#channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #002b36; border-color: #00232c; }
+
+#channel_prefs_dialog { color: #a1adad; }
+
+#at_channel_warning_dialog { background-color: #002b36; }
+
+#at_channel_warning_dialog.fullsize { background-color: #002b36; }
+
+#at_channel_warning_dialog.fullsize .modal-body { background-color: #002b36; }
+
+.channel_prefs_modal_header { color: #a1adad; }
+
+.channel_prefs_body__section_header_title { color: #a1adad; }
+
+.channel_prefs_body__section_header_icon::before { color: #a1adad; }
+
+.channel_prefs_body__mute_help_text { color: #2aa198; }
+
+.channel_prefs_notifications_table { border-bottom-color: #00232c; color: #a1adad; }
+
+.channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #003340 !important; }
+
+.channel_prefs__muting_checkbox_label { color: #a1adad; }
+
+.channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #a1adad !important; }
+
+.notification_prefs_icon::before { color: #a1adad; }
+
+.channel_modal_header { color: #a1adad; }
+
+#channel_browser .channel_browser_row { border-top: 1px solid #00232c; color: #a1adad; }
+
+#channel_browser .channel_browser_row_header { color: #a1adad; }
+
+#channel_browser .channel_browser_creator_name { color: #2aa198; }
+
+#channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #2aa198; }
+
+#channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #00171d; border: 1px solid #003340; }
+
+#channel_browser .channel_browser_divider { background: transparent; color: #2aa198; }
+
+#channel_browser .channel_browser_sort_container::after { color: #a1adad; }
+
+#channel_browser .channel_browser_channel_purpose { color: #a1adad; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #268bd2; }
+
+.channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #2aa198 !important; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #00171d; color: #a1adad; }
+
+#invite_members_container .lfs_input_container { background: #003340; }
+
+#notifications_not_working p.highlight_yellow_bg a { color: #a1adad; }
+
+#im_browser .im_browser_row { border-top: 1px solid #003340; }
+
+#im_browser .im_browser_row.multiparty { color: #a1adad; }
+
+#im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #00171d; }
+
+#im_browser .im_browser_row .im_unread_cnt { background: #dc322f; color: #a1adad; }
+
+#im_browser .im_browser_row.disabled { color: #2aa198; }
+
+#im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser #im_browser .im_browser_row.highlighted { background: #00171d !important; border: 1px solid #003340 !important; }
+
+#im_browser_tokens { background: #003340; border: 1px solid #003f50; }
+
+#im_browser_tokens.active { border-color: #003f50; box-shadow: 0 0 7px rgba(0, 63, 80, 0.15); }
+
+#im_browser_tokens .member_token { background: #002b36; border: 1px solid #00171d; color: #a1adad; }
+
+#im_browser_tokens .member_token.ra { background: #dc322f; }
+
+.fs_modal_file_viewer_header { background-color: #00232c; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.fs_modal_file_viewer_header .btn { color: #a1adad; }
+
+.fs_modal_file_viewer_header .star { color: #2aa198; }
+
+.fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #a1adad; }
+
+.fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #a1adad; }
+
+.fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #2aa198; }
+
+.fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #003340; }
+
+.fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #2aa198; }
+
+.fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #003340; }
+
+.fs_modal_file_viewer_content .viewer { background-color: #00171d; color: #a1adad !important; }
+
+.fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #003340; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(0, 63, 80, 0.25); color: #a1adad; }
+
+.fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(42, 161, 152, 0.8); }
+
+.fs_modal_file_viewer_content .aside_panel { background-color: #002b36; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #00171d; }
+
+.fs_modal_file_viewer_content .no_comment { background-color: #002b36; color: #2aa198; }
+
+.fs_modal_file_viewer_content .aside_close_btn { color: #a1adad; }
+
+.fs_modal_file_viewer_content #file_comment { color: #a1adad; }
+
+#file_comment_textarea.texty_comment_input { background: #002b36; border-color: #00232c; color: #a1adad; }
+
+#file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #00232c; }
+
+#fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #2aa198; }
+
+#fs_modal.help_modal .help_modal_header { background-color: #00232c; border-color: #003340; }
+
+#fs_modal.help_modal .help_modal_header a { color: #a1adad; }
+
+#fs_modal.help_modal .help_modal_divider { color: #2aa198; }
+
+#fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #00232c; }
+
+#fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #2aa198; }
+
+#fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #00232c; border-color: #00171d; }
+
+.admin_invites_account_type_option { border-bottom: 1px solid #00232c; }
+
+.admin_invites_account_type_option p { color: #a1adad; }
+
+.admin_invites_account_type_option .option_arrow { color: #2aa198; }
+
+.admin_invites_account_type_option:hover:not(.disabled) h3 { color: #a1adad; }
+
+.admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+
+.admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(0, 43, 54, 0.95); }
+
+.admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #2aa198; }
+
+.admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #dc322f; }
+
+.admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(220, 50, 47, 0.4); }
+
+#admin_invites_channel_picker_container { border-bottom: 1px solid #00232c; }
+
+#admin_invites_add_row { background: #003340; border: 1px solid #00232c; }
+
+#admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #003340; }
+
+#channel_invite_tokens { background-color: #003340; border-color: #003f50; }
+
+#channel_invite_tokens.active { border-color: #2aa198; box-shadow: 0 0 7px rgba(42, 161, 152, 0.15); }
+
+#channel_invite_tokens .member_token { background: #002b36; color: #a1adad; }
+
+#channel_invite_tokens .member_token.ra { background: rgba(220, 50, 47, 0.4); }
+
+#admin_invites_alert { background: #003340; border-color: #003f50; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #a1adad; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #002b36; color: #a1adad; }
+
+#shortcuts_dialog { background: rgba(0, 43, 54, 0.95); text-shadow: 0 1px 1px rgba(0, 23, 29, 0.7); }
+
+#shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #a1adad; }
+
+#shortcuts_dialog.modal ul ul { border-left-color: #003340; }
+
+#shortcuts_dialog.modal .info_block { color: #2aa198; }
+
+#shortcuts_dialog.modal .close { background: #003340; border-color: #003f50; box-shadow: 0 1px 2px rgba(0, 23, 29, 0.5); color: #a1adad; }
+
+#shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(0, 23, 29, 0.9); }
+
+#fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #2aa198; }
+
+#fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #00232c; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #00232c; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #002b36; border: 1px solid #00232c; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #dc322f; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+
+#fs_modal.prefs_modal legend { color: #a1adad; }
+
+#fs_modal.prefs_modal .global_notification_block { background: #002b36; border-color: #00171d; }
+
+#fs_modal.prefs_modal .global_notification_block.selected { background: #00232c; border-color: #00171d; }
+
+#fs_modal.prefs_modal .channel_overrides_row { border-top-color: #00171d; }
+
+#fs_modal.prefs_modal .channel_overrides_row:hover { background: #00232c; border-color: #00171d; }
+
+#fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #a1adad; }
+
+#fs_modal.prefs_modal .notification_example.mac { background: #00171d; box-shadow: 0 1px 8px 2px #00232c; }
+
+#fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #00171d; color: #a1adad; }
+
+#fs_modal.prefs_modal .badge_example { background: #dc322f; }
+
+#fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #00171d; border-top-color: #00171d; }
+
+#fs_modal.prefs_modal .display_real_names_block_sample { background: #002b36; }
+
+.sidebar_menu_list_item { border: 0; color: #a1adad; }
+
+.sidebar_menu_list_item.is_active { background-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.sidebar_menu_list_item:not(.is_active):hover { background-color: #00232c; }
+
+.jumbomoji_pref_disabled { color: #2aa198; }
+
+.jumbomoji_disabled_note { color: rgba(42, 161, 152, 0.6); }
+
+#edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #003340; border: 1px solid #00171d; }
+
+#edit_team_profile_container .lazy_filter_select.disabled { background: #003340; }
+
+#edit_team_profile_container .lazy_filter_select.disabled input { background: #003340; }
+
+#edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #00232c; }
+
+#edit_team_profile_list .row:nth-last-child(2):hover { border-color: #00232c !important; }
+
+#edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #00232c; border: 1px solid #00171d; }
+
+#edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #2aa198; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i { color: #a1adad; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #2aa198; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #2aa198; }
+
+#edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #003340; }
+
+#edit_team_profile_add .row:last-child { border-bottom: 1px solid #003340; }
+
+#edit_team_profile_add .row:not(.header_row):hover { background: #00232c; border: 1px solid #00171d; }
+
+#edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #a1adad; }
+
+#edit_team_profile_add .row:not(.header_row):hover i { border-color: #00171d; color: #a1adad; }
+
+#edit_team_profile_add i { color: #2aa198; }
+
+#edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #2aa198; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #00171d; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #dc322f; border-color: #dc322f !important; color: #a1adad; }
+
+#edit_team_profile_edit .row i { border: 1px solid #00171d; color: #a1adad; }
+
+#edit_team_profile_custom .row .col .profile_field_preview { background: #00232c; border: 2px solid #00171d; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #00232c; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #2aa198; }
+
+#edit_team_profile_custom .row .col input { background: #003340; border: 1px solid #00171d; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #2aa198; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #00171d; }
+
+.profile_field_preview_protector .profile_field_preview { background: #002b36; border: 1px solid #003340; }
+
+.profile_field_preview_protector .profile_field_preview::after { background-color: #002b36; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview::before { background-color: #002b36; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #003340; color: #2aa198; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #00171d, rgba(255, 255, 255, 0)); }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #00171d; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #00171d transparent transparent; }
+
+ts-jumper ts-jumper-container { background: #002b36; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #002b36; color: #2aa198; }
+
+ts-jumper input[type=text] { border: 1px solid #00171d !important; color: #a1adad; }
+
+ts-jumper input[type=text]:focus { border: 1px solid rgba(0, 35, 44, 0.8) !important; color: #a1adad; }
+
+ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #a1adad; }
+
+ts-jumper ol li { color: #a1adad; }
+
+ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #2aa198; }
+
+ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #2aa198; }
+
+ts-jumper ol li .unread_count { background: #dc322f; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+ts-jumper ol li.highlighted { background: #003f50 !important; color: #a1adad !important; }
+
+ts-jumper ol:not(.keyboard_active) li:hover { background: #003f50 !important; color: #a1adad !important; }
+
+ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #a1adad; }
+
+.basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+
+.share_dialog_attachment_container { color: #a1adad; }
+
+#share_dialog .file_list_item { border-color: #00171d; }
+
+#generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container { border-color: #00232c; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #003340; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #a1adad; }
+
+.ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #003340; }
+
+.ts_tip .ts_tip_tip { color: #a1adad; }
+
+.ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #003340; }
+
+.ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #003340; }
+
+.ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #003340; }
+
+.ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #003340; }
+
+.ts_tip.success .ts_tip_tip { background: #003f50; }
+
+.ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #003f50; }
+
+.ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #003f50; }
+
+.ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #003f50; }
+
+.ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #003f50; }
+
+.c-tooltip__tip { background-color: #003340; color: #a1adad; }
+
+.c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #003340; }
+
+.c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #003340; }
+
+.c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #003340; }
+
+.c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #003340; }
+
+.c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+
+.c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+
+.c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+
+.c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #003340; }
+
+.c-tooltip__tip--success { background-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #859900; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #003340; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #003340; }
+
+#coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(0, 63, 80, 0.5) !important; }
+
+#coachmark_interior { color: #a1adad; }
+
+#coachmark_interior .coachmark_close_btn { color: #a1adad; }
+
+.menu_member_header { background: #00171d; }
+
+.menu_member_header .member_details .member_name_and_presence { color: #a1adad; }
+
+.menu_member_header .member_details .member_name_and_presence .member_name { color: #a1adad; }
+
+.menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+
+.menu_member_header .member_details .member_title { color: #2aa198; }
+
+.menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #2aa198; }
+
+.menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #268bd2; }
+
+.menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #dc322f; }
+
+.menu_member_header .member_details_divider { border-color: #003340; }
+
+.menu_member_footer { background: #00171d; border-top: 1px solid #003340; }
+
+.menu_member_footer p { color: #2aa198; }
+
+.member_meta { color: #268bd2; }
+
+.mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #a1adad !important; }
+
+.greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #2aa198 !important; }
+
+.clear_blue { color: #268bd2 !important; }
+
+.moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #dc322f !important; }
+
+.seafoam_green { color: #859900 !important; }
+
+.candy_red_bg { background-color: #dc322f !important; }
+
+.off_white_bg, .neutral_white_bg { background-color: #00232c !important; }
+
+.yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #002b36 !important; }
+
+.sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #003340 !important; }
+
+.sk_black { color: inherit; }
+
+.monkey_scroll_bar { z-index: 99; }
+
+.client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+
+nav.top.persistent { background: #00232c; }
+
+nav.top.persistent .logo { background-position: 50% 0 !important; }
+
+.widescreen #header_team_name a i { margin-left: 1.5em; }
+
+.widescreen #user_menu { border-right: none; }
+
+header #menu_toggle { color: #268bd2; }
+
+header #header_team_nav { background: #00232c; border: 1px solid #00171d; }
+
+header #header_team_nav li.active a { background: #002b36; color: #a1adad; }
+
+header .header_btns a { color: #268bd2; }
+
+header .header_btns a .label { color: #2aa198; }
+
+header .vert_divider { border-left: 1px solid #00171d; }
+
+footer, #autocomplete_menu.search_menu footer.unified { background-color: #00232c; border-color: #00171d; color: #a1adad; }
+
+footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #a1adad; }
+
+footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #a1adad; }
+
+.plastic_row h3 { color: #a1adad; }
+
+.plastic_row h4 a { color: #a1adad; }
+
+.plastic_row .icon { color: #a1adad; }
+
+.plastic_row .chevron { color: #2aa198; }
+
+.plastic_row .description { color: #a1adad; }
+
+.plastic_row:active { background: #002b36; border-color: #00171d; }
+
+.plastic_row:active .chevron { color: #a1adad; }
+
+html.no_touch .plastic_row:hover { background: #002b36; border-color: #00171d; }
+
+html.no_touch .plastic_row:hover .chevron { color: #a1adad; }
+
+html.no_touch .pagination ul > li > a:hover { background-color: #00171d; }
+
+html.no_touch .pagination ul > .disabled > a:hover { background: #00232c; color: #2aa198; }
+
+html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #dc322f; }
+
+.card, .tab_pane { background: #00232c; border: 1px solid #00171d; color: #a1adad; }
+
+.card h3 a { color: #a1adad; }
+
+#page_contents .card { background: rgba(0, 35, 44, 0.8) !important; }
+
+#page_contents .card p { color: #a1adad; }
+
+.tab_set a.secondary { color: #268bd2; }
+
+.tab_set a.selected, .tab_set a.secondary.selected { background: #00232c; border: 1px solid #00171d; border-bottom-color: #00232c; color: #dc322f; }
+
+.tab_actions { background: #00232c; border: 1px solid #00171d; border-color: #00171d; }
+
+.accordion_section { border-bottom-color: #002b36; }
+
+.accordion_section h4 { color: #a1adad; }
+
+.accordion_section h4 a { color: #a1adad; }
+
+.no_touch .accordion_section h4 a:hover { color: #a1adad; }
+
+.accordion_section_fixed { border-bottom-color: #002b36 !important; }
+
+.pager li > a, .pager li > span { background-color: #002b36; background-image: none; border-color: #00232c; color: #268bd2; }
+
+.pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+
+.pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+
+.pager .disabled > a, .pager .disabled > span { color: #2aa198; }
+
+.pagination ul > li > a, .pagination ul > li > span { background: #00232c; border: 1px solid #00171d; color: #a1adad; }
+
+.pagination ul > li > a:focus { background-color: #00171d; }
+
+.pagination ul > .active > a, .pagination ul > .active > span { background-color: #00171d; }
+
+.pagination ul > .disabled > span { background: #00232c; color: #2aa198; }
+
+.pagination ul > .disabled > a { background: #00232c; color: #268bd2; }
+
+.pagination ul > .disabled > a:focus { background: #00232c; color: #dc322f; }
+
+.loading_hash_animation img { display: none; }
+
+.icon_search_close { color: #268bd2; }
+
+.icon_search_close:hover { color: #dc322f; }
+
+.help { border-top-color: #00171d; color: #2aa198; }
+
+.two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+
+.two_factor_choice { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+.two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+.two_factor_choice:hover .two_factor_link { color: #a1adad; }
+
+a.two_factor_choice { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:link { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #a1adad; }
+
+.backup_codes { background: #00171d; border-color: #003340; color: #a1adad; }
+
+#channel_specific_settings tr { border-top-color: #002b36; }
+
+#channel_specific_settings tr.channel_override_row.muted td { background: rgba(0, 43, 54, 0.5); }
+
+#channel_specific_settings .extra_left_border { border-left-color: #002b36; }
+
+#channel_specific_settings .extra_right_border { border-right-color: #002b36; }
+
+#channel_specific_settings .revert_to_default { color: #2aa198; }
+
+#channel_specific_settings .revert_to_default:hover { color: #dc322f; }
+
+.admin_list_item { border-bottom-color: #002b36; color: #2aa198; }
+
+.admin_list_item:hover { background-color: #00232c; }
+
+.admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #a1adad; }
+
+.admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #2aa198; }
+
+.admin_list_item .pill.group { background: #002b36; }
+
+.admin_list_item .two_factor_auth_badge:hover { background: #002b36; }
+
+.admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+
+.admin_list_item.invite_item.bouncing { background: #003f50; }
+
+.admin_list_item.invite_item.bouncing .email { color: #dc322f; }
+
+.admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #002b36; }
+
+.admin_list_item.expanded .btn_outline { border-color: #002b36; color: #a1adad !important; }
+
+.admin_list_item.expanded .btn_outline:hover { border-color: #00232c; color: #a1adad !important; }
+
+.admin_list_item.expanded .sub_action { color: #268bd2; }
+
+.admin_list_item.expanded .sub_action:hover { color: #dc322f; }
+
+@media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #268bd2; } }
+
+.billing_selection { border-color: #00171d; color: #a1adad !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection:hover { border-color: #003f50; }
+
+.billing_selection.active { background: #003340; border-color: #003f50; }
+
+.billing_selection.billing_selection--refactor { border-color: #003340; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection.billing_selection--refactor:hover { border-color: #003f50; }
+
+.billing_selection.billing_selection--refactor.active { background: #003340; border-color: #003f50; }
+
+.billing_selection .billing_selection__price { color: #a1adad; }
+
+#billing_contacts_container { background: #00232c; border-top: 1px solid #00171d; }
+
+.billing_contact { border-bottom: 1px solid #002b36; }
+
+table.billing tr:hover td { background: #00232c; }
+
+.link_billing_statement { color: #a1adad !important; }
+
+.link_invoice_id, .link_statement_id { color: #268bd2 !important; }
+
+.billing_invoice tbody tbody tr { color: #a1adad !important; }
+
+.billing_settings_label_name { color: #a1adad; }
+
+table tr { border-bottom-color: #002b36; }
+
+table tr:first-child th:not(:only-of-type) { border-bottom-color: #00171d; }
+
+.slackbot_response_fieldset .delete_response { color: #2aa198; }
+
+.slackbot_response_fieldset .delete_response:hover { color: #dc322f; }
+
+.author_cell { color: #a1adad; }
+
+.message_cell.disabled { color: #2aa198; }
+
+#message_container #msg_limit { color: #a1adad; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #003340; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #003340; }
+
+.inactive { background-image: none; }
+
+.c3 line, .c3 path { stroke: #003f50; }
+
+.c3-chart-arc .c3-gauge-value { fill: #003f50; }
+
+.c3-chart-arc path { stroke: #00232c; }
+
+.c3-chart-arc text { fill: #00232c; }
+
+.c3-chart-arcs .c3-chart-arcs-background { fill: #003340; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #00232c; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #003f50; }
+
+.c3-circle._expanded_ { stroke: #00232c; }
+
+.c3-grid line { stroke: #003f50; }
+
+.c3-grid text { fill: #a1adad; }
+
+.c3-legend-background { fill: #00232c; stroke: #003340; }
+
+.c3-region { fill: #003340; }
+
+.c3-selected-circle { fill: #00232c; }
+
+.c3-tooltip { background-color: #00232c; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+
+.c3-tooltip td { background-color: #00232c; border-left-color: #003340; }
+
+.c3-tooltip th { background-color: #00232c; color: #a1adad; }
+
+.c3-tooltip tr { border-color: #003340; }
+
+.ent_alert a { color: #268bd2; }
+
+.ent_alert a:link, .ent_alert a:visited { color: #dc322f; }
+
+.ent_alert_page.ent_alert_error { background: #dc322f; }
+
+.ent_alert_page.ent_alert_success { background: #859900; }
+
+.ent_analytics__disclaimer { border-top-color: #003f50; color: #2aa198; }
+
+.ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+
+.ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+
+.ent_avatar { background-color: #003340; }
+
+.ent_callout__difference--increase { color: #859900; }
+
+.ent_callout__icon_border { background-color: #00232c; border-color: #003f50; }
+
+.ent_callout__icon_image, .ent_callout__icon--filled { border-color: #003f50; }
+
+.ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #003340; }
+
+.ent_callout__icon--limit_reached { border-color: #003f50; }
+
+.ent_callout__insight { color: #2aa198; }
+
+.ent_callout__limit { color: #2aa198; }
+
+.ent_callout__meter_bar_container { background: #002b36; }
+
+.ent_callout__meter_bar_border { border-color: #002b36; }
+
+.ent_callout__meter_bar_fill--empty { background: #003f50; border-color: #003f50; }
+
+.ent_callout__meter_bar_fill--filled { background: #003f50; border-color: #003f50; }
+
+.ent_callout__meter_bar_fill--limit_reached { background: #dc322f; border-color: #dc322f; }
+
+.ent_callout__meter_bar_gleam { background: rgba(0, 63, 80, 0.5); }
+
+.ent_callout__title { color: #a1adad; }
+
+.ent_copy_muted { color: #2aa198; }
+
+.ent_copy { color: #a1adad; }
+
+.ent_csv_popover__footer_text { color: #2aa198; }
+
+.ent_csv_popover__footer { background: #00232c; border-top-color: #003f50; }
+
+.ent_csv_popover__subtitle { color: #2aa198; }
+
+.ent_csv_popover__title { color: #a1adad; }
+
+.ent_data_table__cell--header { color: #2aa198; }
+
+.ent_data_table__cell--positive { color: #a1adad; }
+
+.ent_data_table__cell--sortable:hover { background-color: #00232c; }
+
+.ent_data_table__cell--sorting { color: #2aa198; }
+
+.ent_data_table__cell { border-bottom-color: #003f50; color: #a1adad; }
+
+.ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #003f50; }
+
+.ent_data_table__column_group { background-color: #00232c; }
+
+.ent_data_table__data_link, a.ent_data_table__data_link { color: #a1adad; }
+
+.ent_data_table__row--hovered { background-color: #002b36; }
+
+.ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+
+.ent_data_table__secondary_text { color: #2aa198; }
+
+.ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #00232c; }
+
+.ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #003f50; }
+
+.ent_data_table--rounded_top { border-top-color: #003f50; }
+
+.ent_data_table { border-bottom-color: #003f50; border-left-color: #003f50; border-right-color: #003f50; }
+
+.ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #a1adad; }
+
+.ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #2aa198; }
+
+.ent_graph__legend_item--defocus { fill: #2aa198 !important; }
+
+.ent_graph__legend_text { fill: #a1adad; }
+
+.ent_graph__svg_container .c3-axis path { stroke: #003f50; }
+
+.ent_graph__svg_container .c3-grid line { stroke: #003f50; }
+
+.ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #003f50; }
+
+.ent_graph__svg_container .c3-tooltip { border-color: #003f50; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+
+.ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #00232c; color: #a1adad; }
+
+.ent_graph__svg_container .c3-tooltip th { border-bottom-color: #003f50; }
+
+.ent_graph__svg_container .c3-xgrid-focus line { stroke: #2aa198; }
+
+.ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #00232c !important; }
+
+.ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #00232c !important; }
+
+.ent_graph__svg_container text { fill: #2aa198; }
+
+.ent_graph__tooltip { color: #2aa198; }
+
+.ent_graph_empty__overlay { background: #00232c; }
+
+.ent_graph_empty__text { color: #a1adad; }
+
+.ent_graph_header--primary { color: #a1adad; }
+
+.ent_graph_header--secondary { color: #2aa198; }
+
+.ent_graph_tabs__tab--selected { color: #a1adad; }
+
+.ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #003f50; }
+
+.ent_graph_tabs__tab { color: #2aa198; }
+
+.ent_graph_tabs { border-bottom-color: #003f50; }
+
+.ent_header { color: #a1adad; }
+
+.ent_icon_button { color: #2aa198; }
+
+.ent_icon_button:hover { color: #a1adad; }
+
+.ent_infographic_container { border-top-color: #003f50; }
+
+.ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(0, 35, 44, 0.8), #00232c); }
+
+.ent_modal__title--small { color: #a1adad; }
+
+.ent_modal_background { background-color: #002b36; }
+
+.ent_modal_breadcrumb_animated_step { background: #003340; }
+
+.ent_modal_breadcrumb_circle_icon { background: #002b36; }
+
+.ent_modal_breadcrumb_line { background: #003340; }
+
+.ent_modal_breadcrumb_text { color: #2aa198; }
+
+.ent_modal_footer { background-color: #00232c; }
+
+.ent_modal_title { color: #a1adad; }
+
+.ent_table__header--title { color: #a1adad; }
+
+.ent_table__header { background-color: #002b36; border-color: #003f50; }
+
+.ent_table_banner__contents { background: #002b36; border-top-color: #003f50; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+
+.ent_table_banner__header { color: #a1adad; }
+
+.ent_table_banner__secondary_text { color: #2aa198; }
+
+.ent_table_customizer__header_subtitle { color: #2aa198; }
+
+.ent_table_customizer_disabled_list_header { color: #2aa198; }
+
+.ent_table_customizer_footer { background-color: #002b36; border-top-color: #00171d; color: #2aa198; }
+
+.ent_table_customizer_header { border-bottom-color: #002b36; }
+
+.ent_table_customizer_list_item--disabled { color: #2aa198; }
+
+.ent_updated_at { color: #2aa198; }
+
+.enterprise { background-color: #00232c; }
+
+.enterprise .btn.candy_red { color: #dc322f !important; }
+
+.enterprise_analytics { background-color: #00232c; }
+
+.enterprise_org { background-color: #00232c; }
+
+.enterprise_search_bar .ent_clear_search_icon { color: #2aa198; }
+
+.enterprise_search_bar::before { color: #a1adad; }
+
+@keyframes color_fade { from { color: #2aa198; }
+  to { color: #a1adad; } }
+
+.file_header .title a { color: #268bd2; }
+
+.file_header .title a:hover { color: #dc322f; }
+
+.file_actions_cog { color: #268bd2 !important; }
+
+.file_actions_cog:hover { color: #dc322f !important; }
+
+.file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #00171d; }
+
+.action_cog { color: #268bd2; }
+
+.action_cog i { color: #268bd2; }
+
+html.no_touch .action_cog:hover { color: #dc322f; }
+
+html.no_touch .action_cog:hover i { color: #dc322f; }
+
+.help_pages.help_pages p { color: #a1adad; }
+
+.help_pages.help_pages a { border-bottom-color: #003340; }
+
+.help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #002b36; }
+
+.help_pages.help_pages .o-hero__header { color: #a1adad; }
+
+.help_pages.help_pages .o-section--feature { background-color: #00232c; border-top-color: #003340; }
+
+.help_pages.help_pages .c-form__container .c-form__feedback { color: #dc322f; }
+
+.help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #002b36; border-color: #003340; color: #a1adad; }
+
+.help_pages.help_pages .drop_zone { background: #002b36; border-color: #003f50; }
+
+.help_pages.help_pages .drop_zone_attachment { border-bottom-color: #003340; }
+
+.help_pages.help_pages .drop_zone_remove_attachment { background-color: #002b36; }
+
+.help_pages.help_pages .c-form__notice { background-color: #003340; border-color: #003f50; color: #a1adad; }
+
+.help_pages.help_pages .c-form__notice.is-error { border-left-color: #dc322f; }
+
+.help_pages.help_pages .c-nav--footer { border-top-color: #003340; }
+
+@media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #002b36; } }
+
+.widescreen:not(.nav_open) { color: #a1adad; }
+
+@media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(0, 43, 54, 0.9); } }
+
+.widescreen:not(.nav_open) nav#site_nav h3 { color: #a1adad; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a { color: #268bd2; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #dc322f; }
+
+.widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #2aa198; }
+
+nav#site_nav { background: #00232c; }
+
+nav#site_nav #user_menu_contents:hover { background: #002b36; color: #a1adad; }
+
+header { background: #00232c; }
+
+header #header_team_nav li a { color: #a1adad; }
+
+header #header_team_nav li a:hover { background: #002b36; color: #a1adad; }
+
+header #header_team_nav li a .team_icon.ts_icon_plus { background: #00171d; color: #2aa198; }
+
+header #header_team_nav #add_team_option { border-top: 1px solid #00171d; }
+
+html.no_touch header #header_team_nav li a { color: #a1adad; }
+
+html.no_touch header #header_team_nav li a:hover { background: #002b36; color: #a1adad; }
+
+html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #dc322f; }
+
+html.no_touch header .header_btns a:hover { color: #dc322f; }
+
+html.no_touch header .header_btns a:hover .label { color: #2aa198; }
+
+nav#site_nav h3, #header_team_name, header #header_team_name a { color: #268bd2; }
+
+nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #dc322f; }
+
+#home_footer a { color: #dc322f; }
+
+.admin_pref:not(:first-of-type) { border-top-color: #002b36; }
+
+.admin_pref.locked { background-color: rgba(220, 50, 47, 0.2); }
+
+.admin_pref .admin_pref_locked_label { color: #2aa198; }
+
+.tooltip-inner { background-color: #003f50; color: #a1adad; }
+
+.tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #003f50; }
+
+.tooltip.right .tooltip-arrow { border-right-color: #003f50; }
+
+.tooltip.left .tooltip-arrow { border-left-color: #003f50; }
+
+.tooltip.bottom .tooltip-arrow { border-bottom-color: #003f50; }
+
+.api #header_logo img { display: none; }
+
+body.api header .header_links a { color: #a1adad; }
+
+body.api header .header_links a.active { background: #003340; }
+
+body.api .reverse_header { background-color: #00171d; color: #a1adad; }
+
+body.api pre { overflow-x: auto; }
+
+body.api pre code { color: #a1adad; }
+
+body.api #page_contents .card { background: #00232c; }
+
+body.api .scopes_to_methods code { color: #a1adad; }
+
+body.api .scopes_to_methods .selected code { color: #dc322f; }
+
+body.api .scopes_to_methods li { color: #a1adad; }
+
+body.api .scopes_to_methods .selected li { color: #a1adad; }
+
+body.api .section_title { border-bottom: 2px solid #002b36; }
+
+body.api .example { border: 1px solid #00171d; }
+
+body.api .example h5 { background-color: #00171d; color: #a1adad; }
+
+body.api .alert { background: #003340; }
+
+body.api .hljs { background-image: none; }
+
+body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+
+body.api .hljs-number { color: #a5d6a7; }
+
+body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+
+body.api .hljs-variable { color: #9fa8da; }
+
+body.api .hljs-template-variable { color: #c5e1a5; }
+
+body.api .hljs-comment { color: #ffcc80; }
+
+body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+
+body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+
+body.api .hljs-meta { color: #eee; }
+
+body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+
+body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+
+body.api .hljs-tag { color: #a5d6a7; }
+
+body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+
+body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+
+body.api .hljs-quote { color: #b0bec5; }
+
+body.api .hljs-link, body.api .hljs-regexp { color: #268bd2; }
+
+body.api span.btn { background-color: #002b36; }
+
+body.api span.deprecation, body.api span.warning { background-color: #dc322f; border-color: #dc322f; }
+
+nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#api_nav .footer_nav a { color: #268bd2; }
+
+#api_nav .footer_nav a:hover { color: #dc322f; }
+
+#api_nav .footer_nav .footer_signature { color: #dc322f; }
+
+.api_articles .api_articles_section { border-bottom-color: #002b36; }
+
+.api_articles .article_tag_count { color: #2aa198; }
+
+.api.feature_related_content #api_related_content h2 { color: #a1adad; }
+
+.api.feature_related_content #api_related_content .article_link_title_wrapper { color: #268bd2; }
+
+.tab_menu { background-color: #00232c; }
+
+.tab_menu.grey { background-color: #00232c; }
+
+.tab_menu .tab { color: #a1adad; }
+
+.tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(220, 50, 47, 0.4); }
+
+.tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #dc322f; color: #a1adad; }
+
+.tab_menu .tab:disabled { color: #2aa198; }
+
+.page_faq h3, .page_scim h3 { background-color: #002b36; }
+
+.application_config aside { color: #2aa198; }
+
+.page_apps_directory_home { background-color: #002b36 !important; }
+
+.page_apps_directory_home .nav_title { color: #a1adad !important; }
+
+.page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #2aa198; }
+
+.page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #003f50; }
+
+.splash_container__background { background-color: #00232c; }
+
+.splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+
+.splash_interactive__button { border-color: #003340; }
+
+.splash_interactive__button--active { box-shadow: 0 0 10px 1px #003f50; }
+
+.splash_interactive__window { background-color: #002b36; border-color: #003340; }
+
+.splash_interactive__window:hover .splash_interactive__window_headline { color: #a1adad; }
+
+.splash_interactive__window::after { background: linear-gradient(to bottom, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+
+.splash_interactive__window_response { background-color: #fff; }
+
+a.splash_interactive__window_link { color: #a1adad; }
+
+.splash_interactive__window_message_content_text--drive { color: #2aa198; }
+
+.search_input.apps_search_input { border-color: #003f50; }
+
+.menu_launcher, .menu_launcher_large { background-color: #003340; border-color: #002b36 !important; color: #a1adad; }
+
+.menu_launcher_large { border-color: #002b36; }
+
+.menu.avatar_menu ul li:hover ts-icon { background: #003340; color: #a1adad; }
+
+.menu.avatar_menu ul li a { color: #a1adad; }
+
+.menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #003340; color: #2aa198; }
+
+.menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #a1adad; }
+
+#page .media_list { background-color: #00232c; border: 1px solid #003340; }
+
+#page .media_list > li + li::before { border-top-color: #003340; }
+
+#page .media_list > li.interactive a { color: #a1adad; }
+
+#page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #003340; border-color: #003f50; }
+
+#page .media_list > li .media_list_text { color: #a1adad; }
+
+#page .media_list.media_list_with_arrows a::before { color: #2aa198; }
+
+#page .media_list_title { color: #a1adad; }
+
+#page .media_list_subtitle { color: #2aa198; }
+
+#page .sidebar_menu_list_item { color: #a1adad; }
+
+#page .sidebar_menu_list_item.is_active { background-color: #002b36; border-color: #002b36; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#page .sidebar_menu_list_item.is_active a { color: #a1adad; }
+
+#page .sidebar_menu_list_item:not(.is_active):hover { background-color: #002b36; border-color: #002b36; }
+
+#page .sidebar_menu_list_item a { color: #a1adad; }
+
+#page ul.breadcrumbs li { color: #2aa198; }
+
+#page ul.breadcrumbs li:not(:first-child)::before { color: #2aa198; }
+
+#page ul.navigation_list li a { color: #a1adad; }
+
+#page ul.navigation_list li a:hover { background-color: #003340; }
+
+#page ul.navigation_list li a::after { color: #a1adad; }
+
+#page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+
+#page .tag { background-color: #00171d; border: 1px solid #00232c; }
+
+#page .tag:hover { background-color: #003340 !important; }
+
+#page .app_desc_btn { background-color: #003340; color: #a1adad; }
+
+#page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+
+#page .service_panel { background-color: #00232c; }
+
+#page .service_card { background-color: #002b36; border: 1px solid #002b36; }
+
+.app_card, .large_app_card { background-color: #002b36; border: 1px solid #00232c; }
+
+nav.top.persistent ul a { color: #a1adad; }
+
+nav.top.apps_nav { background: transparent; }
+
+nav.top.apps_nav.persistent .nav_title { border-color: #003f50; }
+
+nav.top.apps_nav.clear_nav .nav_title a { color: #a1adad; }
+
+nav.top.apps_nav .nav_title a { color: #a1adad; }
+
+nav.top.apps_nav ul a.active { color: #dc322f; }
+
+.plastic_typeahead { background: #00232c; border: 1px solid #00232c; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+
+.plastic_typeahead_item { color: #a1adad; }
+
+.plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #003340; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #002b36; border-top-color: #00232c; color: #a1adad; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #2aa198; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #00171d; border-color: #003340; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #003340; }
+
+a.plastic_typeahead_item { color: #a1adad; }
+
+.apps_typeahead_item_media { background: #00171d; }
+
+.search_input_container .search_input:focus ~ .icon_search_input { color: #a1adad; }
+
+.icon_search_input { color: #2aa198; }
+
+.quote_block { color: #a1adad; }
+
+.quote_block::before { background-color: #003340; }
+
+.well { background: #00171d; border-color: #000f12; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #2aa198; }
+
+.c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #003340; }
+
+.c-tabs__tab { color: #2aa198; }
+
+.c-tabs__tab:hover { color: #a1adad; }
+
+.c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #003f50; color: #a1adad; }
+
+.c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #003340; }
+
+a.c-tabs__tab--plastic { color: #2aa198; }
+
+a.c-tabs__tab--plastic:hover { color: #a1adad; }
+
+a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #003f50; color: #a1adad; }
+
+.p-detail_scope { box-shadow: inset 0 1px 0 0 #003340; }
+
+.p-detail_scope:last-child { border-bottom-color: #003340; }
+
+.p-detail_dangerous_scope { border-left-color: #dc322f; border-right-color: #003340; }
+
+.p-detail_arrow_icon { color: #2aa198; }
+
+.p-detail_arrow_icon:hover { color: #a1adad; }
+
+.p-detail_permissions { background: #00232c; border-color: #003340; }
+
+table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #003340; }
+
+.section_rollup { border-bottom-color: #002b36; }
+
+.section_rollup:first-of-type { border-top-color: #002b36; }
+
+.section_rollup:hover:not(.is_active) { background: rgba(0, 43, 54, 0.5); color: #a1adad; }
+
+.is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #859900; color: #00171d; }
+
+.developer_apps_functionality_link:hover { border-color: #003340; box-shadow: 0 0 6px 0 rgba(0, 63, 80, 0.25); }
+
+.developer_apps_functionality_link::before { background-color: #003340; }
+
+.developer_apps_functionality_link_enabled::before { background-color: #859900; }
+
+.legal-hero { background-color: #002b36; }
+
+.legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #002b36; }
+
+.legal-hero .o-hero__header__headline--larger { color: #a1adad; }
+
+.legal-main { background-color: #00232c; }
+
+.legal-main.v--no-switch { background-color: #00232c; border-bottom-color: #003340; border-top-color: #003340; }
+
+.legal-main p { color: #a1adad; }
+
+.legal-main a { border-bottom-color: #003340; }
+
+@media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #a1adad; }
+  .legal-main .c-nav--sidebar__listitem a.is-selected { color: #2aa198; } }
+
+.legal-main .t-contains-subtle-links a:not(.c-button) { color: #a1adad; }
+
+.legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #2aa198; }
+
+@media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #00232c; } }
+
+.t-no-header .legal-hero.o-hero.v--short { background-color: #00232c; }
+
+.c-oauth_scope_info__spacer_icon { color: #dc322f; }
+
+.c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #003340; }
+
+.c-oauth_scope_info__dangerous_scopes { border-left-color: #dc322f; border-right-color: #003340; border-top-color: #003340; }
+
+.c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #003340; }
+
+a.p-oauth_nav__anchor { color: #2aa198; }
+
+.p-oauth_nav__team-switcher .menu_launcher { border-color: #00232c; }
+
+.p-oauth_nav__team-switcher .menu_launcher:hover { border: #003340; }
+
+.p-oauth_page, .p-oauth_page--error { background: #002b36; }
+
+.p-oauth_page__title { color: #a1adad; }
+
+.p-oauth_page_single_channel_picker { border-bottom-color: #00232c; }
+
+ts-rocket { color: #a1adad; }
+
+ts-rocket a { color: #268bd2; }
+
+ts-rocket a caret::before { background-color: #00232c; border-color: #00232c; }
+
+ts-rocket hr { border-color: #00232c; }
+
+ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #00171d; }
+
+ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #00171d; }
+
+ts-rocket .cl.text { background-color: #00171d; border-bottom: 1px solid #00232c; }
+
+ts-rocket .cl.text .checkbox.checked + li { color: #2aa198; }
+
+ts-rocket > div > .checklist { background-color: #00171d; border-bottom: 1px solid #00232c; }
+
+ts-rocket > div > .checklist .checkbox.checked + li { color: #2aa198; }
+
+ts-rocket > div > .checklist li::before { background: #00232c; }
+
+ts-rocket > div > .checklist li.checked { color: #2aa198; }
+
+ts-rocket .unfurl .unfurl-container { background-color: #00171d; }
+
+ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(220, 50, 47, 0.1); }
+
+ts-rocket .unfurl .attachment_bar { background-color: #00232c !important; }
+
+ts-rocket .unfurl .unfurl-remove::before { color: #2aa198; }
+
+ts-rocket .unfurl .unfurl-remove:hover::before { color: #a1adad; }
+
+ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(0, 63, 80, 0.5) !important; }
+
+ts-rocket caret::before { background-color: #00232c; border: 1px solid #00232c; }
+
+ts-rocket carriage { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-rocket selection { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-rocket ime { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(0, 63, 80, 0.5); }
+
+.focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #00171d; }
+
+nav { background: #00232c; }
+
+nav .space { background-color: #00232c; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+
+nav .space::after { border-left: 1px solid #003340; }
+
+nav .comments { background-color: #00232c; }
+
+nav .space_buttons .btn_outline { background-color: #002b36; }
+
+nav .space_buttons .btn_outline::after { border-color: #003340; }
+
+nav .space_btn_star { background: none; border: 0; }
+
+nav .space_btn_star:hover { background: none !important; }
+
+nav .space_btn_edit { background: #003340; }
+
+nav .space_btn_edit.editing { background: #003f50; }
+
+nav .star_info { color: #2aa198; }
+
+nav #space_status { border-left: 1px solid #003340; color: #2aa198; }
+
+nav #space_status.slightly_concerned { color: #dc322f; }
+
+nav #edit_status { color: #2aa198; }
+
+nav .comments_open.unread span.notif { background-color: #dc322f; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+
+nav .comments_close { color: #2aa198; }
+
+nav .comments_close:hover::before { color: #268bd2 !important; }
+
+ts-space header { background: transparent; }
+
+ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #a1adad; }
+
+ts-space header .owner_detail .inline-edit { background: none; }
+
+ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #a1adad; }
+
+ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #a1adad; }
+
+ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #2aa198; }
+
+ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #2aa198; }
+
+ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(0, 63, 80, 0.5); }
+
+ts-space header .owner_detail small { color: #2aa198; }
+
+ts-space header .divider { border-top: 1px solid #003340; }
+
+ts-space a.feedback { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+
+ts-space a.feedback:hover { background-color: #00232c; color: #a1adad; }
+
+comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+
+#space_alert { background-color: #00171d; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+
+#space_alert.error { background-color: #dc322f; }
+
+#space_alert span#space_alert_text { color: #a1adad; }
+
+#space_alert a { color: #268bd2; }
+
+#space_alert button#space_alert_close::before { color: #2aa198; }
+
+#space_alert button#space_alert_close:hover::before { color: #2aa198; }
+
+#space_alert .btn_outline.btn_transparent { background-color: #002b36 !important; color: #a1adad !important; }
+
+#space_alert .btn_outline.btn_transparent::after { border-color: #003340; }
+
+#space_find_bar { background-color: #00232c; border-bottom: 1px solid rgba(0, 63, 80, 0.1); border-left: 1px solid rgba(0, 63, 80, 0.07); border-right: 1px solid rgba(0, 63, 80, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#space_find_bar #space_find_info.no_matches { color: #dc322f; }
+
+#space_find_bar #space_find_next .ts_icon { background-color: #003340; }
+
+#space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #a1adad; }
+
+#space_find_bar #space_find_next:hover .ts_icon { background-color: #003f50; }
+
+#space_find_bar #space_find_close::before { color: #2aa198; }
+
+#space_find_bar #space_find_close:hover::before { color: #2aa198; }
+
+#connected_members .connected_members_count { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+
+#connected_members .toggle_more_members_popover { background: #002b36; color: #2aa198; }
+
+#connected_members_overflow_popover { border-bottom: 1px solid #00232c; border-left: 1px solid rgba(0, 23, 29, 0.11); border-right: 1px solid rgba(0, 23, 29, 0.11); border-top: 1px solid rgba(0, 23, 29, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .arrow::after { background-color: #00232c; }
+
+#connected_members_overflow_popover .arrow_shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .monkey_scroll_wrapper { background: #00232c; }
+
+#connection_status #connection_label { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+
+#shortcuts_spaces_dialog { background-color: rgba(0, 23, 29, 0.8); text-shadow: 0 1px 1px rgba(0, 35, 44, 0.7); }
+
+#shortcuts_spaces_dialog .modal-body { color: #a1adad; }
+
+#shortcuts_spaces_dialog .col .keyboard { background-color: #003f50; border-bottom: 2px solid #002b36; box-shadow: 0 1px 2px rgba(0, 23, 29, 0.5); color: #a1adad; }
+
+#shortcuts_spaces_dialog .close:hover { background-color: #003f50; }
+
+#shortcuts_spaces_dialog .close .ts_icon::before { color: #2aa198 !important; }
+
+.textstyle_menu .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #00232c; }
+
+.textstyle_menu .arrow::after { background-color: #00232c; }
+
+.textstyle_menu .content { background-color: #00232c; box-shadow: 0 0 0 1px #00232c, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .arrow-shadow::after { background-color: #00232c; }
+
+.textstyle_menu.link .arrow::after { background-color: #00232c; }
+
+.textstyle_menu.link .content { background-color: #00232c; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .content input[type=text] { background-color: #003340; }
+
+.textstyle_menu.link .content > a.link { color: #268bd2; }
+
+.textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #2aa198; }
+
+.textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #00232c; }
+
+.textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #003340; }
+
+.textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #003340; border: 1px solid #003f50; }
+
+.textstyle_menu.style a.deformat::before { border-left: 1px solid #003340; }
+
+.textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #2aa198; }
+
+.para_menu .insert .tip { color: #2aa198; }
+
+.para_menu .insert .tooltip .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #003340; }
+
+.para_menu .insert .tooltip .arrow::after { background-color: #00232c; }
+
+.para_menu .insert .tooltip .content { background-color: #00232c; box-shadow: 0 0 0 1px #003340, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #003340; }
+
+.para_menu .format .options .arrow::after { background-color: #00232c; }
+
+.para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #003340; }
+
+.para_menu .format .options .content { background-color: #00232c; box-shadow: 0 0 0 1px #003340, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .content ul:first-child { border-bottom: 1px solid #00232c; }
+
+.para_menu .format .options.show .tooltip > div { background-color: #00232c; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #a1adad; }
+
+.para_menu .format .options.show .tooltip span { background-color: #003340; }
+
+.para_menu .options a:hover { border: 1px solid #003340; }
+
+.para_menu .options a.active { background-color: #002b36; border: 1px solid #00232c; }
+
+.para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+
+.para_menu .options a span { filter: grayscale(2) brightness(5); }
+
+.para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+
+.para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); }

--- a/css/raw/variants/solarized-light.css
+++ b/css/raw/variants/solarized-light.css
@@ -1,0 +1,4066 @@
+body { background: #fdf6e3; color: #586e75; }
+
+a { color: #268bd2; }
+
+a:link, a:visited { color: #268bd2; }
+
+a:hover, a:active, a:focus { color: #dc322f; }
+
+hr { border-bottom: 1px solid #fdf6e3; border-top: 1px solid #fdf6e3; }
+
+h1, h2, h3, h4 { color: #586e75; }
+
+h1 a { color: #586e75; }
+
+h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #586e75; }
+
+.bordered { border: 1px solid #fcf3d9; }
+
+.top_border { border-top: 1px solid #fcf3d9; }
+
+.bottom_border { border-bottom: 1px solid #fcf3d9; }
+
+.left_border { border-left: 1px solid #fcf3d9; }
+
+.right_border { border-right: 1px solid #fcf3d9; }
+
+.bullet { color: #2aa198; }
+
+.alert, .c-alert, .c-alert--boxed { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.alert h4, .c-alert h4, .c-alert--boxed h4 { color: #586e75; }
+
+.alert-info { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; }
+
+.alert-info h4 { color: #586e75; }
+
+::-webkit-scrollbar-track { background: #fcf3d9 !important; border-left-color: #fcf3d9 !important; border-right-color: #fcf3d9 !important; color: #fcf3d9 !important; }
+
+::-webkit-scrollbar-thumb { background: #fef9ed !important; border-left-color: #fcf3d9 !important; border-right-color: #fcf3d9 !important; color: #fdf6e3 !important; }
+
+::-webkit-scrollbar-corner { background: #fdf6e3 !important; }
+
+.supports_custom_scrollbar #messages_container::after { background: none !important; }
+
+.monkey_scroll_bar { background: #fdf6e3; }
+
+.monkey_scroll_handle_inner { background: #fef9ed; border: 1px solid #fffefb; }
+
+.monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+
+#client-ui .monkey_scroll_bar { background: #fdf6e3; }
+
+#client-ui .monkey_scroll_handle_inner { background: #fef9ed; border: 3px solid #fdf6e3; }
+
+.c-scrollbar--monkey .c-scrollbar__track { background: #fdf6e3; }
+
+.c-scrollbar--monkey .c-scrollbar__bar { background: #fef9ed; box-shadow: 0 3px 0 #fdf6e3, 0 -3px 0 #fdf6e3; }
+
+.client_channels_list_container { background-color: #fcf3d9; border-right-color: #fdf6e3; }
+
+#col_channels { color: #586e75; }
+
+.p-channel_sidebar { background-color: #fcf3d9; color: #586e75; }
+
+.p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(88, 110, 117, 0.8) !important; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #586e75; }
+
+.p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #fdf6e3 !important; }
+
+.p-channel_sidebar__header { color: #586e75 !important; }
+
+.p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #586e75; }
+
+.p-channel_sidebar__channel--im .c-presence--away { color: #2aa198; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #fef9ed !important; }
+
+.p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #fef9ed !important; }
+
+.p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #586e75; }
+
+.p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #586e75; }
+
+.p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #dc322f; }
+
+.p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #fef9ed; }
+
+.p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #657e86 !important; }
+
+.p-channel_sidebar__close_container:hover { background: #fbeecb; }
+
+.p-channel_sidebar__jumper { background: transparent !important; }
+
+.channels_list_holder h2 { color: #586e75 !important; }
+
+.channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #586e75; opacity: 0.8; }
+
+.channels_list_holder ul { color: #586e75 !important; }
+
+.channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #fcf3d9; color: rgba(88, 110, 117, 0.8) !important; }
+
+.channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #fdf6e3 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+
+.channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #fdf6e3; }
+
+.channels_list_holder ul li.mention a { color: #586e75; }
+
+.channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #657e86 !important; }
+
+.channels_list_holder ul li.unread .prefix { color: #586e75 !important; opacity: 1; }
+
+.channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #268bd2 !important; }
+
+.channels_list_holder .unread_highlights { background: #dc322f; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder .unread_msgs { background: #fdf6e3; color: #586e75; }
+
+#channel_list_invites_link { border-bottom: 1px dotted #268bd2; color: #268bd2 !important; font-size: 0.9rem; }
+
+#channel_list_invites_link:hover { border-bottom: 1px solid #268bd2; }
+
+#quick_switcher_btn { background: #fcf3d9; border-top: 2px solid #fcf3d9; }
+
+#quick_switcher_btn > i { color: #2aa198; }
+
+#quick_switcher_btn:active, #quick_switcher_btn:hover { background: #fdf6e3; border-color: #fdf6e3; }
+
+#quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #268bd2; }
+
+#quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #268bd2; }
+
+#quick_switcher_label { color: #2aa198; }
+
+.loading #loading-zone { background: #fdf6e3; }
+
+#loading_welcome { background-image: none; }
+
+#loading_message p { color: #586e75; }
+
+#loading_message #loading_message_attribution { color: #2aa198; }
+
+#loading_team_menu_bg, #loading_user_menu_bg { background: #fdf6e3; border: none; }
+
+.infinite_spinner_bg, .infinite_spinner_blue { stroke: #586e75; }
+
+body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #fcf3d9; }
+
+.p-degraded_list__loading { background-color: #fdf6e3; color: #586e75; }
+
+input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #fef9ed; border-color: #fbeecb; color: #586e75; }
+
+input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(252, 243, 217, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+
+input[type=file]:focus { outline: #586e75 dotted thin; }
+
+input[type=radio]:focus, input[type=checkbox]:focus { outline: #586e75 dotted thin; }
+
+select { background: #fef9ed; }
+
+select, textarea { border: 1px solid #fbeecb; color: #586e75; }
+
+select:active, select:focus, textarea:active, textarea:focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(255, 254, 251, 0.15); }
+
+input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #fdf6e3 !important; }
+
+.no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #fcf3d9; }
+
+.no_touch label.select:hover select { border-color: #fcf3d9; }
+
+.no_touch label.select:not(.disabled):hover::after { color: #fcf3d9; }
+
+label.disabled { color: #586e75; }
+
+legend { border-bottom: 1px solid #fffefb; }
+
+legend small { color: #2aa198; }
+
+.uneditable-input, .uneditable-textarea { background-color: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+
+.uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(255, 254, 251, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+
+textarea { background-color: #fef9ed; border: 1px solid #fbeecb; color: #586e75; }
+
+textarea:focus { border-color: rgba(255, 254, 251, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+
+::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+[data-placeholder]:empty::before { color: #586e75 !important; }
+
+input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+input::-moz-placeholder, textarea::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+input::placeholder, textarea::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #586e75 !important; }
+
+input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #fef9ed !important; }
+
+.form-actions { background-color: #fdf6e3; border-top: 1px solid #fcf3d9; }
+
+.help-block, .help-inline { color: #2aa198; }
+
+.input-append .add-on, .input-prepend .add-on { background-color: #fffefb; border: 1px solid #fef9ed; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.btn { background-color: #fef9ed; color: #586e75 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #fef9ed; color: #586e75; }
+
+.btn.btn_border { border: 2px solid #fdf6e3; }
+
+.btn.disabled, .btn:disabled { background-color: #fbeecb !important; }
+
+.btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #fbeecb !important; }
+
+.btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #dc322f !important; color: #586e75 !important; }
+
+.btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #fdf6e3 !important; border-color: #dc322f !important; color: #dc322f !important; }
+
+.btn.btn_outline.disabled { background: #fdf6e3 !important; color: #268bd2 !important; }
+
+.btn.btn_outline.disabled:hover { background: #fdf6e3 !important; color: #268bd2 !important; }
+
+.btn.btn_attachment { border-color: #fef9ed; }
+
+.btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #fcf3d9; border-color: #fffefb; }
+
+.btn.btn_attachment.btn_danger { border-color: #dc322f; }
+
+.btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e35d5b; }
+
+.btn.btn_attachment.btn_primary { border-color: #fffefb; }
+
+.btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: white; }
+
+.btn_basic:focus, .btn_basic:hover { color: #586e75; }
+
+.btn_outline { background: #fdf6e3; color: #268bd2 !important; }
+
+.btn_outline::after { border: 1px solid #fdf6e3; }
+
+.btn_outline.btn_transparent { color: rgba(254, 249, 237, 0.9) !important; }
+
+.btn_outline.btn_transparent::after { border: 1px solid rgba(253, 246, 227, 0.5); }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(254, 249, 237, 0.9) !important; color: #dc322f !important; }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(254, 249, 237, 0.8) !important; }
+
+.btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #fdf6e3; color: #dc322f !important; }
+
+.btn_outline:active { color: #dc322f; }
+
+.btn_outline.active { color: #dc322f !important; }
+
+.btn_link { color: #268bd2; }
+
+.btn_link:hover, .btn_link:focus { color: #dc322f; }
+
+.btn-group.open .btn.dropdown-toggle { background-color: #fef9ed; }
+
+.btn-group.open .btn-primary.dropdown-toggle { background-color: #fdf6e3; }
+
+.btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+
+.btn_info, .btn.btn_success { background-color: #fdf6e3 !important; }
+
+.btn_warning, .btn_danger { background-color: #dc322f !important; }
+
+.btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #586e75; border-top-color: #586e75; }
+
+.input_note { color: #586e75; }
+
+.c-enhanced_text_input { background-color: #fef9ed; border-color: #fcf3d9; color: #2aa198; }
+
+.c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #fef9ed; }
+
+.lazy_filter_select.disabled { background: #fcf3d9; }
+
+.lazy_filter_select.disabled input.lfs_input { background: #fffefb; }
+
+.lazy_filter_select .lfs_input_container { background-color: #fef9ed; border-color: #fbeecb; }
+
+.lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #fcf3d9; }
+
+.lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(253, 246, 227, 0.15); }
+
+.lazy_filter_select .lfs_list_container { background: #fdf6e3; border-color: #fbeecb; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+
+.lazy_filter_select .lfs_list .lfs_item.selected { color: #586e75; }
+
+.lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #586e75 !important; }
+
+.lazy_filter_select .lfs_list .lfs_item.disabled { color: #2aa198; }
+
+.lazy_filter_select .lfs_list .lfs_item.active { background-color: #fbeecb; border-color: #fcf3d9; color: #586e75; }
+
+.lazy_filter_select .lfs_token { background: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+
+.lazy_filter_select .lfs_token::after { color: #586e75; }
+
+.lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #586e75; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #586e75 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item { color: #2aa198 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+
+#message_edit_form .emo_menu { color: rgba(88, 110, 117, 0.3); }
+
+#message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #fffefb; }
+
+#message_edit_form.focus .emo_menu { color: rgba(88, 110, 117, 0.6); }
+
+#message_edit_form.focus #primary_file_button:not(:hover) { border-color: #fcf3d9; }
+
+#message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #fcf3d9 !important; }
+
+#message_edit_form.offline #primary_file_button { border-color: #fdf6e3; color: #2aa198; }
+
+#msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #fcf3d9; }
+
+#msg_form #msg_input { background: padding-box #fef9ed; border-color: #fdf6e3; border-left: 0; color: #586e75; }
+
+#msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #586e75; }
+
+#msg_form .msg_mentions_button { color: #2aa198; }
+
+#msg_form .msg_mentions_button:hover { color: #586e75; }
+
+#msg_input { background: #fef9ed; border-color: #fdf6e3; color: #586e75; }
+
+#msg_input::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+#msg_input::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+#msg_input::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+
+#msg_input[data-placeholder]:empty::before { color: #586e75 !important; }
+
+#msg_input:focus, #msg_input.focus { border-color: #fcf3d9; }
+
+#msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #fcf3d9; }
+
+#msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #fdf6e3; }
+
+#msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #fdf6e3; }
+
+#msg_input.offline:not(.pretend-to-be-online) { background-color: #fcf3d9 !important; color: #2aa198; }
+
+#msg_input.disabled, #msg_input.ql-disabled { background-color: #fcf3d9; border-color: #fcf3d9; color: #2aa198; }
+
+#msg_input_message { background-color: #fcf3d9; color: #586e75; }
+
+#primary_file_button { background: padding-box #fef9ed; border-color: #fdf6e3; color: #2aa198; }
+
+#primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #fdf6e3; border-color: #fcf3d9; color: #586e75; }
+
+#footer, #footer.footer_msg_input { background: #fdf6e3; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+
+#footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #fcf3d9 !important; border-color: #fcf3d9 !important; }
+
+#footer_archives_table { color: #2aa198; }
+
+#typing_text { color: #2aa198; filter: none; }
+
+#notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+
+#special_formatting_text { color: #2aa198; }
+
+#message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.inline_message_input_container .ql-container { border-color: #fef9ed; }
+
+.inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #fffefb; }
+
+.c-message--editing { background: #fcf3d9; border-color: #fcf3d9; color: #586e75; }
+
+.c-message__editor__input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.c-message__editor__input.focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-message__editor__warning { color: #dc322f; }
+
+#message_edit_container .message_input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+#message_edit_container .message_input.focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.ql-editor::-webkit-scrollbar-thumb { background-color: rgba(254, 249, 237, 0.5); color: #fdf6e3; }
+
+.ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(254, 249, 237, 0.8); }
+
+.ql-placeholder, .texty_legacy .ql-placeholder { color: #586e75; filter: none; }
+
+.ql-container.texty_single_line_input { background: #fef9ed; border: 1px solid #fcf3d9; color: #586e75; }
+
+.ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-input_select { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #586e75; }
+
+.c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.c-input_select_options_list__option { color: #586e75; }
+
+.menu { background: #fcf3d9; border: 1px solid #fdf6e3; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #586e75; }
+
+.menu .menu_content { background: #fcf3d9 !important; }
+
+.menu .menu_filter_container { background: #fdf6e3; }
+
+.menu .menu_filter_container input.menu_filter { border: 1px solid #fdf6e3; }
+
+.menu .menu_filter_container input.menu_filter:focus { border-color: #fef9ed; }
+
+.menu .menu_filter_container .icon_search { color: #2aa198; }
+
+.menu .menu_filter_container .icon_close { color: #2aa198 !important; }
+
+.menu #menu_header .menu_simple_header { background: #fbeecb; border-color: #fcf3d9; color: #586e75; }
+
+.menu #menu_header .menu_simple_header a { color: #268bd2; }
+
+.menu #menu_header .menu_simple_header a:hover { color: #dc322f; }
+
+.menu #menu_header .menu_close { color: #586e75; }
+
+.menu .section_header .header_label { background-color: #fcf3d9; color: #2aa198; }
+
+.menu .section_header > div.header_label_container { color: #2aa198; }
+
+.menu ul li a { background: #fcf3d9; border-bottom: 0; color: #586e75; }
+
+.menu ul li a.delete_link { color: #dc322f; }
+
+.menu ul li a:not(.inline_menu_link) { color: #586e75; }
+
+.menu ul li.highlighted a { background: #fdf6e3; border-bottom-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #586e75; }
+
+.menu ul li.highlighted a.delete_link { color: #dc322f; }
+
+.menu ul li.disabled a { color: #2aa198; }
+
+.menu ul li i { color: #2aa198; }
+
+.menu ul li.divider { border-bottom-color: #fdf6e3; }
+
+.menu ul li .menu_item_details { color: #2aa198; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #fdf6e3; border-bottom-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #586e75; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #dc322f; }
+
+.menu input { background: #fcf3d9; border: 1px solid #fef9ed; }
+
+.menu textarea { background: #fcf3d9; border: 1px solid #fef9ed; }
+
+.menu #menu_footer .menu_footer { background: #fbeecb; border-top: 1px solid #fcf3d9; }
+
+.menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #fcf3d9; }
+
+.menu #menu_list_container #menu_list .menu_list_item a { color: #586e75; }
+
+.menu #menu_list_container #menu_list .menu_list_item.active a { background: #fef9ed; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu { color: #586e75; }
+
+#autocomplete_menu header { background-color: #fdf6e3; }
+
+#autocomplete_menu header .header_label { color: #2aa198; }
+
+#autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #fbeecb; }
+
+#autocomplete_menu h2 { color: #586e75; }
+
+#autocomplete_menu .no_results { color: #586e75; }
+
+#autocomplete_menu .keyword_match .modifier { color: #2aa198; }
+
+#autocomplete_menu .boxed { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu .pickmeup { border-bottom: 1px solid #fcf3d9; }
+
+#autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #fef9ed; }
+
+#autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #586e75; }
+
+#autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #fcf3d9; }
+
+#autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+
+#autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #586e75; }
+
+#autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #fcf3d9; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #586e75; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #268bd2; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #dc322f; }
+
+#autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #fcf3d9; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #586e75; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #268bd2; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #dc322f; }
+
+#autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #2aa198; }
+
+#autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #fcf3d9; }
+
+#autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #586e75; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #586e75; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #fdf6e3; color: #586e75; }
+
+#autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #2aa198; }
+
+#autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+
+#autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(254, 249, 237, 0.25); border: #fffefb; }
+
+#autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #fcf3d9; border: 1px solid #fbeecb; }
+
+.search_light_grey { color: #586e75 !important; }
+
+.highlighter_underlay .keyword::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+
+.highlighter_underlay .modifier::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+
+.highlighter_underlay .modifier.incomplete::before { background: #fcf3d9; border: 1px solid #fbeecb; }
+
+.highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(255, 254, 251, 0.25); border: #fef9ed; }
+
+.highlighter_underlay .ghost_text { color: #586e75; }
+
+.pickmeup { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+
+.pickmeup .pmu-instance .pmu-button { color: #586e75; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #fcf3d9 !important; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #fffefb; color: #586e75 !important; }
+
+.pickmeup .pmu-instance .pmu-today-border { border: 2px solid #fef9ed !important; color: #fffefb !important; }
+
+.pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #fef9ed; color: #586e75; }
+
+.pickmeup .pmu-instance .pmu-not-in-month { background: #fdf6e3; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #fef9ed; }
+
+.pickmeup .pmu-instance .pmu-disabled { background: #fdf6e3; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-disabled:hover { background: #fdf6e3; color: #2aa198; }
+
+.pickmeup .pmu-instance .pmu-selected { background: #fef9ed; color: #586e75; }
+
+.pickmeup .pmu-instance nav { color: #268bd2; }
+
+.pickmeup .pmu-instance nav :first-child :hover { color: #dc322f; }
+
+.pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #fcf3d9; }
+
+.pickmeup .pmu-instance .pmu-day-of-week { color: #586e75; }
+
+.pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #fcf3d9; }
+
+.pickmeup .pmu-instance .pmu-days * { border: 1px solid #fcf3d9; }
+
+.p-block_kit_date_picker_calendar_wrapper { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #fef9ed; color: #fffefb; }
+
+#menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #fef9ed; }
+
+#menu.date_picker li.date_picker_item a { color: #586e75; }
+
+#menu.date_picker li.date_picker_item a:hover { color: #586e75; }
+
+#menu.date_picker li.date_picker_item.highlighted a { color: #2aa198; }
+
+#file_member_filter { background: #fbeecb; }
+
+#client-ui .member_filter { border: 1px solid #fef9ed; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #fdf6e3; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #586e75; }
+
+#client-ui #team_list_container #team_filter .member_filter { background-color: #fdf6e3; border-left: 1px solid #fbeecb; }
+
+#client-ui #file_member_filter { border-color: #fef9ed; }
+
+#client-ui #file_member_filter .member_filter { border-color: #fef9ed; }
+
+#client-ui .team_tabs_container { border-bottom: 1px solid #fbeecb; }
+
+#team_filter .icon_search { color: #2aa198; }
+
+#team_filter a.icon_close { color: #268bd2; }
+
+#team_filter a.icon_close:hover { color: #dc322f; }
+
+.filter_header { background-color: #fdf6e3; }
+
+.popover_menu { background-color: #fdf6e3; border-top: 1px solid #fef9ed; }
+
+.popover_menu .arrow::after { background-color: #fbeecb; }
+
+.popover_menu .arrow_shadow::after { background-color: #fdf6e3; box-shadow: 0 0 0 1px #fef9ed, 0 0 3px rgba(0, 0, 0, 0.08); }
+
+.popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #fdf6e3 !important; }
+
+.popover_menu .content { background-color: #fdf6e3; }
+
+.tab_complete_ui { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+
+.tab_complete_ui .tab_complete_ui_header { background: padding-box #fbeecb; border-bottom: 1px solid #fcf3d9; color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui ul.type_emoji li { color: #586e75; }
+
+.tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #586e75; }
+
+.tab_complete_ui ul.type_members .unify_broadcast { color: #586e75; }
+
+.tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #2aa198; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #586e75 !important; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #fcf3d9; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #2aa198; }
+
+.tab_complete_ui ul.type_cmds .cmdname { color: #586e75; }
+
+.tab_complete_ui ul.type_cmds .cmddesc { color: #2aa198; }
+
+.tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #fcf3d9; }
+
+.tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #fef9ed; border-bottom-color: #fcf3d9; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #586e75 !important; }
+
+.tab_complete_ui .not_in_channel { color: #2aa198; }
+
+#team_menu { background: #fcf3d9; border-bottom: 2px solid #fcf3d9; color: #586e75; }
+
+#team_menu.active, #team_menu:hover { background: #fcf3d9 !important; border-bottom-color: #fcf3d9 !important; }
+
+#team_menu.active i, #team_menu:hover i { color: #586e75; }
+
+#team_menu i { color: #2aa198; }
+
+#team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+#team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #586e75 !important; }
+
+#team_menu_user { color: #2aa198; }
+
+#team_menu_user_name, #team_menu_user_details { color: #586e75 !important; opacity: 0.75; }
+
+.slack_menu_section::before { border-top-color: #fdf6e3; }
+
+.slack_menu_header_secondary { color: #2aa198; }
+
+.slack_menu_download { background-color: #fcf3d9; }
+
+.slack_menu_download ts-icon { color: #2aa198; }
+
+#menu_items_scroller::-webkit-scrollbar-track { background: #fdf6e3 !important; }
+
+#limit_meter:hover #limit_meter_message_body { color: #586e75; }
+
+#limit_meter_message_body { color: #2aa198; }
+
+.channel_header { background: #fdf6e3; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+
+.channel_header .blue_on_hover:hover { color: #586e75; }
+
+#client_body:not(.onboarding)::before { background: #fdf6e3; border-bottom: 1px solid #fcf3d9; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+
+.messages_header { color: #586e75; }
+
+.channel_title .channel_name_container .channel_name { color: #586e75; }
+
+.channel_title .channel_name_container .channel_name.muted { color: #2aa198; }
+
+.channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #2aa198; }
+
+.channel_title .channel_name_container .muted_icon { color: #2aa198; }
+
+.channel_title .channel_name_container .muted_icon:hover { color: #dc322f; }
+
+#im_title.away { color: #2aa198; }
+
+.channel_header_info button { color: #268bd2; }
+
+.channel_header_icon { color: #586e75; }
+
+.channel_calls_button .call_icon.call_window_offline { color: #2aa198; }
+
+.channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #586e75; }
+
+#flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #586e75; }
+
+#flex_menu_toggle .flex_menu_download_circle { background: #fdf6e3; }
+
+#flex_menu_toggle .flex_menu_download_circle canvas { background: #fdf6e3; }
+
+#flex_menu_toggle.unread #help_icon_circle_count { background-color: #dc322f; color: #fff; }
+
+#flex_menu_toggle.open #help_icon_circle_count { background-color: #fbeecb; color: #586e75; }
+
+#canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #fcf3d9; color: #586e75; }
+
+#canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #fef9ed; color: #586e75; }
+
+#recent_mentions_toggle:hover { color: #dc322f; }
+
+#rxn_toast_div { background: #fbeecb; border: 1px solid #fef9ed; }
+
+.presence { color: #2aa198; }
+
+#edit_topic_inner:not(.unable_to_post)::before { background: #fdf6e3; border-color: #fcf3d9; }
+
+#edit_topic_trigger { color: #268bd2; }
+
+.c-message_list__day_divider__label { color: #2aa198; }
+
+.c-message_list__day_divider__label__pill { background: #fdf6e3; position: relative; }
+
+.c-message_list__day_divider__line { border-top-color: #fcf3d9; }
+
+.day_divider, .mention_day_container_div .day_divider { background: #fdf6e3; color: #2aa198; }
+
+.day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #fcf3d9; }
+
+.day_divider .day_divider_label { background: #fdf6e3; }
+
+.day_container .day_msgs { border-top: 1px solid #fcf3d9; }
+
+.day_container.unread_day_container .day_msgs { border-color: #fffefb; }
+
+.day_container .day_divider { background: none; color: #2aa198; }
+
+.day_container .day_divider .day_divider_label { background: #fdf6e3; }
+
+.search_form { border-color: #fef9ed; }
+
+.search_form .search_input { background: transparent; }
+
+.search_form:hover { border-color: #fffefb; }
+
+.search_focused .search_form { border-color: #fffefb; }
+
+.search_clear_icon .ts_icon_times_circle { color: #2aa198; }
+
+#search_spinner { color: #586e75; }
+
+#search_container .search_input { background: transparent; }
+
+#search_container .icon_search { color: #2aa198; }
+
+#search_container .icon_close { color: #268bd2; }
+
+#team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #2aa198; }
+
+#team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #268bd2; }
+
+#team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #dc322f; }
+
+.c-search { background: transparent; }
+
+.c-search_message__body { color: #586e75; }
+
+.p-search_filter__more_link { color: #586e75; }
+
+.p-search_filter__title_text { background: #fcf3d9; color: #586e75; }
+
+.p-search_filter__datepicker_trigger { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+
+.p-search_filter__datepicker_trigger:hover { color: #2aa198; }
+
+.c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+
+.c-search_autocomplete footer { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+
+.c-search_autocomplete__suggestion_item { color: #586e75; }
+
+.c-search_autocomplete__suggestion_item--selected { background-color: #fdf6e3; }
+
+.c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #586e75; }
+
+.c-search__input_and_close { border-bottom-color: #fbeecb; }
+
+.c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #586e75; }
+
+#msgs_overlay_div { background: #fdf6e3; }
+
+#col_messages { box-shadow: inset 1px 0 0 0 #fdf6e3; }
+
+.c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #2aa198 !important; }
+
+.c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(251, 238, 203, 0.1); }
+
+.c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #2aa198; }
+
+.c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #2aa198; }
+
+.c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(251, 238, 203, 0.1); }
+
+.c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(251, 238, 203, 0.2); }
+
+.c-message--custom_response { background: rgba(251, 238, 203, 0.15); }
+
+.c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(251, 238, 203, 0.1); }
+
+.c-message--pinned .c-message__label__icon { color: #dc322f; }
+
+.c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #586e75; }
+
+.c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #2aa198; }
+
+.c-message--sli_highlight_negative .c-message__label { background: rgba(251, 238, 203, 0.1); }
+
+.c-message--resend .c-message__body { color: #2aa198; }
+
+.c-message--deleting { background: rgba(220, 50, 47, 0.6); }
+
+.c-message--standalone { border-color: rgba(254, 249, 237, 0.1); }
+
+.c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+
+.c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #2aa198; }
+
+.c-message__sender { color: #586e75; }
+
+.c-message__sender a { color: #586e75; }
+
+.c-message__sender .c-emoji__text_mode_icon { color: #2aa198; }
+
+.c-message__body { color: #586e75; }
+
+.c-message__body--unknown { background: rgba(254, 249, 237, 0.1); }
+
+.c-message__body--automated { color: #2aa198; }
+
+.c-message__body--tombstone { color: #2aa198; }
+
+.c-message__label { color: #2aa198; }
+
+.c-message__label__highlight_title { color: #586e75; }
+
+.c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #2aa198; }
+
+.c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #586e75; }
+
+.c-message__resend_controls { color: #2aa198; }
+
+.c-message__resend_column { background-color: rgba(254, 249, 237, 0.1); }
+
+.c-message__resend, .c-message__cancel { color: #586e75; }
+
+.c-message__edited_label { color: #2aa198; }
+
+.c-message__tombstone_icon { background: rgba(254, 249, 237, 0.1); color: #2aa198; }
+
+.c-message__bot_label { background: rgba(254, 249, 237, 0.1); color: #2aa198; }
+
+.c-message__comment:before { color: #2aa198; }
+
+.c-message__call_attachment { background: #fdf6e3; border-color: rgba(254, 249, 237, 0.1); }
+
+.c-message__call_icon { color: #586e75; }
+
+.c-message__call--ended .c-message__call_icon { color: #2aa198; }
+
+.c-message__call_info { color: #586e75; }
+
+.c-message__call_name--linked { color: #586e75; }
+
+.c-message__call_name + .c-message__call_description::before { color: #2aa198; }
+
+.c-message__call_sub { color: #2aa198; }
+
+.c-message_actions__container { background: #fdf6e3; border-color: #fcf3d9; }
+
+.c-message_actions__container:hover { border-color: #fef9ed; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+.c-message_actions__button { border-right-color: #fcf3d9; color: #268bd2; }
+
+.c-message_actions__button:hover { color: #586e75; }
+
+.c-message_actions__button:active { background: #fcf3d9; }
+
+.c-message_group { background-color: #fdf6e3; border-color: #fcf3d9; }
+
+.c-message_group:hover .c-message_group__header { color: #2aa198; }
+
+.c-message_group__header { color: #586e75; }
+
+.c-message_group__divider_text { background-color: #fdf6e3; color: #586e75; }
+
+.c-message_list__unread_divider__separator { border-color: #fef9ed; }
+
+.c-message_list__unread_divider__label { background: #fdf6e3; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #fef9ed; }
+
+.c-message_list__spinner { color: #2aa198; }
+
+.c-message_list .c-scrollbar__bar { background: #fdf6e3; }
+
+.c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(255, 254, 251, 0.8); }
+
+ts-message { color: #586e75; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(251, 238, 203, 0.1); box-shadow: inset 1px 0 0 0 #fdf6e3; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(251, 238, 203, 0.2); }
+
+ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #2aa198; }
+
+ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #2aa198 !important; }
+
+ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+
+ts-message.is_pinned { background: rgba(251, 238, 203, 0.15); }
+
+ts-message .timestamp { color: #268bd2; }
+
+ts-message .temp_msg_controls { color: #2aa198; }
+
+ts-message .edited { color: rgba(42, 161, 152, 0.8); }
+
+ts-message:hover .edited { color: #2aa198; }
+
+ts-message .only_visible_to_user { color: #2aa198; }
+
+ts-message.ephemeral { color: #586e75; }
+
+ts-message .bot_label { background: #fbeecb; color: #2aa198; }
+
+ts-message .in_reply_to { background: #fbeecb; color: #2aa198; }
+
+ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #fcf3d9; }
+
+ts-message.unprocessed { color: rgba(88, 110, 117, 0.75); }
+
+ts-message.highlight { background: rgba(220, 50, 47, 0.4); }
+
+ts-message.highlight:hover { background: rgba(220, 50, 47, 0.4); }
+
+ts-message .is_highlights_holder { color: #2aa198; }
+
+ts-message .is_highlights_holder ts-icon { color: #2aa198; }
+
+ts-message .is_highlights_holder .highlights_feedback_link { color: #2aa198; }
+
+ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #586e75; }
+
+ts-message .recap_highlight { background: rgba(220, 50, 47, 0.4); }
+
+ts-message .recap_highlight a { color: #586e75; }
+
+ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(220, 50, 47, 0.75); }
+
+ts-message.automated .message_body { color: rgba(88, 110, 117, 0.8); }
+
+ts-message .action_hover_container { border: 1px solid #fcf3d9; }
+
+ts-message .action_hover_container:hover { border-color: #fef9ed; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+ts-message .action_hover_container:hover a { background: #fcf3d9; border-right: 1px solid #fef9ed; }
+
+ts-message .action_hover_container .btn_msg_action { background: #fdf6e3; border-right: 1px solid #fcf3d9; color: #268bd2; }
+
+ts-message .action_hover_container .btn_msg_action:hover { color: #586e75; }
+
+ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #fcf3d9; color: #586e75; }
+
+ts-message.selected { background: #fdf6e3; }
+
+ts-message.selected:not(.delete_mode) { background: #fdf6e3; }
+
+ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+
+ts-message .meta { color: #2aa198; }
+
+ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #268bd2 !important; }
+
+ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+
+ts-message .pinned_item_message_header { color: #2aa198; }
+
+ts-message .mention { background: #fffefb !important; color: #586e75 !important; }
+
+ts-message .internal_member_link { background: #fdf6e3 !important; border: 0; color: #268bd2 !important; }
+
+ts-message .internal_member_link:hover { color: #dc322f !important; }
+
+ts-message.show_recap:not(.is_pinned) { background: rgba(251, 238, 203, 0.15); }
+
+ts-message.show_recap:not(.is_pinned):hover { background: rgba(251, 238, 203, 0.15); }
+
+.ephemeral.message .message_content { color: #586e75; }
+
+ts-mention { background: rgba(255, 254, 251, 0.1) !important; color: #586e75 !important; }
+
+.selecting_messages ts-message:hover { background: #fbeecb; }
+
+.selecting_messages ts-message.multi_delete_mode:hover { background: rgba(220, 50, 47, 0.75); }
+
+#convo_container { background-color: #fdf6e3; }
+
+#convo_container #message_edit_container { border-bottom: 1px solid #fef9ed; border-top: 1px solid #fef9ed; }
+
+#convo_container ts-conversation::after { background: rgba(251, 238, 203, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(251, 238, 203, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(251, 238, 203, 0.08) 100%); }
+
+#convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(251, 238, 203, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(251, 238, 203, 0.08) 0, transparent 100%); }
+
+#convo_container ts-conversation ts-message.selected { background: #fdf6e3; }
+
+#convo_container ts-conversation ts-relatives::after { background: #fef9ed; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #fef9ed; color: #2aa198; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #586e75; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #fdf6e3; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #fffefb; }
+
+#msgs_div .unread_divider hr { border-top: 1px solid #fef9ed; }
+
+#msgs_div .unread_divider .divider_label { background: #fdf6e3; color: #fef9ed; }
+
+#msgs_div .unread_divider.no_unreads hr { border-top-color: #fcf3d9; }
+
+#msgs_div .unread_divider.no_unreads .divider_label { color: #2aa198; }
+
+.channel_archive_messages.card .col:first-child { border-right: 1px solid #fef9ed; }
+
+.star { color: #2aa198; }
+
+.star_item { border-bottom: 1px solid #fbeecb; }
+
+.star_item .star_meta { color: #2aa198; }
+
+.bot_message .message_sender { color: #586e75; }
+
+.bot_message .message_sender a { color: #586e75; }
+
+.color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #586e75; }
+
+#msgs_scroller_div #end_display_div #end_display_status { color: #2aa198; }
+
+#msgs_scroller_div #end_display_div #end_display_meta { color: #2aa198; }
+
+#msgs_scroller_div #end_display_div #end_display_meta h1 { color: #586e75; }
+
+#msgs_scroller_div #end_display_div p { color: #586e75; }
+
+.member_mentions_options { background-color: #fbeecb; border-top: 1px solid #fcf3d9; }
+
+.dm_badge .dm_badge_meta { color: #586e75; }
+
+.dm_badge a { color: #268bd2; }
+
+.dm_badge a.member_preview_link { color: #268bd2; }
+
+.dm_badge .dm_badge:hover a { color: #268bd2; }
+
+.dm_badge .hint { color: #2aa198; }
+
+#toggle-subscription-status .subscription_desc { color: #2aa198; }
+
+.bot_label { background: #fbeecb; color: #2aa198; }
+
+@keyframes to-grey { 0% { color: inherit; }
+  100% { color: #2aa198; } }
+
+@keyframes fade-background-highlight { 0% { background: #fef9ed; }
+  100% { background: transparent; } }
+
+@keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #fef9ed, 0 0 0 0.5px #fffefb; }
+  100% { box-shadow: 0 0 4px 0 #fef9ed, 0 0 0 0 #fffefb; } }
+
+.c-message_attachment { color: #586e75; }
+
+.c-message_attachment__border { background-color: #fef9ed; }
+
+.c-message_attachment__delete { color: #268bd2; }
+
+.c-message_attachment__delete:hover { color: #dc322f; }
+
+.c-message_attachment__pretext { color: #586e75; }
+
+.c-message_attachment__part + .c-message_attachment__part::before { color: #fef9ed; }
+
+.c-message_attachment__author .c-message_attachment__autor--distinct { color: #268bd2; }
+
+.c-message_attachment__author_link + .c-message_attachment__author_link { color: #268bd2; }
+
+.c-message_attachment__title_link span { color: #586e75; }
+
+.c-message_attachment__text_expander { color: #268bd2; }
+
+.c-message_attachment__footer { color: #268bd2; }
+
+.c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(251, 238, 203, 0.1) inset; }
+
+.c-message_attachment__video_html { background-color: rgba(253, 246, 227, 0.4); }
+
+.c-message_attachment__video_buttons { background: rgba(251, 238, 203, 0.4); }
+
+.c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #586e75; }
+
+.c-message_attachment__video_play, .c-message_attachment__video_link { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+
+.c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #586e75; }
+
+.c-message_attachment__media_trigger .c-expandable_trigger { color: #268bd2; }
+
+.c-message_attachment__media_trigger--too_large { color: #268bd2; }
+
+.c-message_attachment__select { border-color: #fbeecb; }
+
+.c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #fef9ed; }
+
+.c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #fdf6e3; border-color: #fbeecb; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #2aa198; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #fef9ed; }
+
+.c-message__reply_bar_description { color: #2aa198; }
+
+.c-message__file_meta { color: #2aa198; }
+
+.c-message__image_container { background: rgba(251, 238, 203, 0.1); }
+
+.c-message__image_wrapper:after { border-color: transparent; }
+
+.attachment_group.has_container { background: #fdf6e3; border: 1px solid #fcf3d9; }
+
+.attachment_group.has_container .inline_attachment::after { background-color: #fcf3d9; }
+
+.attachment_group.has_container.has_link:hover { border-bottom-color: #fcf3d9; border-left-color: #fcf3d9; border-right-color: #fcf3d9; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.attachment_group .media_caret { color: #2aa198; }
+
+.attachment_group .attachment_source span { color: #2aa198 !important; }
+
+.attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #2aa198; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #2aa198; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #fcf3d9; }
+
+.attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #2aa198; }
+
+.attachment_group .attachment_title a { color: #586e75; }
+
+.attachment_group .attachment_footer_text + .attachment_ts::before { color: #2aa198; }
+
+.attachment_group .delete_attachment_link ts-icon::before { color: #268bd2; }
+
+.attachment_group .delete_attachment_link:hover ts-icon::before { color: #dc322f; }
+
+.attachment_still_pending ts-inline-saver { color: #2aa198; }
+
+.msg_inline_attachment_column.column_border { background-color: #fef9ed; }
+
+.msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #fbeecb; }
+
+.msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #268bd2; }
+
+.msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #dc322f; }
+
+.msg_inline_img { background: #fef9ed; }
+
+.msg_inline_room_preview_collapser { color: #2aa198; }
+
+.msg_inline_room_preview_collapser:hover { color: #2aa198; }
+
+.inline_attachment span.attachment_author_name { color: #268bd2; }
+
+.inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #268bd2; }
+
+.inline_attachment a span:active, .inline_attachment a span:hover { color: #dc322f !important; }
+
+.inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #268bd2; }
+
+.inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #268bd2; }
+
+.inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #dc322f !important; }
+
+.inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #dc322f !important; }
+
+.inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #fbeecb; }
+
+.meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #268bd2 !important; }
+
+.meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #268bd2 !important; }
+
+.meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #dc322f !important; }
+
+.meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #dc322f !important; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #586e75; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #2aa198; }
+
+.meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #dc322f !important; }
+
+.meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #268bd2 !important; }
+
+.delete_attachment_link { color: #268bd2; }
+
+.delete_attachment_link:hover { color: #dc322f; }
+
+.file_container, .c-file_container { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+
+.file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #fcf3d9; border-left-color: #fcf3d9; border-right-color: #fcf3d9; }
+
+.file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: -moz-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: -o-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+
+.file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #fdf6e3; box-shadow: 0 0 0 3px #fdf6e3; color: #586e75; }
+
+.file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #fcf3d9; }
+
+.file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #fbeecb; color: #586e75; }
+
+.file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #2aa198; }
+
+.file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #fbeecb; }
+
+.file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #fcf3d9; color: #586e75 !important; }
+
+.file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #fbeecb; }
+
+.file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(255, 254, 251, 0.9); color: #586e75 !important; }
+
+.file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #fbeecb; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #fcf3d9; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #fcf3d9; }
+
+.file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #fdf6e3; }
+
+.file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(255, 254, 251, 0.9); }
+
+.file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #fcf3d9; }
+
+.file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(255, 254, 251, 0.9); border: 1px solid rgba(251, 238, 203, 0.1); }
+
+.file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(254, 249, 237, 0.8), rgba(254, 249, 237, 0.8)), linear-gradient(rgba(255, 254, 251, 0.3), rgba(255, 254, 251, 0.3)); color: #586e75; }
+
+.file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(254, 249, 237, 0.8); color: #586e75; }
+
+.file_container .c-file__title, .c-file_container .c-file__title { color: #586e75; }
+
+.message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #fef9ed; color: #586e75; }
+
+.msg_inline_video_buttons_div { background-color: rgba(253, 246, 227, 0.4); }
+
+.msg_inline_video_buttons_div a { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+
+.msg_inline_video_buttons_div a:visited { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+
+.post_body ul.checklist { background-color: #fcf3d9; }
+
+.post_body ul.checklist li::before { background: #fcf3d9; }
+
+.post_body ul.checklist li.checked { color: #2aa198; }
+
+.post_body ul.list.checklist li { border-bottom: 1px solid #fef9ed; }
+
+.post_body ul.list.checklist li.checked { color: #2aa198; }
+
+.post_body .message { background-color: #586e75; }
+
+.post_body code, .post_body pre { background: #fcf3d9; }
+
+ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #2aa198; }
+
+ts-message .reply_bar:hover { background: #fdf6e3; border-color: #fbeecb; }
+
+.inline_color_block { border-color: #fef9ed; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #fdf6e3; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #fdf6e3; border-bottom: 1px solid #fdf6e3; }
+
+.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #fdf6e3; }
+
+.p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #586e75; }
+
+.p-message_pane__limited_history_foreword { background: #fcf3d9; background-image: none; color: #586e75; }
+
+.p-message_pane__unread_banner__banner { background: #fef9ed; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner { color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner a { color: #586e75; }
+
+.messages_banner a:hover { color: #586e75; }
+
+#connection_div { background: #dc322f; }
+
+#archives_return { background: padding-box #fffefb; color: #586e75; }
+
+#archives_return.warning { background: #dc322f; }
+
+#archives_return a { color: #586e75; }
+
+#archives_return a:hover { color: rgba(88, 110, 117, 0.8); }
+
+#messages_unread_status { background: #fef9ed; }
+
+#messages_unread_status:hover { background: #fffefb; }
+
+#messages_unread_status:hover .clear_unread_messages { background: #fffefb; }
+
+#messages_unread_status:hover .clear_unread_messages:hover { background: #fef9ed; }
+
+#messages_unread_status.quiet { background: #fffefb; color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#messages_unread_status.quiet a { color: #586e75; }
+
+.clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+
+#messages_container.has_top_messages_banner::before { background: none; }
+
+.end_div_msg_lim { background-color: #fcf3d9; background-image: none; }
+
+#archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #586e75; }
+
+#archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(88, 110, 117, 0.8); }
+
+code { background-color: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+
+.file_list_item.snippet .snippet_preview { background: #fbeecb; }
+
+.snippet_preview, .snippet_body { background: #fbeecb; }
+
+.snippet_preview pre, .snippet_body pre { color: #586e75 !important; }
+
+.file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #fcf3d9; border-right: 1px solid #fcf3d9; color: #2aa198; }
+
+.c-snippet .c-file_container { background-color: #fdf6e3; }
+
+.c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #fdf6e3); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+
+.CodeMirror { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75 !important; }
+
+.CodeMirror pre { background: transparent !important; }
+
+.CodeMirror div.CodeMirror-cursor { border-left: 1px solid #586e75; }
+
+.CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #586e75; }
+
+.CodeMirror .CodeMirror-gutters { background-color: #fcf3d9; border-right: 1px solid #fdf6e3; }
+
+.CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #fcf3d9; }
+
+.CodeMirror-linenumber { color: #2aa198 !important; }
+
+.CodeMirror-guttermarker { color: #2aa198; }
+
+.CodeMirror-guttermarker-subtle { color: #2aa198; }
+
+.CodeMirror-ruler { border-left: 1px solid #fffefb; }
+
+.cm-s-default .cm-keyword { color: #ce93d8; }
+
+.cm-s-default .cm-atom { color: #9fa8da; }
+
+.cm-s-default .cm-number { color: #a5d6a7; }
+
+.cm-s-default .cm-def { color: #536dfe; }
+
+.cm-s-default .cm-variable-2 { color: #9fa8da; }
+
+.cm-s-default .cm-variable-3 { color: #c5e1a5; }
+
+.cm-s-default .cm-comment { color: #ffcc80; }
+
+.cm-s-default .cm-string { color: #ef9a9a; }
+
+.cm-s-default .cm-string-2 { color: #ffab91; }
+
+.cm-s-default .cm-meta { color: #eee; }
+
+.cm-s-default .cm-qualifier { color: #eee; }
+
+.cm-s-default .cm-builtin { color: #b39ddb; }
+
+.cm-s-default .cm-bracket { color: #e6ee9c; }
+
+.cm-s-default .cm-tag { color: #a5d6a7; }
+
+.cm-s-default .cm-attribute { color: #40c4ff; }
+
+.cm-s-default .cm-header { color: #80cbc4; }
+
+.cm-s-default .cm-quote { color: #b0bec5; }
+
+.cm-s-default .cm-hr { color: #fcf3d9; }
+
+.cm-s-default .cm-link { color: #268bd2; }
+
+.cm-negative { color: #dc322f; }
+
+.cm-positive { color: #859900; }
+
+.cm-invalidchar, .cm-s-default .cm-error { color: #dc322f; }
+
+div.CodeMirror span.CodeMirror-matchingbracket { color: #859900; }
+
+div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #dc322f; }
+
+.CodeMirror-matchingtag { background: #fbeecb; }
+
+.CodeMirror-activeline-background { background: #fffefb; }
+
+.CodeMirror-selected { background: #fffefb; }
+
+.CodeMirror-focused .CodeMirror-selected { background: #fffefb; }
+
+.cm-searching { background: #fffefb; }
+
+.sssh-keyword { color: #ce93d8; }
+
+.sssh-atom { color: #9fa8da; }
+
+.sssh-number { color: #a5d6a7; }
+
+.sssh-def { color: #536dfe; }
+
+.sssh-variable { color: #9fa8da; }
+
+.sssh-variable-2 { color: #c5e1a5; }
+
+.sssh-variable-3 { color: #c1a5e1; }
+
+.sssh-operator { color: #586e75; }
+
+.sssh-property { color: #586e75; }
+
+.sssh-comment { color: #ffcc80; }
+
+.sssh-string { color: #ef9a9a; }
+
+.sssh-string-2 { color: #ffab91; }
+
+.sssh-meta { color: #eee; }
+
+.sssh-error { color: #dc322f; }
+
+.sssh-qualifier { color: #eee; }
+
+.sssh-builtin { color: #b39ddb; }
+
+.sssh-bracket { color: #e6ee9c; }
+
+.sssh-tag { color: #a5d6a7; }
+
+.sssh-attribute { color: #40c4ff; }
+
+.sssh-header { color: #80cbc4; }
+
+.sssh-quote { color: #b0bec5; }
+
+.sssh-hr { color: #fcf3d9; }
+
+.sssh-link { color: #268bd2; }
+
+.c-message--dense .c-timestamp__label { color: #268bd2; }
+
+.c-message--dense .c-message__content_header .c-custom_status { border-color: #fcf3d9; }
+
+.dense_theme ts-message { color: #586e75; }
+
+.dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #268bd2; }
+
+.dense_theme ts-message .message_content .message_current_status { border-color: #fcf3d9; }
+
+.c-message--light .c-message__sender .c-message__sender_link { color: #586e75; }
+
+.light_theme ts-message { color: #586e75; }
+
+.light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #586e75 !important; }
+
+.light_theme ts-message .comment::before { color: #2aa198; }
+
+.channel_overlay { border-color: #fcf3d9; color: #2aa198; }
+
+.channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #586e75; }
+
+.channel_overlay.channel_overlay_redesign li { color: #2aa198; }
+
+.channel_overlay_title_wrap { border-color: #fcf3d9; }
+
+.channel_overlay_title_shared { color: #586e75; }
+
+pre { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+
+pre span.mention { padding: 2px 0 !important; }
+
+#page pre, body > pre { background: #fbeecb; color: #586e75 !important; }
+
+body > pre { background: #fffefb; }
+
+.special_formatting_quote .quote_bar { background-color: #fef9ed; }
+
+#threads_msgs_scroller_div { background: #fdf6e3; }
+
+#threads_msgs_scroller_div:not(.loading)::before { background: #fdf6e3; }
+
+#threads_msgs_scroller_div.loading::before { color: #2aa198; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #fcf3d9; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #fef9ed; color: #586e75; }
+
+#threads_msgs_scroller_div.loading { background: none; }
+
+#threads_msgs_scroller_div.loading::before { color: #586e75; }
+
+#threads_view_banner.messages_banner { background: #fcf3d9; }
+
+#threads_view_banner.messages_banner:hover { background: #fef9ed; }
+
+#threads_view_banner.messages_banner:hover .clear_unread_messages { background: #fef9ed; }
+
+#threads_msgs.new_banner_is_showing::before { background: #fdf6e3; }
+
+ts-thread { background: #fdf6e3; }
+
+ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #fcf3d9; color: #586e75; }
+
+ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #fcf3d9; border-color: #fcf3d9; }
+
+ts-thread .thread_messages { background: #fcf3d9; border-color: #fcf3d9; }
+
+ts-thread ts-message.new_reply { background: #fdf6e3; }
+
+ts-thread ts-message.new_reply:hover { background: #fcf3d9; }
+
+ts-thread .thread_header .thread_channel_name a { color: #586e75; }
+
+ts-thread .thread_header .thread_action_btns button { color: #2aa198; }
+
+ts-thread .new_reply_indicator .blue_dot { color: #dc322f; }
+
+#convo_tab .thread_participants, ts-thread .thread_participants { color: #2aa198; }
+
+#convo_loading_indicator { background-image: none; }
+
+.reply_input_container .inline_message_input_container .ql-container { background-color: #fef9ed; border: 1px solid #fcf3d9; }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #586e75; }
+
+.reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #2aa198; }
+
+#file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #2aa198; }
+
+#unread_msgs_scroller_div::after { background: transparent; }
+
+#unread_msgs_scroller_div.loading { background-image: none; }
+
+#unread_msgs_scroller_div.loading::before { color: #2aa198; }
+
+#unread_msgs_div .day_divider .day_divider_line { border-top-color: #fcf3d9; }
+
+.unread_group.marked_as_read .unread_group_header { background: #fdf6e3; }
+
+.unread_group .unread_group_header { background: #fcf3d9; border-top-color: #fef9ed; color: #586e75; }
+
+.unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #586e75; }
+
+.unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #2aa198; }
+
+.unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #fdf6e3; }
+
+.unread_group.active .unread_group_header { background: #fbeecb; border-top-color: #fef9ed; color: #586e75; }
+
+.collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #2aa198; }
+
+.mark_as_read_checkmark { color: #2aa198; }
+
+.bottom_mark_all_read { border-top-color: #fcf3d9; }
+
+.unread_group_header_name a { color: #586e75; }
+
+.unread_group_footer .unread_group_new .unread_group_new_text { color: #2aa198; }
+
+.unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #2aa198; }
+
+.unread_empty_state_message { color: #2aa198; }
+
+.unread_empty_state_undo_inner { background: #fbeecb; color: #586e75; }
+
+.unread_empty_state_undo_action { color: #586e75; }
+
+.unread_empty_state_refresh { background: rgba(253, 246, 227, 0.97); }
+
+.unread_msgs_loading { background: #fdf6e3; background-image: none; }
+
+#col_flex { background: transparent; }
+
+#flex_contents { background: #fdf6e3; }
+
+#flex_contents .heading { background: #fbeecb; border-bottom-color: #fcf3d9; color: #268bd2; }
+
+#flex_contents .heading a { color: #268bd2; }
+
+#flex_contents .heading a:hover { color: #dc322f; }
+
+#flex_contents .heading a.close_flexpane { color: #268bd2; }
+
+#flex_contents .heading .cancel_link { color: #268bd2; }
+
+#flex_contents .heading .menu_heading:hover { color: #586e75; }
+
+#flex_contents .heading .menu_icon { color: #268bd2; }
+
+#flex_contents .heading .menu_icon:hover { color: #dc322f; }
+
+#flex_contents .heading_text { color: #268bd2; }
+
+#flex_contents .subheading:not(.empty) { background: #fdf6e3; border-top: 1px solid #fbeecb; color: #2aa198; }
+
+#flex_contents .subheading:not(.empty) p a { color: #586e75; }
+
+#flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #2aa198; }
+
+#flex_contents .toolbar_container { background: #fdf6e3; }
+
+#flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #268bd2; }
+
+#flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #fcf3d9; }
+
+#flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #268bd2; }
+
+#flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #fcf3d9; }
+
+#flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #268bd2; }
+
+#flex_contents .help { border-top: 5px solid #fbeecb; color: #586e75; }
+
+#flex_contents i.callout { color: #2aa198; }
+
+.close_flexpane { color: #2aa198; }
+
+.close_flexpane:focus, .close_flexpane:hover { color: #586e75; }
+
+#client-ui.flex_pane_showing #col_flex { border-left-color: #fcf3d9; }
+
+.toolbar_container { background: #fdf6e3; border-bottom: 1px solid #fbeecb; color: #586e75; }
+
+.msg_right_link { color: #268bd2; }
+
+.message_location_label { color: #2aa198; }
+
+.p-flexpane_header { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+
+#client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #fcf3d9; }
+
+#details_tab .heading { background: #fbeecb; }
+
+#details_tab .heading a.close_flexpane { color: #268bd2; }
+
+#details_tab .heading a.close_flexpane:hover { color: #dc322f; }
+
+#details_tab hr { border-top-color: #fcf3d9; }
+
+#details_tab .conversation_details .member_name:hover { color: #2aa198; }
+
+#details_tab .conversation_details .member_username:hover { color: #586e75; }
+
+#details_tab .conversation_details .member_info_timezone { border-top-color: #fef9ed; }
+
+#details_tab .channel_page_section { background: #fdf6e3; border-top: 1px solid #fcf3d9; }
+
+#details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #dc322f; }
+
+#details_tab .channel_page_section .section_header a { color: #268bd2; }
+
+#details_tab .channel_page_section .section_title { color: #586e75; }
+
+#details_tab .channel_page_section .disclosure_triangle { color: #268bd2; }
+
+#details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(220, 50, 47, 0.25) !important; }
+
+#details_tab .created_by { color: #586e75; }
+
+#details_tab .channel_page_member_tabs .icon_member_header { color: #2aa198; }
+
+#details_tab .pinned_item:hover { border-color: #fef9ed; }
+
+#details_tab .channel_page_action .leave_link { color: #268bd2; }
+
+#details_tab .channel_page_action .leave_link:hover { color: #dc322f; }
+
+#details_tab .channel_section_label .ts_icon_info_circle { color: #2aa198; }
+
+#details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #2aa198; }
+
+.channel_page_member_row { color: #586e75; }
+
+.channel_page_member_row a { color: #268bd2; }
+
+.channel_page_member_row.away { color: #586e75; }
+
+.channel_page_member_row.away a { color: #268bd2; }
+
+.channel_page_member_row:hover { background-color: #fef9ed; border-color: #fcf3d9; }
+
+.pinned_item { color: #586e75; }
+
+.pinned_item .pin_file_title { color: #268bd2; }
+
+.pinned_item .pin_member_name a { color: #268bd2 !important; }
+
+.pinned_item .pin_metadata { color: #2aa198; }
+
+.pinned_item .remove_pin { color: #268bd2; }
+
+.pinned_item .remove_pin:hover { color: #dc322f; }
+
+.pinned_item .pinned_message_text .pin_truncate_fade { background: #fdf6e3; }
+
+.pinned_item.delete_mode { border-color: #dc322f !important; }
+
+.c-channel_insights__title { color: #586e75; }
+
+.c-channel_insights__section:not(.c-channel_insights__section--no_border) { border-color: #fef9ed; }
+
+.c-channel_insights__drawer_title { color: #2aa198; }
+
+.c-channel_insights__item--user .member_preview_link, .c-channel_insights__item--user .message_sender { color: #586e75 !important; }
+
+.c-channel_insights__user_title { color: #2aa198; }
+
+.c-channel_insights__channel .channel_link { color: #586e75; }
+
+.c-channel_insights__member_count { color: #2aa198; }
+
+.c-channel_insights__member_count .ts_icon_user { color: #2aa198; }
+
+.c-channel_insights .c-member__title { color: #2aa198; }
+
+.c-channel_insights__activity { border-color: #fef9ed; }
+
+.c-channel_insights_activity_bar_container:hover { background-color: rgba(251, 238, 203, 0.05); }
+
+.c-channel_insights_activity_bar_container:hover .c-channel_insights__activity_bar { background-color: #fef9ed; }
+
+.c-channel_insights__activity_bar { background-color: rgba(254, 249, 237, 0.5); }
+
+.c-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.c-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #fdf6e3 90%); }
+
+.c-channel_insights__highlights_description { color: #2aa198; }
+
+.c-channel_insights__date_heading span { background-color: #fdf6e3; color: #586e75; }
+
+.c-channel_insights__date_heading::before { background-color: #fef9ed; }
+
+#file_list_toggle_users { color: #268bd2; }
+
+#file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #dc322f; }
+
+#file_list_toggle_users.active { color: #2aa198; }
+
+.file_list_item .icon, .file_reference .icon { background: #fffefb; border: 1px solid #fef9ed; color: #586e75 !important; }
+
+.filetype_button { background: #fffefb; border: 1px solid #fef9ed; color: #586e75 !important; }
+
+.filetype_button:hover { background: #fffefb; }
+
+.filetype_button:hover .file_download_label { background: #fef9ed; color: #586e75; }
+
+.filetype_button .file_title { color: #586e75; }
+
+.filetype_button .file_download_label { background: #fffefb; border-top: 1px solid #fef9ed; }
+
+a.filetype_button_web { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+
+a.filetype_button_web .filetype_icon { background-color: #fef9ed; }
+
+a.file_download_link { color: #268bd2; }
+
+a.file_download_link:hover { color: #dc322f; }
+
+a:hover .file_inline_icon { color: #2aa198; }
+
+a.gsheet img, a.pdf img { background: #fdf6e3 !important; }
+
+html.no_touch a.filetype_button_web:hover { border-color: #fef9ed; }
+
+html.no_touch a.filetype_button_web:hover .file_title { color: #586e75; }
+
+.file_header_detailed { color: #2aa198; }
+
+.file_header_detailed .member { color: #586e75 !important; }
+
+.file_inline_icon { color: #2aa198; }
+
+.file_header .member { color: #2aa198 !important; }
+
+.file_header .title { color: #586e75; }
+
+.file_header .title a { color: #268bd2; }
+
+.file_header .title a:hover { color: #dc322f; }
+
+.flexpane_file_title .member, .flexpane_file_title .service_link { color: #268bd2 !important; }
+
+.flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #268bd2; }
+
+.flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #dc322f; }
+
+.file_actions_cog { color: #268bd2 !important; }
+
+.file_actions_cog:hover { color: #dc322f !important; }
+
+.file_list_item { color: #586e75; }
+
+.file_list_item a { color: #268bd2; }
+
+.file_list_item a.member { color: #dc322f; }
+
+.file_list_item .bullet { color: #2aa198; }
+
+.file_list_item .icon { background: #fffefb; border-color: #fef9ed; }
+
+.file_list_item .ts_icon_comment { color: #2aa198; }
+
+.file_list_item .file_comment_link:hover { color: #268bd2; }
+
+.file_list_item .file_comment_link:hover .ts_icon_comment { color: #2aa198; }
+
+.file_list_item .title a { color: #268bd2; }
+
+.file_list_item .share_info .unshare_link { color: #268bd2; }
+
+.file_list_item .share_info .unshare_link:hover { color: #dc322f; }
+
+.file_list_item .actions a, .file_list_item .actions span { background-color: #fcf3d9; border: 1px solid #fffefb; color: #268bd2; }
+
+.file_list_item .actions a:hover { background-color: #fdf6e3 !important; border-color: #fffefb; color: #dc322f; }
+
+.file_list_item.post .preview, .file_list_item.space .preview { color: #586e75; }
+
+.file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #fcf3d9; border-color: #fef9ed; }
+
+.file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #268bd2; }
+
+.file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+
+.file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #fcf3d9; }
+
+.unshare_link { color: #268bd2 !important; }
+
+.unshare_link i::before { color: #2aa198 !important; }
+
+.unshare_link i.ts_icon_minus_circle_small:hover::before { color: #dc322f !important; }
+
+.snippet_preview pre { color: #586e75; }
+
+.file_preview_wrapper .file_preview { background: #fdf6e3; }
+
+.file_preview_wrapper .file_preview:hover { background: #fcf3d9; }
+
+#file_preview_container .file_meta { color: #2aa198; }
+
+.file_page_meta { color: #2aa198; }
+
+#file_page_preview img { background: #fdf6e3; border: 1px solid #fbeecb; }
+
+#file_page_preview img:hover { background: #fcf3d9; }
+
+.comment_meta { color: #2aa198; }
+
+.comment .special_formatting_quote .content { color: #586e75; }
+
+.comment .member { color: #586e75 !important; }
+
+.comment_body { color: #586e75; }
+
+.comment_actions { color: #2aa198; }
+
+.comment_actions:hover { color: #586e75; }
+
+.icon_quote { color: #586e75; }
+
+.edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #fcf3d9; }
+
+.tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #fdf6e3; }
+
+.tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #fcf3d9; }
+
+.tab_container .star_item ts-message .timestamp { color: #2aa198; }
+
+.tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #fdf6e3; border-color: #fcf3d9; }
+
+.tab_container .file_list_item .star { color: #2aa198; }
+
+.tab_container .file_list_item .contents .file_comment_link { color: #268bd2; }
+
+.tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #268bd2; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #dc322f; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #dc322f; }
+
+.tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #2aa198; }
+
+.tab_container .file_list_item .filetype_image { background-color: #fbeecb; }
+
+.active .tab_container .file_list_item { background-color: #fdf6e3; }
+
+.c-file__actions { background: #fef9ed; }
+
+.c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #fef9ed; border-color: #fcf3d9; color: #fff; }
+
+.p-file_details__name, .p-file_details__share_channel { color: #586e75; }
+
+.p-file_details__meta_container .c-file__action_button { color: #fff; }
+
+.c-pillow_file_container { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+
+.c-pillow_file__description, .c-pillow_file__title { color: #586e75; }
+
+#user_groups_pane .mention { background: rgba(220, 50, 47, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+
+#user_groups_container .info_panel { background: #fdf6e3; border: 1px solid #fef9ed; }
+
+#user_groups_container .mention { background-color: rgba(220, 50, 47, 0.25) !important; }
+
+#user_groups_header .user_groups_search .icon_search { color: #2aa198; }
+
+#user_groups_header a.icon_close { color: #268bd2; }
+
+#user_groups_header a.icon_close:hover { color: #dc322f; }
+
+.user_group_item { border-bottom: 1px solid #fef9ed; }
+
+.user_group_item a { color: #268bd2; }
+
+#flex_contents .user_group_item:hover { background-color: #fdf6e3; }
+
+#flex_contents .user_group_item:hover h4 { color: #586e75; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #fdf6e3; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #586e75; }
+
+.user_group_invite_member_small .add_icon { color: #2aa198; }
+
+#user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #fffefb; border-color: #fffefb; }
+
+#flex_contents .subheading:not(.empty)#mentions_options { background-color: #fdf6e3; border-bottom-color: #fcf3d9; color: #586e75; }
+
+.mention_day_container_div .day_divider::before { background: none; border-color: #fcf3d9; }
+
+#member_mentions h3 a { color: #268bd2; }
+
+a.internal_member_link { background: #fcf3d9; color: #586e75; }
+
+a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #fcf3d9; border: 1px solid #fef9ed; color: #586e75; }
+
+a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #fdf6e3; color: #586e75; }
+
+.mention_rxn .mention_rxn_summary { color: #586e75; }
+
+.mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #2aa198; }
+
+.search_message_result { background: #fdf6e3 !important; border-color: #fcf3d9 !important; color: #586e75 !important; }
+
+.search_message_result .search_message_result_meta { color: #2aa198; }
+
+.search_message_result .search_message_result_meta a { color: #268bd2; }
+
+.search_message_result .search_message_result_meta .date_links a { color: #268bd2; }
+
+.search_message_result_text .result_msg_format a { color: #268bd2; }
+
+span.match { background: rgba(220, 50, 47, 0.25); }
+
+#search_filters .tab { background: #fdf6e3; color: #586e75; }
+
+#search_filters .tab:hover { border-bottom: 4px solid #fcf3d9; }
+
+#search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #fcf3d9; color: #586e75; }
+
+#search_file_list_toggle_users.active:hover { border: 2px solid #dc322f; color: #dc322f !important; }
+
+.no_results { color: #586e75; }
+
+#search_results_team .team_results_heading { color: #586e75; }
+
+#search_results_team .team_result { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+
+#search_results_team .team_result a { color: #268bd2; }
+
+#search_results_team .team_result:hover a { color: #dc322f; }
+
+#search_results_team .team_result a:hover { color: #dc322f; }
+
+#search_results_team .member_name { color: #586e75 !important; }
+
+.suggestion { color: #586e75; }
+
+.suggestion.active, .suggestion:hover { background: #fef9ed; }
+
+#paging_in_options .search_paging { color: #2aa198; }
+
+#search_results_items .search_paging { color: #586e75; }
+
+.search_paging i.disabled { color: #2aa198; }
+
+.search_paging a { color: #268bd2; }
+
+.search_paging a:hover { color: #dc322f; }
+
+.search_sort_prefix { color: #586e75; }
+
+.search_segmented_control { border-color: #fcf3d9; color: #268bd2 !important; }
+
+.search_segmented_control:hover { color: #dc322f !important; }
+
+.search_segmented_control.active { background: #fbeecb; color: #dc322f !important; }
+
+.search_result_with_extract { background: #fcf3d9; border-color: #fef9ed; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+
+.search_result_with_extract:hover { border-color: #fffefb; }
+
+.search_result_for_context::after { background: rgba(253, 246, 227, 0.1); }
+
+.extract_expand_text, .extract_expand_icons { color: #268bd2; }
+
+.search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #dc322f; }
+
+.search_module_header { color: #586e75; }
+
+.search_module_footer { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-left-color: #fef9ed; border-right-color: #fef9ed; }
+
+.search_module_footer p { color: #586e75; }
+
+.search_module_footer #see_more { color: #586e75; }
+
+.search_module_footer #see_more a { color: #586e75; }
+
+.search_module_footer .top_results_feedback a { color: #586e75; }
+
+.search_module_footer ts-icon { color: #586e75; }
+
+.top_results_search_message_result { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-left-color: #fef9ed; border-right-color: #fef9ed; }
+
+.top_results_search_message_result.duplicate { background-color: #fcf3d9; }
+
+.top_results_search_message_result .timestamp { color: #2aa198; }
+
+.top_results_search_message_result .channel { color: #2aa198; }
+
+.top_results_search_message_result .channel a { color: #2aa198; }
+
+.top_results_search_message_result .jump { color: #586e75; }
+
+.top_results_search_message_result:hover { border-color: rgba(255, 254, 251, 0.6) !important; border-top: 2px solid #fef9ed !important; }
+
+.top_results_search_message_result:first-child { border-top: 2px solid #fef9ed; }
+
+.sli_expert_search { background-color: #fdf6e3; color: #586e75; }
+
+.sli_expert_search__result { border-color: #fef9ed; }
+
+.sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #586e75 !important; }
+
+.sli_expert_search__fg_face::before { background-color: #fdf6e3; }
+
+.sli_expert_search_cta { border-color: #fef9ed; }
+
+.sli_expert_search_cta:hover { border-color: #fffefb; }
+
+.sli_expert_search_cta__text { color: #586e75; }
+
+.sli_expert_search_cta__text:hover { color: #586e75; }
+
+.sli_expert_search__plus_sign_overlay { background-color: #fcf3d9; color: #2aa198; }
+
+.sli_expert_search__arrow { color: #2aa198; }
+
+.sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #2aa198; }
+
+.sli_expert_search__partial_terms { color: #2aa198; }
+
+.feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #fcf3d9; color: #586e75; }
+
+.feature_sli_file_search #search_results .file_list_item { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #fdf6e3; }
+
+.feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #586e75; }
+
+.feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #586e75; }
+
+.feature_sli_file_search #search_results.all { background-color: #fdf6e3; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #2aa198; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #fffefb; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #fffefb; }
+
+.feature_sli_file_search #search_results.all .team_result { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.feature_sli_file_search #search_results.files { background-color: #fdf6e3; }
+
+.feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #586e75; }
+
+.feature_sli_file_search #search_results_loading { background-color: #fdf6e3; }
+
+.feature_sli_file_search #search_results_container #search_options { background-color: #fdf6e3; }
+
+.feature_sli_file_search #search_results_container .heading { background-color: #fdf6e3; }
+
+#client-ui .file_list_item.file_list_item--redesign { border-color: #fef9ed; }
+
+#client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #2aa198; }
+
+#client-ui .file_list_item.file_list_item--redesign .message_sender { color: #2aa198; }
+
+.p-shortcuts_flexpane__shortcut { border-color: #fbeecb; }
+
+.p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #fbeecb; }
+
+.p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #586e75; }
+
+.p-shortcuts_flexpane__shortcut_title { color: #2aa198; }
+
+.p-shortcuts_flexpane__title { color: #586e75; }
+
+.p-shortcuts_flexpane__tip { color: #2aa198; }
+
+.p-shortcuts_flexpane__section_description { color: #2aa198; }
+
+.p-shortcuts_flexpane__sub_heading { color: #2aa198; }
+
+.c-keyboard_key { background: #fef9ed; border-color: #fffefb; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #586e75; }
+
+.tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #268bd2; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #dc322f; }
+
+#member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #268bd2; }
+
+#member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #dc322f; }
+
+#member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #268bd2 !important; }
+
+#member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #fffefb !important; color: #dc322f !important; }
+
+#member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #586e75; }
+
+#member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #268bd2 !important; }
+
+#member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #dc322f !important; }
+
+#member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #fbeecb; color: #2aa198; }
+
+#member_preview_scroller { background-color: #fcf3d9; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #fcf3d9; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(88, 110, 117, 0.35) !important; }
+
+#team_tab #member_preview_scroller { background-color: #fdf6e3; }
+
+#member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #586e75; }
+
+#member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #586e75; }
+
+#member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #2aa198; }
+
+#member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #268bd2; }
+
+#member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #dc322f; }
+
+#member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #268bd2; }
+
+#member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #fcf3d9; }
+
+#disabled_members_tab a { color: #268bd2; }
+
+#disabled_members_tab a:hover { background: #fdf6e3; color: #dc322f; }
+
+#disabled_members_tab.active a { color: #268bd2; }
+
+.team_list_item { border-top: 1px solid #fef9ed; color: #268bd2; }
+
+.team_list_item .member_name { color: #586e75; }
+
+#client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #586e75 !important; }
+
+#client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #fcf3d9 !important; }
+
+#client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #fef9ed !important; }
+
+#client-ui .searchable_member_list .team_list_item { border-bottom-color: #fbeecb; }
+
+#client-ui .searchable_member_list .team_list_item:hover { background: #fef9ed; }
+
+.c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #586e75 !important; }
+
+#convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #586e75; }
+
+#convo_tab textarea.message_input { color: #586e75; }
+
+#reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #fcf3d9; color: #586e75; }
+
+#reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #fbeecb; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #586e75; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #2aa198 !important; }
+
+#reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #fdf6e3; color: #2aa198; }
+
+#convo_container .convo_flexpane_divider { border-top-color: #fcf3d9; color: #2aa198; }
+
+#convo_container .convo_flexpane_divider .reply_count { background: #fdf6e3; }
+
+#convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #268bd2; }
+
+#convo_tab .message_input, #convo_tab textarea#msg_text { color: #586e75; }
+
+ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+
+ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+
+#whats_new_tab p { color: #586e75; }
+
+#whats_new_tab .flex_heading_controls label { color: #2aa198; }
+
+.c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #586e75; }
+
+.c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #586e75; }
+
+.c-member .external_team_badge { background-color: #fef9ed; box-shadow: 0 0 0 2px #fef9ed; }
+
+.c-member .external_team_badge.default { background-color: #2aa198; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #fef9ed; }
+
+.c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #586e75; }
+
+.c-member--small .presence { color: #2aa198; }
+
+.c-member--small .team_image.icon_16 { border-color: #fcf3d9; }
+
+.c-member--small .team_image.default { background-color: #2aa198; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member--dark .c-member__current-status { color: #2aa198; }
+
+.c-member--dark .c-member__current-status::before { color: #2aa198; }
+
+.c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #2aa198; }
+
+.c-member--dark .c-member__display-name, .c-member--dark .presence { color: #586e75; }
+
+.c-member--medium { color: #2aa198; }
+
+.c-member--medium .presence { color: #2aa198; }
+
+.c-member__secondary-name--medium { color: #586e75; }
+
+.c-member--large { color: #2aa198; }
+
+.c-member__display-name--large, .c-member__title--large { color: #586e75; }
+
+.c-member__other-names--large { color: #2aa198; }
+
+.c-usergroup--small .c-usergroup__icon { background-color: #2aa198; color: #586e75; }
+
+.c-usergroup__not-in-channel-context--small { color: #2aa198; }
+
+.p-emoji_picker { background: #fbeecb !important; color: #586e75 !important; }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #fdf6e3; }
+
+.p-emoji_picker__group_tabs { border-bottom-color: #fdf6e3; }
+
+.p-emoji_picker__group_tab { color: #268bd2; }
+
+.p-emoji_picker__group_tab:hover { background: #fcf3d9; color: #dc322f; }
+
+.p-emoji_picker__group_tab--active { background: #fef9ed; border-bottom-color: #fdf6e3; color: #586e75; }
+
+.p-emoji_picker__icon_search { color: #2aa198; }
+
+.p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #fdf6e3; border-color: #fdf6e3; }
+
+.p-emoji_picker__skintone_options { background: #fdf6e3; }
+
+.p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #2aa198; }
+
+.p-emoji_picker__tip { color: #586e75; }
+
+.p-emoji_picker__no_results { color: #2aa198; }
+
+.p-emoji_picker__preview_text { background: #fbeecb; color: #586e75; }
+
+.p-emoji_picker__footer { background: #fbeecb; border-top-color: #fcf3d9; }
+
+.p-emoji_picker__footer .p-emoji_picker__heading { background: #fbeecb; }
+
+.p-emoji_picker__emoji_deluxe_label { color: #2aa198; }
+
+input[type="text"].p-emoji_picker__input:focus { border-color: #fef9ed; box-shadow: none; }
+
+#message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #2aa198; }
+
+#message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #586e75; }
+
+#message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #586e75; }
+
+#message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #586e75; }
+
+.current_status_emoji_picker { border-right-color: #fcf3d9; }
+
+.current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #fbeecb; }
+
+.current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #2aa198; }
+
+.rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #fcf3d9; border: 1px solid #fef9ed; }
+
+.rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #fdf6e3; }
+
+.rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #586e75; }
+
+.rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(253, 246, 227, 0.08); border-color: rgba(255, 254, 251, 0.4) !important; }
+
+.rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #586e75; }
+
+.rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #586e75; }
+
+.rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(88, 110, 117, 0.25); }
+
+a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #b58900; color: #fcf3d9; }
+
+.modal { background-color: #fdf6e3; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+.modal .close, .modal label { color: #586e75; }
+
+.modal_input_note, .modal_input_note_full_width, .input_note_special { color: #2aa198; }
+
+.modal-footer { background: padding-box #fdf6e3; border-top: 1px solid transparent; box-shadow: none; }
+
+.modal-header { background: padding-box #fbeecb; border-bottom: 1px solid #fcf3d9; color: #586e75; }
+
+.modal-backdrop { background-color: #fdf6e3; }
+
+.close { color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+#fs_modal_bg { background: #fdf6e3; }
+
+#fs_modal { background: #fdf6e3; }
+
+#fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #586e75; }
+
+#fs_modal #fs_modal_sidebar a { color: #586e75; }
+
+#fs_modal #fs_modal_sidebar a:hover { background: #fcf3d9; }
+
+#fs_modal #fs_modal_sidebar a.active { background: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#fs_modal .fs_modal_btn { color: rgba(88, 110, 117, 0.5); }
+
+#fs_modal .fs_modal_btn:hover { background: #fffefb; color: #586e75; }
+
+#fs_modal .fs_modal_btn:active { background: #fffefb; color: #586e75; }
+
+#fs_modal.fs_modal_header .fs_modal_btn:active { color: #586e75; }
+
+#fs_modal #fs_modal_footer { background-color: #fcf3d9; }
+
+.p-apps_browser__apps_list--loading::before { background-color: #fcf3d9; }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #fef9ed; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #fcf3d9; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+
+.p-apps_browser__category_header { background: #fdf6e3; color: #2aa198; }
+
+.p-apps_browser__app { border-top-color: #fef9ed; }
+
+.p-apps_browser__app--selected { background: #fcf3d9; border-color: #fffefb; }
+
+.p-apps_browser__app_info { color: #586e75; }
+
+.p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+
+.p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #fffefb; color: #586e75; }
+
+.p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__app_description { color: #2aa198; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #2aa198; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #586e75; }
+
+#incoming_call { background-color: rgba(251, 238, 203, 0.97); color: #586e75; }
+
+#fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #fcf3d9; }
+
+#fs_modal.channel_options_modal .convert_to_shared label { color: #2aa198; }
+
+#fs_modal.channel_options_modal .channel_option_item { border-top-color: #fcf3d9; }
+
+#fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #586e75; }
+
+#fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(251, 238, 203, 0.75); border-color: #fcf3d9; }
+
+#channel_invite_container .lfs_list_container .lfs_item { border-top-color: #fcf3d9; }
+
+#channel_invite_container .lfs_list_container .lfs_item.active { border-color: #fcf3d9; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #fcf3d9; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #2aa198; }
+
+#channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #fdf6e3; border-color: #fcf3d9; }
+
+#channel_prefs_dialog { color: #586e75; }
+
+#at_channel_warning_dialog { background-color: #fdf6e3; }
+
+#at_channel_warning_dialog.fullsize { background-color: #fdf6e3; }
+
+#at_channel_warning_dialog.fullsize .modal-body { background-color: #fdf6e3; }
+
+.channel_prefs_modal_header { color: #586e75; }
+
+.channel_prefs_body__section_header_title { color: #586e75; }
+
+.channel_prefs_body__section_header_icon::before { color: #586e75; }
+
+.channel_prefs_body__mute_help_text { color: #2aa198; }
+
+.channel_prefs_notifications_table { border-bottom-color: #fcf3d9; color: #586e75; }
+
+.channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #fef9ed !important; }
+
+.channel_prefs__muting_checkbox_label { color: #586e75; }
+
+.channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #586e75 !important; }
+
+.notification_prefs_icon::before { color: #586e75; }
+
+.channel_modal_header { color: #586e75; }
+
+#channel_browser .channel_browser_row { border-top: 1px solid #fcf3d9; color: #586e75; }
+
+#channel_browser .channel_browser_row_header { color: #586e75; }
+
+#channel_browser .channel_browser_creator_name { color: #2aa198; }
+
+#channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #2aa198; }
+
+#channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #fbeecb; border: 1px solid #fef9ed; }
+
+#channel_browser .channel_browser_divider { background: transparent; color: #2aa198; }
+
+#channel_browser .channel_browser_sort_container::after { color: #586e75; }
+
+#channel_browser .channel_browser_channel_purpose { color: #586e75; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #268bd2; }
+
+.channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #2aa198 !important; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #fbeecb; color: #586e75; }
+
+#invite_members_container .lfs_input_container { background: #fef9ed; }
+
+#notifications_not_working p.highlight_yellow_bg a { color: #586e75; }
+
+#im_browser .im_browser_row { border-top: 1px solid #fef9ed; }
+
+#im_browser .im_browser_row.multiparty { color: #586e75; }
+
+#im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #fbeecb; }
+
+#im_browser .im_browser_row .im_unread_cnt { background: #dc322f; color: #586e75; }
+
+#im_browser .im_browser_row.disabled { color: #2aa198; }
+
+#im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser #im_browser .im_browser_row.highlighted { background: #fbeecb !important; border: 1px solid #fef9ed !important; }
+
+#im_browser_tokens { background: #fef9ed; border: 1px solid #fffefb; }
+
+#im_browser_tokens.active { border-color: #fffefb; box-shadow: 0 0 7px rgba(255, 254, 251, 0.15); }
+
+#im_browser_tokens .member_token { background: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+
+#im_browser_tokens .member_token.ra { background: #dc322f; }
+
+.fs_modal_file_viewer_header { background-color: #fcf3d9; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.fs_modal_file_viewer_header .btn { color: #586e75; }
+
+.fs_modal_file_viewer_header .star { color: #2aa198; }
+
+.fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #586e75; }
+
+.fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #586e75; }
+
+.fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #2aa198; }
+
+.fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #fef9ed; }
+
+.fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #2aa198; }
+
+.fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #fef9ed; }
+
+.fs_modal_file_viewer_content .viewer { background-color: #fbeecb; color: #586e75 !important; }
+
+.fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #fef9ed; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(255, 254, 251, 0.25); color: #586e75; }
+
+.fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(42, 161, 152, 0.8); }
+
+.fs_modal_file_viewer_content .aside_panel { background-color: #fdf6e3; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #fbeecb; }
+
+.fs_modal_file_viewer_content .no_comment { background-color: #fdf6e3; color: #2aa198; }
+
+.fs_modal_file_viewer_content .aside_close_btn { color: #586e75; }
+
+.fs_modal_file_viewer_content #file_comment { color: #586e75; }
+
+#file_comment_textarea.texty_comment_input { background: #fdf6e3; border-color: #fcf3d9; color: #586e75; }
+
+#file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #fcf3d9; }
+
+#fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #2aa198; }
+
+#fs_modal.help_modal .help_modal_header { background-color: #fcf3d9; border-color: #fef9ed; }
+
+#fs_modal.help_modal .help_modal_header a { color: #586e75; }
+
+#fs_modal.help_modal .help_modal_divider { color: #2aa198; }
+
+#fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #fcf3d9; }
+
+#fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #2aa198; }
+
+#fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #fcf3d9; border-color: #fbeecb; }
+
+.admin_invites_account_type_option { border-bottom: 1px solid #fcf3d9; }
+
+.admin_invites_account_type_option p { color: #586e75; }
+
+.admin_invites_account_type_option .option_arrow { color: #2aa198; }
+
+.admin_invites_account_type_option:hover:not(.disabled) h3 { color: #586e75; }
+
+.admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+
+.admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(253, 246, 227, 0.95); }
+
+.admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #2aa198; }
+
+.admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #dc322f; }
+
+.admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(220, 50, 47, 0.4); }
+
+#admin_invites_channel_picker_container { border-bottom: 1px solid #fcf3d9; }
+
+#admin_invites_add_row { background: #fef9ed; border: 1px solid #fcf3d9; }
+
+#admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #fef9ed; }
+
+#channel_invite_tokens { background-color: #fef9ed; border-color: #fffefb; }
+
+#channel_invite_tokens.active { border-color: #2aa198; box-shadow: 0 0 7px rgba(42, 161, 152, 0.15); }
+
+#channel_invite_tokens .member_token { background: #fdf6e3; color: #586e75; }
+
+#channel_invite_tokens .member_token.ra { background: rgba(220, 50, 47, 0.4); }
+
+#admin_invites_alert { background: #fef9ed; border-color: #fffefb; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #586e75; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #fdf6e3; color: #586e75; }
+
+#shortcuts_dialog { background: rgba(253, 246, 227, 0.95); text-shadow: 0 1px 1px rgba(251, 238, 203, 0.7); }
+
+#shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #586e75; }
+
+#shortcuts_dialog.modal ul ul { border-left-color: #fef9ed; }
+
+#shortcuts_dialog.modal .info_block { color: #2aa198; }
+
+#shortcuts_dialog.modal .close { background: #fef9ed; border-color: #fffefb; box-shadow: 0 1px 2px rgba(251, 238, 203, 0.5); color: #586e75; }
+
+#shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(251, 238, 203, 0.9); }
+
+#fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #2aa198; }
+
+#fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #fcf3d9; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #fcf3d9; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #fdf6e3; border: 1px solid #fcf3d9; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #dc322f; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+
+#fs_modal.prefs_modal legend { color: #586e75; }
+
+#fs_modal.prefs_modal .global_notification_block { background: #fdf6e3; border-color: #fbeecb; }
+
+#fs_modal.prefs_modal .global_notification_block.selected { background: #fcf3d9; border-color: #fbeecb; }
+
+#fs_modal.prefs_modal .channel_overrides_row { border-top-color: #fbeecb; }
+
+#fs_modal.prefs_modal .channel_overrides_row:hover { background: #fcf3d9; border-color: #fbeecb; }
+
+#fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #586e75; }
+
+#fs_modal.prefs_modal .notification_example.mac { background: #fbeecb; box-shadow: 0 1px 8px 2px #fcf3d9; }
+
+#fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #fbeecb; color: #586e75; }
+
+#fs_modal.prefs_modal .badge_example { background: #dc322f; }
+
+#fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #fbeecb; border-top-color: #fbeecb; }
+
+#fs_modal.prefs_modal .display_real_names_block_sample { background: #fdf6e3; }
+
+.sidebar_menu_list_item { border: 0; color: #586e75; }
+
+.sidebar_menu_list_item.is_active { background-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.sidebar_menu_list_item:not(.is_active):hover { background-color: #fcf3d9; }
+
+.jumbomoji_pref_disabled { color: #2aa198; }
+
+.jumbomoji_disabled_note { color: rgba(42, 161, 152, 0.6); }
+
+#edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #fef9ed; border: 1px solid #fbeecb; }
+
+#edit_team_profile_container .lazy_filter_select.disabled { background: #fef9ed; }
+
+#edit_team_profile_container .lazy_filter_select.disabled input { background: #fef9ed; }
+
+#edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #fcf3d9; }
+
+#edit_team_profile_list .row:nth-last-child(2):hover { border-color: #fcf3d9 !important; }
+
+#edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #fcf3d9; border: 1px solid #fbeecb; }
+
+#edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #2aa198; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i { color: #586e75; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #2aa198; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #2aa198; }
+
+#edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #fef9ed; }
+
+#edit_team_profile_add .row:last-child { border-bottom: 1px solid #fef9ed; }
+
+#edit_team_profile_add .row:not(.header_row):hover { background: #fcf3d9; border: 1px solid #fbeecb; }
+
+#edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #586e75; }
+
+#edit_team_profile_add .row:not(.header_row):hover i { border-color: #fbeecb; color: #586e75; }
+
+#edit_team_profile_add i { color: #2aa198; }
+
+#edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #2aa198; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #fbeecb; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #dc322f; border-color: #dc322f !important; color: #586e75; }
+
+#edit_team_profile_edit .row i { border: 1px solid #fbeecb; color: #586e75; }
+
+#edit_team_profile_custom .row .col .profile_field_preview { background: #fcf3d9; border: 2px solid #fbeecb; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #fcf3d9; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #2aa198; }
+
+#edit_team_profile_custom .row .col input { background: #fef9ed; border: 1px solid #fbeecb; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #2aa198; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #fbeecb; }
+
+.profile_field_preview_protector .profile_field_preview { background: #fdf6e3; border: 1px solid #fef9ed; }
+
+.profile_field_preview_protector .profile_field_preview::after { background-color: #fdf6e3; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview::before { background-color: #fdf6e3; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #fef9ed; color: #2aa198; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #fbeecb, rgba(255, 255, 255, 0)); }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #fbeecb; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #fbeecb transparent transparent; }
+
+ts-jumper ts-jumper-container { background: #fdf6e3; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #fdf6e3; color: #2aa198; }
+
+ts-jumper input[type=text] { border: 1px solid #fbeecb !important; color: #586e75; }
+
+ts-jumper input[type=text]:focus { border: 1px solid rgba(252, 243, 217, 0.8) !important; color: #586e75; }
+
+ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #586e75; }
+
+ts-jumper ol li { color: #586e75; }
+
+ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #2aa198; }
+
+ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #2aa198; }
+
+ts-jumper ol li .unread_count { background: #dc322f; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+ts-jumper ol li.highlighted { background: #fffefb !important; color: #586e75 !important; }
+
+ts-jumper ol:not(.keyboard_active) li:hover { background: #fffefb !important; color: #586e75 !important; }
+
+ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #586e75; }
+
+.basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+
+.share_dialog_attachment_container { color: #586e75; }
+
+#share_dialog .file_list_item { border-color: #fbeecb; }
+
+#generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container { border-color: #fcf3d9; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #fef9ed; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #586e75; }
+
+.ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #fef9ed; }
+
+.ts_tip .ts_tip_tip { color: #586e75; }
+
+.ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #fef9ed; }
+
+.ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #fef9ed; }
+
+.ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #fef9ed; }
+
+.ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #fef9ed; }
+
+.ts_tip.success .ts_tip_tip { background: #fffefb; }
+
+.ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #fffefb; }
+
+.ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #fffefb; }
+
+.ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #fffefb; }
+
+.ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #fffefb; }
+
+.c-tooltip__tip { background-color: #fef9ed; color: #586e75; }
+
+.c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+
+.c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+
+.c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+
+.c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #fef9ed; }
+
+.c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+
+.c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+
+.c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+
+.c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #fef9ed; }
+
+.c-tooltip__tip--success { background-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #859900; }
+
+.c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #859900; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #fef9ed; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #fef9ed; }
+
+#coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(255, 254, 251, 0.5) !important; }
+
+#coachmark_interior { color: #586e75; }
+
+#coachmark_interior .coachmark_close_btn { color: #586e75; }
+
+.menu_member_header { background: #fbeecb; }
+
+.menu_member_header .member_details .member_name_and_presence { color: #586e75; }
+
+.menu_member_header .member_details .member_name_and_presence .member_name { color: #586e75; }
+
+.menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+
+.menu_member_header .member_details .member_title { color: #2aa198; }
+
+.menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #2aa198; }
+
+.menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #268bd2; }
+
+.menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #dc322f; }
+
+.menu_member_header .member_details_divider { border-color: #fef9ed; }
+
+.menu_member_footer { background: #fbeecb; border-top: 1px solid #fef9ed; }
+
+.menu_member_footer p { color: #2aa198; }
+
+.member_meta { color: #268bd2; }
+
+.mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #586e75 !important; }
+
+.greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #2aa198 !important; }
+
+.clear_blue { color: #268bd2 !important; }
+
+.moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #dc322f !important; }
+
+.seafoam_green { color: #859900 !important; }
+
+.candy_red_bg { background-color: #dc322f !important; }
+
+.off_white_bg, .neutral_white_bg { background-color: #fcf3d9 !important; }
+
+.yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #fdf6e3 !important; }
+
+.sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #fef9ed !important; }
+
+.sk_black { color: inherit; }
+
+.monkey_scroll_bar { z-index: 99; }
+
+.client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+
+nav.top.persistent { background: #fcf3d9; }
+
+nav.top.persistent .logo { background-position: 50% 0 !important; }
+
+.widescreen #header_team_name a i { margin-left: 1.5em; }
+
+.widescreen #user_menu { border-right: none; }
+
+header #menu_toggle { color: #268bd2; }
+
+header #header_team_nav { background: #fcf3d9; border: 1px solid #fbeecb; }
+
+header #header_team_nav li.active a { background: #fdf6e3; color: #586e75; }
+
+header .header_btns a { color: #268bd2; }
+
+header .header_btns a .label { color: #2aa198; }
+
+header .vert_divider { border-left: 1px solid #fbeecb; }
+
+footer, #autocomplete_menu.search_menu footer.unified { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; }
+
+footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #586e75; }
+
+footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #586e75; }
+
+.plastic_row h3 { color: #586e75; }
+
+.plastic_row h4 a { color: #586e75; }
+
+.plastic_row .icon { color: #586e75; }
+
+.plastic_row .chevron { color: #2aa198; }
+
+.plastic_row .description { color: #586e75; }
+
+.plastic_row:active { background: #fdf6e3; border-color: #fbeecb; }
+
+.plastic_row:active .chevron { color: #586e75; }
+
+html.no_touch .plastic_row:hover { background: #fdf6e3; border-color: #fbeecb; }
+
+html.no_touch .plastic_row:hover .chevron { color: #586e75; }
+
+html.no_touch .pagination ul > li > a:hover { background-color: #fbeecb; }
+
+html.no_touch .pagination ul > .disabled > a:hover { background: #fcf3d9; color: #2aa198; }
+
+html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #dc322f; }
+
+.card, .tab_pane { background: #fcf3d9; border: 1px solid #fbeecb; color: #586e75; }
+
+.card h3 a { color: #586e75; }
+
+#page_contents .card { background: rgba(252, 243, 217, 0.8) !important; }
+
+#page_contents .card p { color: #586e75; }
+
+.tab_set a.secondary { color: #268bd2; }
+
+.tab_set a.selected, .tab_set a.secondary.selected { background: #fcf3d9; border: 1px solid #fbeecb; border-bottom-color: #fcf3d9; color: #dc322f; }
+
+.tab_actions { background: #fcf3d9; border: 1px solid #fbeecb; border-color: #fbeecb; }
+
+.accordion_section { border-bottom-color: #fdf6e3; }
+
+.accordion_section h4 { color: #586e75; }
+
+.accordion_section h4 a { color: #586e75; }
+
+.no_touch .accordion_section h4 a:hover { color: #586e75; }
+
+.accordion_section_fixed { border-bottom-color: #fdf6e3 !important; }
+
+.pager li > a, .pager li > span { background-color: #fdf6e3; background-image: none; border-color: #fcf3d9; color: #268bd2; }
+
+.pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+
+.pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+
+.pager .disabled > a, .pager .disabled > span { color: #2aa198; }
+
+.pagination ul > li > a, .pagination ul > li > span { background: #fcf3d9; border: 1px solid #fbeecb; color: #586e75; }
+
+.pagination ul > li > a:focus { background-color: #fbeecb; }
+
+.pagination ul > .active > a, .pagination ul > .active > span { background-color: #fbeecb; }
+
+.pagination ul > .disabled > span { background: #fcf3d9; color: #2aa198; }
+
+.pagination ul > .disabled > a { background: #fcf3d9; color: #268bd2; }
+
+.pagination ul > .disabled > a:focus { background: #fcf3d9; color: #dc322f; }
+
+.loading_hash_animation img { display: none; }
+
+.icon_search_close { color: #268bd2; }
+
+.icon_search_close:hover { color: #dc322f; }
+
+.help { border-top-color: #fbeecb; color: #2aa198; }
+
+.two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+
+.two_factor_choice { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+.two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+.two_factor_choice:hover .two_factor_link { color: #586e75; }
+
+a.two_factor_choice { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:link { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #586e75; }
+
+.backup_codes { background: #fbeecb; border-color: #fef9ed; color: #586e75; }
+
+#channel_specific_settings tr { border-top-color: #fdf6e3; }
+
+#channel_specific_settings tr.channel_override_row.muted td { background: rgba(253, 246, 227, 0.5); }
+
+#channel_specific_settings .extra_left_border { border-left-color: #fdf6e3; }
+
+#channel_specific_settings .extra_right_border { border-right-color: #fdf6e3; }
+
+#channel_specific_settings .revert_to_default { color: #2aa198; }
+
+#channel_specific_settings .revert_to_default:hover { color: #dc322f; }
+
+.admin_list_item { border-bottom-color: #fdf6e3; color: #2aa198; }
+
+.admin_list_item:hover { background-color: #fcf3d9; }
+
+.admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #586e75; }
+
+.admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #2aa198; }
+
+.admin_list_item .pill.group { background: #fdf6e3; }
+
+.admin_list_item .two_factor_auth_badge:hover { background: #fdf6e3; }
+
+.admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+
+.admin_list_item.invite_item.bouncing { background: #fffefb; }
+
+.admin_list_item.invite_item.bouncing .email { color: #dc322f; }
+
+.admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #fdf6e3; }
+
+.admin_list_item.expanded .btn_outline { border-color: #fdf6e3; color: #586e75 !important; }
+
+.admin_list_item.expanded .btn_outline:hover { border-color: #fcf3d9; color: #586e75 !important; }
+
+.admin_list_item.expanded .sub_action { color: #268bd2; }
+
+.admin_list_item.expanded .sub_action:hover { color: #dc322f; }
+
+@media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #268bd2; } }
+
+.billing_selection { border-color: #fbeecb; color: #586e75 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection:hover { border-color: #fffefb; }
+
+.billing_selection.active { background: #fef9ed; border-color: #fffefb; }
+
+.billing_selection.billing_selection--refactor { border-color: #fef9ed; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection.billing_selection--refactor:hover { border-color: #fffefb; }
+
+.billing_selection.billing_selection--refactor.active { background: #fef9ed; border-color: #fffefb; }
+
+.billing_selection .billing_selection__price { color: #586e75; }
+
+#billing_contacts_container { background: #fcf3d9; border-top: 1px solid #fbeecb; }
+
+.billing_contact { border-bottom: 1px solid #fdf6e3; }
+
+table.billing tr:hover td { background: #fcf3d9; }
+
+.link_billing_statement { color: #586e75 !important; }
+
+.link_invoice_id, .link_statement_id { color: #268bd2 !important; }
+
+.billing_invoice tbody tbody tr { color: #586e75 !important; }
+
+.billing_settings_label_name { color: #586e75; }
+
+table tr { border-bottom-color: #fdf6e3; }
+
+table tr:first-child th:not(:only-of-type) { border-bottom-color: #fbeecb; }
+
+.slackbot_response_fieldset .delete_response { color: #2aa198; }
+
+.slackbot_response_fieldset .delete_response:hover { color: #dc322f; }
+
+.author_cell { color: #586e75; }
+
+.message_cell.disabled { color: #2aa198; }
+
+#message_container #msg_limit { color: #586e75; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #fef9ed; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #fef9ed; }
+
+.inactive { background-image: none; }
+
+.c3 line, .c3 path { stroke: #fffefb; }
+
+.c3-chart-arc .c3-gauge-value { fill: #fffefb; }
+
+.c3-chart-arc path { stroke: #fcf3d9; }
+
+.c3-chart-arc text { fill: #fcf3d9; }
+
+.c3-chart-arcs .c3-chart-arcs-background { fill: #fef9ed; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #fcf3d9; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #fffefb; }
+
+.c3-circle._expanded_ { stroke: #fcf3d9; }
+
+.c3-grid line { stroke: #fffefb; }
+
+.c3-grid text { fill: #586e75; }
+
+.c3-legend-background { fill: #fcf3d9; stroke: #fef9ed; }
+
+.c3-region { fill: #fef9ed; }
+
+.c3-selected-circle { fill: #fcf3d9; }
+
+.c3-tooltip { background-color: #fcf3d9; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+
+.c3-tooltip td { background-color: #fcf3d9; border-left-color: #fef9ed; }
+
+.c3-tooltip th { background-color: #fcf3d9; color: #586e75; }
+
+.c3-tooltip tr { border-color: #fef9ed; }
+
+.ent_alert a { color: #268bd2; }
+
+.ent_alert a:link, .ent_alert a:visited { color: #dc322f; }
+
+.ent_alert_page.ent_alert_error { background: #dc322f; }
+
+.ent_alert_page.ent_alert_success { background: #859900; }
+
+.ent_analytics__disclaimer { border-top-color: #fffefb; color: #2aa198; }
+
+.ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+
+.ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+
+.ent_avatar { background-color: #fef9ed; }
+
+.ent_callout__difference--increase { color: #859900; }
+
+.ent_callout__icon_border { background-color: #fcf3d9; border-color: #fffefb; }
+
+.ent_callout__icon_image, .ent_callout__icon--filled { border-color: #fffefb; }
+
+.ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #fef9ed; }
+
+.ent_callout__icon--limit_reached { border-color: #fffefb; }
+
+.ent_callout__insight { color: #2aa198; }
+
+.ent_callout__limit { color: #2aa198; }
+
+.ent_callout__meter_bar_container { background: #fdf6e3; }
+
+.ent_callout__meter_bar_border { border-color: #fdf6e3; }
+
+.ent_callout__meter_bar_fill--empty { background: #fffefb; border-color: #fffefb; }
+
+.ent_callout__meter_bar_fill--filled { background: #fffefb; border-color: #fffefb; }
+
+.ent_callout__meter_bar_fill--limit_reached { background: #dc322f; border-color: #dc322f; }
+
+.ent_callout__meter_bar_gleam { background: rgba(255, 254, 251, 0.5); }
+
+.ent_callout__title { color: #586e75; }
+
+.ent_copy_muted { color: #2aa198; }
+
+.ent_copy { color: #586e75; }
+
+.ent_csv_popover__footer_text { color: #2aa198; }
+
+.ent_csv_popover__footer { background: #fcf3d9; border-top-color: #fffefb; }
+
+.ent_csv_popover__subtitle { color: #2aa198; }
+
+.ent_csv_popover__title { color: #586e75; }
+
+.ent_data_table__cell--header { color: #2aa198; }
+
+.ent_data_table__cell--positive { color: #586e75; }
+
+.ent_data_table__cell--sortable:hover { background-color: #fcf3d9; }
+
+.ent_data_table__cell--sorting { color: #2aa198; }
+
+.ent_data_table__cell { border-bottom-color: #fffefb; color: #586e75; }
+
+.ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #fffefb; }
+
+.ent_data_table__column_group { background-color: #fcf3d9; }
+
+.ent_data_table__data_link, a.ent_data_table__data_link { color: #586e75; }
+
+.ent_data_table__row--hovered { background-color: #fdf6e3; }
+
+.ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+
+.ent_data_table__secondary_text { color: #2aa198; }
+
+.ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #fcf3d9; }
+
+.ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #fffefb; }
+
+.ent_data_table--rounded_top { border-top-color: #fffefb; }
+
+.ent_data_table { border-bottom-color: #fffefb; border-left-color: #fffefb; border-right-color: #fffefb; }
+
+.ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #586e75; }
+
+.ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #2aa198; }
+
+.ent_graph__legend_item--defocus { fill: #2aa198 !important; }
+
+.ent_graph__legend_text { fill: #586e75; }
+
+.ent_graph__svg_container .c3-axis path { stroke: #fffefb; }
+
+.ent_graph__svg_container .c3-grid line { stroke: #fffefb; }
+
+.ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #fffefb; }
+
+.ent_graph__svg_container .c3-tooltip { border-color: #fffefb; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+
+.ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #fcf3d9; color: #586e75; }
+
+.ent_graph__svg_container .c3-tooltip th { border-bottom-color: #fffefb; }
+
+.ent_graph__svg_container .c3-xgrid-focus line { stroke: #2aa198; }
+
+.ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #fcf3d9 !important; }
+
+.ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #fcf3d9 !important; }
+
+.ent_graph__svg_container text { fill: #2aa198; }
+
+.ent_graph__tooltip { color: #2aa198; }
+
+.ent_graph_empty__overlay { background: #fcf3d9; }
+
+.ent_graph_empty__text { color: #586e75; }
+
+.ent_graph_header--primary { color: #586e75; }
+
+.ent_graph_header--secondary { color: #2aa198; }
+
+.ent_graph_tabs__tab--selected { color: #586e75; }
+
+.ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #fffefb; }
+
+.ent_graph_tabs__tab { color: #2aa198; }
+
+.ent_graph_tabs { border-bottom-color: #fffefb; }
+
+.ent_header { color: #586e75; }
+
+.ent_icon_button { color: #2aa198; }
+
+.ent_icon_button:hover { color: #586e75; }
+
+.ent_infographic_container { border-top-color: #fffefb; }
+
+.ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(252, 243, 217, 0.8), #fcf3d9); }
+
+.ent_modal__title--small { color: #586e75; }
+
+.ent_modal_background { background-color: #fdf6e3; }
+
+.ent_modal_breadcrumb_animated_step { background: #fef9ed; }
+
+.ent_modal_breadcrumb_circle_icon { background: #fdf6e3; }
+
+.ent_modal_breadcrumb_line { background: #fef9ed; }
+
+.ent_modal_breadcrumb_text { color: #2aa198; }
+
+.ent_modal_footer { background-color: #fcf3d9; }
+
+.ent_modal_title { color: #586e75; }
+
+.ent_table__header--title { color: #586e75; }
+
+.ent_table__header { background-color: #fdf6e3; border-color: #fffefb; }
+
+.ent_table_banner__contents { background: #fdf6e3; border-top-color: #fffefb; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+
+.ent_table_banner__header { color: #586e75; }
+
+.ent_table_banner__secondary_text { color: #2aa198; }
+
+.ent_table_customizer__header_subtitle { color: #2aa198; }
+
+.ent_table_customizer_disabled_list_header { color: #2aa198; }
+
+.ent_table_customizer_footer { background-color: #fdf6e3; border-top-color: #fbeecb; color: #2aa198; }
+
+.ent_table_customizer_header { border-bottom-color: #fdf6e3; }
+
+.ent_table_customizer_list_item--disabled { color: #2aa198; }
+
+.ent_updated_at { color: #2aa198; }
+
+.enterprise { background-color: #fcf3d9; }
+
+.enterprise .btn.candy_red { color: #dc322f !important; }
+
+.enterprise_analytics { background-color: #fcf3d9; }
+
+.enterprise_org { background-color: #fcf3d9; }
+
+.enterprise_search_bar .ent_clear_search_icon { color: #2aa198; }
+
+.enterprise_search_bar::before { color: #586e75; }
+
+@keyframes color_fade { from { color: #2aa198; }
+  to { color: #586e75; } }
+
+.file_header .title a { color: #268bd2; }
+
+.file_header .title a:hover { color: #dc322f; }
+
+.file_actions_cog { color: #268bd2 !important; }
+
+.file_actions_cog:hover { color: #dc322f !important; }
+
+.file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #fbeecb; }
+
+.action_cog { color: #268bd2; }
+
+.action_cog i { color: #268bd2; }
+
+html.no_touch .action_cog:hover { color: #dc322f; }
+
+html.no_touch .action_cog:hover i { color: #dc322f; }
+
+.help_pages.help_pages p { color: #586e75; }
+
+.help_pages.help_pages a { border-bottom-color: #fef9ed; }
+
+.help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #fdf6e3; }
+
+.help_pages.help_pages .o-hero__header { color: #586e75; }
+
+.help_pages.help_pages .o-section--feature { background-color: #fcf3d9; border-top-color: #fef9ed; }
+
+.help_pages.help_pages .c-form__container .c-form__feedback { color: #dc322f; }
+
+.help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #fdf6e3; border-color: #fef9ed; color: #586e75; }
+
+.help_pages.help_pages .drop_zone { background: #fdf6e3; border-color: #fffefb; }
+
+.help_pages.help_pages .drop_zone_attachment { border-bottom-color: #fef9ed; }
+
+.help_pages.help_pages .drop_zone_remove_attachment { background-color: #fdf6e3; }
+
+.help_pages.help_pages .c-form__notice { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+
+.help_pages.help_pages .c-form__notice.is-error { border-left-color: #dc322f; }
+
+.help_pages.help_pages .c-nav--footer { border-top-color: #fef9ed; }
+
+@media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #fdf6e3; } }
+
+.widescreen:not(.nav_open) { color: #586e75; }
+
+@media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(253, 246, 227, 0.9); } }
+
+.widescreen:not(.nav_open) nav#site_nav h3 { color: #586e75; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a { color: #268bd2; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #dc322f; }
+
+.widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #2aa198; }
+
+nav#site_nav { background: #fcf3d9; }
+
+nav#site_nav #user_menu_contents:hover { background: #fdf6e3; color: #586e75; }
+
+header { background: #fcf3d9; }
+
+header #header_team_nav li a { color: #586e75; }
+
+header #header_team_nav li a:hover { background: #fdf6e3; color: #586e75; }
+
+header #header_team_nav li a .team_icon.ts_icon_plus { background: #fbeecb; color: #2aa198; }
+
+header #header_team_nav #add_team_option { border-top: 1px solid #fbeecb; }
+
+html.no_touch header #header_team_nav li a { color: #586e75; }
+
+html.no_touch header #header_team_nav li a:hover { background: #fdf6e3; color: #586e75; }
+
+html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #dc322f; }
+
+html.no_touch header .header_btns a:hover { color: #dc322f; }
+
+html.no_touch header .header_btns a:hover .label { color: #2aa198; }
+
+nav#site_nav h3, #header_team_name, header #header_team_name a { color: #268bd2; }
+
+nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #dc322f; }
+
+#home_footer a { color: #dc322f; }
+
+.admin_pref:not(:first-of-type) { border-top-color: #fdf6e3; }
+
+.admin_pref.locked { background-color: rgba(220, 50, 47, 0.2); }
+
+.admin_pref .admin_pref_locked_label { color: #2aa198; }
+
+.tooltip-inner { background-color: #fffefb; color: #586e75; }
+
+.tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #fffefb; }
+
+.tooltip.right .tooltip-arrow { border-right-color: #fffefb; }
+
+.tooltip.left .tooltip-arrow { border-left-color: #fffefb; }
+
+.tooltip.bottom .tooltip-arrow { border-bottom-color: #fffefb; }
+
+.api #header_logo img { display: none; }
+
+body.api header .header_links a { color: #586e75; }
+
+body.api header .header_links a.active { background: #fef9ed; }
+
+body.api .reverse_header { background-color: #fbeecb; color: #586e75; }
+
+body.api pre { overflow-x: auto; }
+
+body.api pre code { color: #586e75; }
+
+body.api #page_contents .card { background: #fcf3d9; }
+
+body.api .scopes_to_methods code { color: #586e75; }
+
+body.api .scopes_to_methods .selected code { color: #dc322f; }
+
+body.api .scopes_to_methods li { color: #586e75; }
+
+body.api .scopes_to_methods .selected li { color: #586e75; }
+
+body.api .section_title { border-bottom: 2px solid #fdf6e3; }
+
+body.api .example { border: 1px solid #fbeecb; }
+
+body.api .example h5 { background-color: #fbeecb; color: #586e75; }
+
+body.api .alert { background: #fef9ed; }
+
+body.api .hljs { background-image: none; }
+
+body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+
+body.api .hljs-number { color: #a5d6a7; }
+
+body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+
+body.api .hljs-variable { color: #9fa8da; }
+
+body.api .hljs-template-variable { color: #c5e1a5; }
+
+body.api .hljs-comment { color: #ffcc80; }
+
+body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+
+body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+
+body.api .hljs-meta { color: #eee; }
+
+body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+
+body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+
+body.api .hljs-tag { color: #a5d6a7; }
+
+body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+
+body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+
+body.api .hljs-quote { color: #b0bec5; }
+
+body.api .hljs-link, body.api .hljs-regexp { color: #268bd2; }
+
+body.api span.btn { background-color: #fdf6e3; }
+
+body.api span.deprecation, body.api span.warning { background-color: #dc322f; border-color: #dc322f; }
+
+nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#api_nav .footer_nav a { color: #268bd2; }
+
+#api_nav .footer_nav a:hover { color: #dc322f; }
+
+#api_nav .footer_nav .footer_signature { color: #dc322f; }
+
+.api_articles .api_articles_section { border-bottom-color: #fdf6e3; }
+
+.api_articles .article_tag_count { color: #2aa198; }
+
+.api.feature_related_content #api_related_content h2 { color: #586e75; }
+
+.api.feature_related_content #api_related_content .article_link_title_wrapper { color: #268bd2; }
+
+.tab_menu { background-color: #fcf3d9; }
+
+.tab_menu.grey { background-color: #fcf3d9; }
+
+.tab_menu .tab { color: #586e75; }
+
+.tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(220, 50, 47, 0.4); }
+
+.tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #dc322f; color: #586e75; }
+
+.tab_menu .tab:disabled { color: #2aa198; }
+
+.page_faq h3, .page_scim h3 { background-color: #fdf6e3; }
+
+.application_config aside { color: #2aa198; }
+
+.page_apps_directory_home { background-color: #fdf6e3 !important; }
+
+.page_apps_directory_home .nav_title { color: #586e75 !important; }
+
+.page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #2aa198; }
+
+.page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #fffefb; }
+
+.splash_container__background { background-color: #fcf3d9; }
+
+.splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+
+.splash_interactive__button { border-color: #fef9ed; }
+
+.splash_interactive__button--active { box-shadow: 0 0 10px 1px #fffefb; }
+
+.splash_interactive__window { background-color: #fdf6e3; border-color: #fef9ed; }
+
+.splash_interactive__window:hover .splash_interactive__window_headline { color: #586e75; }
+
+.splash_interactive__window::after { background: linear-gradient(to bottom, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+
+.splash_interactive__window_response { background-color: #fff; }
+
+a.splash_interactive__window_link { color: #586e75; }
+
+.splash_interactive__window_message_content_text--drive { color: #2aa198; }
+
+.search_input.apps_search_input { border-color: #fffefb; }
+
+.menu_launcher, .menu_launcher_large { background-color: #fef9ed; border-color: #fdf6e3 !important; color: #586e75; }
+
+.menu_launcher_large { border-color: #fdf6e3; }
+
+.menu.avatar_menu ul li:hover ts-icon { background: #fef9ed; color: #586e75; }
+
+.menu.avatar_menu ul li a { color: #586e75; }
+
+.menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #fef9ed; color: #2aa198; }
+
+.menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #586e75; }
+
+#page .media_list { background-color: #fcf3d9; border: 1px solid #fef9ed; }
+
+#page .media_list > li + li::before { border-top-color: #fef9ed; }
+
+#page .media_list > li.interactive a { color: #586e75; }
+
+#page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #fef9ed; border-color: #fffefb; }
+
+#page .media_list > li .media_list_text { color: #586e75; }
+
+#page .media_list.media_list_with_arrows a::before { color: #2aa198; }
+
+#page .media_list_title { color: #586e75; }
+
+#page .media_list_subtitle { color: #2aa198; }
+
+#page .sidebar_menu_list_item { color: #586e75; }
+
+#page .sidebar_menu_list_item.is_active { background-color: #fdf6e3; border-color: #fdf6e3; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#page .sidebar_menu_list_item.is_active a { color: #586e75; }
+
+#page .sidebar_menu_list_item:not(.is_active):hover { background-color: #fdf6e3; border-color: #fdf6e3; }
+
+#page .sidebar_menu_list_item a { color: #586e75; }
+
+#page ul.breadcrumbs li { color: #2aa198; }
+
+#page ul.breadcrumbs li:not(:first-child)::before { color: #2aa198; }
+
+#page ul.navigation_list li a { color: #586e75; }
+
+#page ul.navigation_list li a:hover { background-color: #fef9ed; }
+
+#page ul.navigation_list li a::after { color: #586e75; }
+
+#page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+
+#page .tag { background-color: #fbeecb; border: 1px solid #fcf3d9; }
+
+#page .tag:hover { background-color: #fef9ed !important; }
+
+#page .app_desc_btn { background-color: #fef9ed; color: #586e75; }
+
+#page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+
+#page .service_panel { background-color: #fcf3d9; }
+
+#page .service_card { background-color: #fdf6e3; border: 1px solid #fdf6e3; }
+
+.app_card, .large_app_card { background-color: #fdf6e3; border: 1px solid #fcf3d9; }
+
+nav.top.persistent ul a { color: #586e75; }
+
+nav.top.apps_nav { background: transparent; }
+
+nav.top.apps_nav.persistent .nav_title { border-color: #fffefb; }
+
+nav.top.apps_nav.clear_nav .nav_title a { color: #586e75; }
+
+nav.top.apps_nav .nav_title a { color: #586e75; }
+
+nav.top.apps_nav ul a.active { color: #dc322f; }
+
+.plastic_typeahead { background: #fcf3d9; border: 1px solid #fcf3d9; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+
+.plastic_typeahead_item { color: #586e75; }
+
+.plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #fef9ed; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #fdf6e3; border-top-color: #fcf3d9; color: #586e75; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #2aa198; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #fbeecb; border-color: #fef9ed; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #fef9ed; }
+
+a.plastic_typeahead_item { color: #586e75; }
+
+.apps_typeahead_item_media { background: #fbeecb; }
+
+.search_input_container .search_input:focus ~ .icon_search_input { color: #586e75; }
+
+.icon_search_input { color: #2aa198; }
+
+.quote_block { color: #586e75; }
+
+.quote_block::before { background-color: #fef9ed; }
+
+.well { background: #fbeecb; border-color: #fbebc2; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #2aa198; }
+
+.c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #fef9ed; }
+
+.c-tabs__tab { color: #2aa198; }
+
+.c-tabs__tab:hover { color: #586e75; }
+
+.c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #fffefb; color: #586e75; }
+
+.c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #fef9ed; }
+
+a.c-tabs__tab--plastic { color: #2aa198; }
+
+a.c-tabs__tab--plastic:hover { color: #586e75; }
+
+a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #fffefb; color: #586e75; }
+
+.p-detail_scope { box-shadow: inset 0 1px 0 0 #fef9ed; }
+
+.p-detail_scope:last-child { border-bottom-color: #fef9ed; }
+
+.p-detail_dangerous_scope { border-left-color: #dc322f; border-right-color: #fef9ed; }
+
+.p-detail_arrow_icon { color: #2aa198; }
+
+.p-detail_arrow_icon:hover { color: #586e75; }
+
+.p-detail_permissions { background: #fcf3d9; border-color: #fef9ed; }
+
+table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #fef9ed; }
+
+.section_rollup { border-bottom-color: #fdf6e3; }
+
+.section_rollup:first-of-type { border-top-color: #fdf6e3; }
+
+.section_rollup:hover:not(.is_active) { background: rgba(253, 246, 227, 0.5); color: #586e75; }
+
+.is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #859900; color: #fbeecb; }
+
+.developer_apps_functionality_link:hover { border-color: #fef9ed; box-shadow: 0 0 6px 0 rgba(255, 254, 251, 0.25); }
+
+.developer_apps_functionality_link::before { background-color: #fef9ed; }
+
+.developer_apps_functionality_link_enabled::before { background-color: #859900; }
+
+.legal-hero { background-color: #fdf6e3; }
+
+.legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #fdf6e3; }
+
+.legal-hero .o-hero__header__headline--larger { color: #586e75; }
+
+.legal-main { background-color: #fcf3d9; }
+
+.legal-main.v--no-switch { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-top-color: #fef9ed; }
+
+.legal-main p { color: #586e75; }
+
+.legal-main a { border-bottom-color: #fef9ed; }
+
+@media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #586e75; }
+  .legal-main .c-nav--sidebar__listitem a.is-selected { color: #2aa198; } }
+
+.legal-main .t-contains-subtle-links a:not(.c-button) { color: #586e75; }
+
+.legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #2aa198; }
+
+@media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #fcf3d9; } }
+
+.t-no-header .legal-hero.o-hero.v--short { background-color: #fcf3d9; }
+
+.c-oauth_scope_info__spacer_icon { color: #dc322f; }
+
+.c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #fef9ed; }
+
+.c-oauth_scope_info__dangerous_scopes { border-left-color: #dc322f; border-right-color: #fef9ed; border-top-color: #fef9ed; }
+
+.c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #fef9ed; }
+
+a.p-oauth_nav__anchor { color: #2aa198; }
+
+.p-oauth_nav__team-switcher .menu_launcher { border-color: #fcf3d9; }
+
+.p-oauth_nav__team-switcher .menu_launcher:hover { border: #fef9ed; }
+
+.p-oauth_page, .p-oauth_page--error { background: #fdf6e3; }
+
+.p-oauth_page__title { color: #586e75; }
+
+.p-oauth_page_single_channel_picker { border-bottom-color: #fcf3d9; }
+
+ts-rocket { color: #586e75; }
+
+ts-rocket a { color: #268bd2; }
+
+ts-rocket a caret::before { background-color: #fcf3d9; border-color: #fcf3d9; }
+
+ts-rocket hr { border-color: #fcf3d9; }
+
+ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #fbeecb; }
+
+ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #fbeecb; }
+
+ts-rocket .cl.text { background-color: #fbeecb; border-bottom: 1px solid #fcf3d9; }
+
+ts-rocket .cl.text .checkbox.checked + li { color: #2aa198; }
+
+ts-rocket > div > .checklist { background-color: #fbeecb; border-bottom: 1px solid #fcf3d9; }
+
+ts-rocket > div > .checklist .checkbox.checked + li { color: #2aa198; }
+
+ts-rocket > div > .checklist li::before { background: #fcf3d9; }
+
+ts-rocket > div > .checklist li.checked { color: #2aa198; }
+
+ts-rocket .unfurl .unfurl-container { background-color: #fbeecb; }
+
+ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(220, 50, 47, 0.1); }
+
+ts-rocket .unfurl .attachment_bar { background-color: #fcf3d9 !important; }
+
+ts-rocket .unfurl .unfurl-remove::before { color: #2aa198; }
+
+ts-rocket .unfurl .unfurl-remove:hover::before { color: #586e75; }
+
+ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(255, 254, 251, 0.5) !important; }
+
+ts-rocket caret::before { background-color: #fcf3d9; border: 1px solid #fcf3d9; }
+
+ts-rocket carriage { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-rocket selection { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-rocket ime { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(255, 254, 251, 0.5); }
+
+.focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #fbeecb; }
+
+nav { background: #fcf3d9; }
+
+nav .space { background-color: #fcf3d9; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+
+nav .space::after { border-left: 1px solid #fef9ed; }
+
+nav .comments { background-color: #fcf3d9; }
+
+nav .space_buttons .btn_outline { background-color: #fdf6e3; }
+
+nav .space_buttons .btn_outline::after { border-color: #fef9ed; }
+
+nav .space_btn_star { background: none; border: 0; }
+
+nav .space_btn_star:hover { background: none !important; }
+
+nav .space_btn_edit { background: #fef9ed; }
+
+nav .space_btn_edit.editing { background: #fffefb; }
+
+nav .star_info { color: #2aa198; }
+
+nav #space_status { border-left: 1px solid #fef9ed; color: #2aa198; }
+
+nav #space_status.slightly_concerned { color: #dc322f; }
+
+nav #edit_status { color: #2aa198; }
+
+nav .comments_open.unread span.notif { background-color: #dc322f; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+
+nav .comments_close { color: #2aa198; }
+
+nav .comments_close:hover::before { color: #268bd2 !important; }
+
+ts-space header { background: transparent; }
+
+ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #586e75; }
+
+ts-space header .owner_detail .inline-edit { background: none; }
+
+ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #586e75; }
+
+ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #586e75; }
+
+ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #2aa198; }
+
+ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #2aa198; }
+
+ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(255, 254, 251, 0.5); }
+
+ts-space header .owner_detail small { color: #2aa198; }
+
+ts-space header .divider { border-top: 1px solid #fef9ed; }
+
+ts-space a.feedback { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+
+ts-space a.feedback:hover { background-color: #fcf3d9; color: #586e75; }
+
+comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+
+#space_alert { background-color: #fbeecb; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+
+#space_alert.error { background-color: #dc322f; }
+
+#space_alert span#space_alert_text { color: #586e75; }
+
+#space_alert a { color: #268bd2; }
+
+#space_alert button#space_alert_close::before { color: #2aa198; }
+
+#space_alert button#space_alert_close:hover::before { color: #2aa198; }
+
+#space_alert .btn_outline.btn_transparent { background-color: #fdf6e3 !important; color: #586e75 !important; }
+
+#space_alert .btn_outline.btn_transparent::after { border-color: #fef9ed; }
+
+#space_find_bar { background-color: #fcf3d9; border-bottom: 1px solid rgba(255, 254, 251, 0.1); border-left: 1px solid rgba(255, 254, 251, 0.07); border-right: 1px solid rgba(255, 254, 251, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#space_find_bar #space_find_info.no_matches { color: #dc322f; }
+
+#space_find_bar #space_find_next .ts_icon { background-color: #fef9ed; }
+
+#space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #586e75; }
+
+#space_find_bar #space_find_next:hover .ts_icon { background-color: #fffefb; }
+
+#space_find_bar #space_find_close::before { color: #2aa198; }
+
+#space_find_bar #space_find_close:hover::before { color: #2aa198; }
+
+#connected_members .connected_members_count { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+
+#connected_members .toggle_more_members_popover { background: #fdf6e3; color: #2aa198; }
+
+#connected_members_overflow_popover { border-bottom: 1px solid #fcf3d9; border-left: 1px solid rgba(251, 238, 203, 0.11); border-right: 1px solid rgba(251, 238, 203, 0.11); border-top: 1px solid rgba(251, 238, 203, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .arrow::after { background-color: #fcf3d9; }
+
+#connected_members_overflow_popover .arrow_shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .monkey_scroll_wrapper { background: #fcf3d9; }
+
+#connection_status #connection_label { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+
+#shortcuts_spaces_dialog { background-color: rgba(251, 238, 203, 0.8); text-shadow: 0 1px 1px rgba(252, 243, 217, 0.7); }
+
+#shortcuts_spaces_dialog .modal-body { color: #586e75; }
+
+#shortcuts_spaces_dialog .col .keyboard { background-color: #fffefb; border-bottom: 2px solid #fdf6e3; box-shadow: 0 1px 2px rgba(251, 238, 203, 0.5); color: #586e75; }
+
+#shortcuts_spaces_dialog .close:hover { background-color: #fffefb; }
+
+#shortcuts_spaces_dialog .close .ts_icon::before { color: #2aa198 !important; }
+
+.textstyle_menu .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fcf3d9; }
+
+.textstyle_menu .arrow::after { background-color: #fcf3d9; }
+
+.textstyle_menu .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fcf3d9, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .arrow-shadow::after { background-color: #fcf3d9; }
+
+.textstyle_menu.link .arrow::after { background-color: #fcf3d9; }
+
+.textstyle_menu.link .content { background-color: #fcf3d9; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .content input[type=text] { background-color: #fef9ed; }
+
+.textstyle_menu.link .content > a.link { color: #268bd2; }
+
+.textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #2aa198; }
+
+.textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #fcf3d9; }
+
+.textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #fef9ed; }
+
+.textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #fef9ed; border: 1px solid #fffefb; }
+
+.textstyle_menu.style a.deformat::before { border-left: 1px solid #fef9ed; }
+
+.textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #2aa198; }
+
+.para_menu .insert .tip { color: #2aa198; }
+
+.para_menu .insert .tooltip .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed; }
+
+.para_menu .insert .tooltip .arrow::after { background-color: #fcf3d9; }
+
+.para_menu .insert .tooltip .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed; }
+
+.para_menu .format .options .arrow::after { background-color: #fcf3d9; }
+
+.para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #fef9ed; }
+
+.para_menu .format .options .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .content ul:first-child { border-bottom: 1px solid #fcf3d9; }
+
+.para_menu .format .options.show .tooltip > div { background-color: #fcf3d9; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #586e75; }
+
+.para_menu .format .options.show .tooltip span { background-color: #fef9ed; }
+
+.para_menu .options a:hover { border: 1px solid #fef9ed; }
+
+.para_menu .options a.active { background-color: #fdf6e3; border: 1px solid #fcf3d9; }
+
+.para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+
+.para_menu .options a span { filter: grayscale(2) brightness(5); }
+
+.para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+
+.para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); }

--- a/css/variants/solarized-dark.css
+++ b/css/variants/solarized-dark.css
@@ -1,0 +1,2036 @@
+@-moz-document regexp("https://[^./]*\\.slack\\.com/(?!pricing)(?!security).*") { body { background: #002b36; color: #a1adad; }
+  a { color: #268bd2; }
+  a:link, a:visited { color: #268bd2; }
+  a:hover, a:active, a:focus { color: #dc322f; }
+  hr { border-bottom: 1px solid #002b36; border-top: 1px solid #002b36; }
+  h1, h2, h3, h4 { color: #a1adad; }
+  h1 a { color: #a1adad; }
+  h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #a1adad; }
+  .bordered { border: 1px solid #00232c; }
+  .top_border { border-top: 1px solid #00232c; }
+  .bottom_border { border-bottom: 1px solid #00232c; }
+  .left_border { border-left: 1px solid #00232c; }
+  .right_border { border-right: 1px solid #00232c; }
+  .bullet { color: #2aa198; }
+  .alert, .c-alert, .c-alert--boxed { background-color: #00232c; border-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .alert h4, .c-alert h4, .c-alert--boxed h4 { color: #a1adad; }
+  .alert-info { background-color: #00232c; border-color: #00171d; color: #a1adad; }
+  .alert-info h4 { color: #a1adad; }
+  ::-webkit-scrollbar-track { background: #00232c !important; border-left-color: #00232c !important; border-right-color: #00232c !important; color: #00232c !important; }
+  ::-webkit-scrollbar-thumb { background: #003340 !important; border-left-color: #00232c !important; border-right-color: #00232c !important; color: #002b36 !important; }
+  ::-webkit-scrollbar-corner { background: #002b36 !important; }
+  .supports_custom_scrollbar #messages_container::after { background: none !important; }
+  .monkey_scroll_bar { background: #002b36; }
+  .monkey_scroll_handle_inner { background: #003340; border: 1px solid #003f50; }
+  .monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+  #client-ui .monkey_scroll_bar { background: #002b36; }
+  #client-ui .monkey_scroll_handle_inner { background: #003340; border: 3px solid #002b36; }
+  .c-scrollbar--monkey .c-scrollbar__track { background: #002b36; }
+  .c-scrollbar--monkey .c-scrollbar__bar { background: #003340; box-shadow: 0 3px 0 #002b36, 0 -3px 0 #002b36; }
+  .client_channels_list_container { background-color: #00232c; border-right-color: #002b36; }
+  #col_channels { color: #a1adad; }
+  .p-channel_sidebar { background-color: #00232c; color: #a1adad; }
+  .p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(161, 173, 173, 0.8) !important; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #a1adad; }
+  .p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #002b36 !important; }
+  .p-channel_sidebar__header { color: #a1adad !important; }
+  .p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #a1adad; }
+  .p-channel_sidebar__channel--im .c-presence--away { color: #2aa198; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #003340 !important; }
+  .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #003340 !important; }
+  .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #a1adad; }
+  .p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #a1adad; }
+  .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #dc322f; }
+  .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #003340; }
+  .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #b1bbbb !important; }
+  .p-channel_sidebar__close_container:hover { background: #00171d; }
+  .p-channel_sidebar__jumper { background: transparent !important; }
+  .channels_list_holder h2 { color: #a1adad !important; }
+  .channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #a1adad; opacity: 0.8; }
+  .channels_list_holder ul { color: #a1adad !important; }
+  .channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #00232c; color: rgba(161, 173, 173, 0.8) !important; }
+  .channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #002b36 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+  .channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #002b36; }
+  .channels_list_holder ul li.mention a { color: #a1adad; }
+  .channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #b1bbbb !important; }
+  .channels_list_holder ul li.unread .prefix { color: #a1adad !important; opacity: 1; }
+  .channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #268bd2 !important; }
+  .channels_list_holder .unread_highlights { background: #dc322f; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .channels_list_holder .unread_msgs { background: #002b36; color: #a1adad; }
+  #channel_list_invites_link { border-bottom: 1px dotted #268bd2; color: #268bd2 !important; font-size: 0.9rem; }
+  #channel_list_invites_link:hover { border-bottom: 1px solid #268bd2; }
+  #quick_switcher_btn { background: #00232c; border-top: 2px solid #00232c; }
+  #quick_switcher_btn > i { color: #2aa198; }
+  #quick_switcher_btn:active, #quick_switcher_btn:hover { background: #002b36; border-color: #002b36; }
+  #quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #268bd2; }
+  #quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #268bd2; }
+  #quick_switcher_label { color: #2aa198; }
+  .loading #loading-zone { background: #002b36; }
+  #loading_welcome { background-image: none; }
+  #loading_message p { color: #a1adad; }
+  #loading_message #loading_message_attribution { color: #2aa198; }
+  #loading_team_menu_bg, #loading_user_menu_bg { background: #002b36; border: none; }
+  .infinite_spinner_bg, .infinite_spinner_blue { stroke: #a1adad; }
+  body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #00232c; }
+  .p-degraded_list__loading { background-color: #002b36; color: #a1adad; }
+  input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #003340; border-color: #00171d; color: #a1adad; }
+  input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(0, 35, 44, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+  input[type=file]:focus { outline: #a1adad dotted thin; }
+  input[type=radio]:focus, input[type=checkbox]:focus { outline: #a1adad dotted thin; }
+  select { background: #003340; }
+  select, textarea { border: 1px solid #00171d; color: #a1adad; }
+  select:active, select:focus, textarea:active, textarea:focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 63, 80, 0.15); }
+  input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #002b36 !important; }
+  .no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #00232c; }
+  .no_touch label.select:hover select { border-color: #00232c; }
+  .no_touch label.select:not(.disabled):hover::after { color: #00232c; }
+  label.disabled { color: #a1adad; }
+  legend { border-bottom: 1px solid #003f50; }
+  legend small { color: #2aa198; }
+  .uneditable-input, .uneditable-textarea { background-color: #002b36; border: 1px solid #00171d; color: #a1adad; }
+  .uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(0, 63, 80, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+  textarea { background-color: #003340; border: 1px solid #00171d; color: #a1adad; }
+  textarea:focus { border-color: rgba(0, 63, 80, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 63, 80, 0.6); }
+  ::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  ::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  ::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  [data-placeholder]:empty::before { color: #a1adad !important; }
+  input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  input::-moz-placeholder, textarea::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  input::placeholder, textarea::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #a1adad !important; }
+  input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #003340 !important; }
+  .form-actions { background-color: #002b36; border-top: 1px solid #00232c; }
+  .help-block, .help-inline { color: #2aa198; }
+  .input-append .add-on, .input-prepend .add-on { background-color: #003f50; border: 1px solid #003340; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .btn { background-color: #003340; color: #a1adad !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #003340; color: #a1adad; }
+  .btn.btn_border { border: 2px solid #002b36; }
+  .btn.disabled, .btn:disabled { background-color: #00171d !important; }
+  .btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #00171d !important; }
+  .btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #dc322f !important; color: #a1adad !important; }
+  .btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #002b36 !important; border-color: #dc322f !important; color: #dc322f !important; }
+  .btn.btn_outline.disabled { background: #002b36 !important; color: #268bd2 !important; }
+  .btn.btn_outline.disabled:hover { background: #002b36 !important; color: #268bd2 !important; }
+  .btn.btn_attachment { border-color: #003340; }
+  .btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #00232c; border-color: #003f50; }
+  .btn.btn_attachment.btn_danger { border-color: #dc322f; }
+  .btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e35d5b; }
+  .btn.btn_attachment.btn_primary { border-color: #003f50; }
+  .btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: #006883; }
+  .btn_basic:focus, .btn_basic:hover { color: #a1adad; }
+  .btn_outline { background: #002b36; color: #268bd2 !important; }
+  .btn_outline::after { border: 1px solid #002b36; }
+  .btn_outline.btn_transparent { color: rgba(0, 51, 64, 0.9) !important; }
+  .btn_outline.btn_transparent::after { border: 1px solid rgba(0, 43, 54, 0.5); }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(0, 51, 64, 0.9) !important; color: #dc322f !important; }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(0, 51, 64, 0.8) !important; }
+  .btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #002b36; color: #dc322f !important; }
+  .btn_outline:active { color: #dc322f; }
+  .btn_outline.active { color: #dc322f !important; }
+  .btn_link { color: #268bd2; }
+  .btn_link:hover, .btn_link:focus { color: #dc322f; }
+  .btn-group.open .btn.dropdown-toggle { background-color: #003340; }
+  .btn-group.open .btn-primary.dropdown-toggle { background-color: #002b36; }
+  .btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+  .btn_info, .btn.btn_success { background-color: #002b36 !important; }
+  .btn_warning, .btn_danger { background-color: #dc322f !important; }
+  .btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #a1adad; border-top-color: #a1adad; }
+  .input_note { color: #a1adad; }
+  .c-enhanced_text_input { background-color: #003340; border-color: #00232c; color: #2aa198; }
+  .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #003340; }
+  .lazy_filter_select.disabled { background: #00232c; }
+  .lazy_filter_select.disabled input.lfs_input { background: #003f50; }
+  .lazy_filter_select .lfs_input_container { background-color: #003340; border-color: #00171d; }
+  .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #00232c; }
+  .lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(0, 43, 54, 0.15); }
+  .lazy_filter_select .lfs_list_container { background: #002b36; border-color: #00171d; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+  .lazy_filter_select .lfs_list .lfs_item.selected { color: #a1adad; }
+  .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #a1adad !important; }
+  .lazy_filter_select .lfs_list .lfs_item.disabled { color: #2aa198; }
+  .lazy_filter_select .lfs_list .lfs_item.active { background-color: #00171d; border-color: #00232c; color: #a1adad; }
+  .lazy_filter_select .lfs_token { background: #002b36; border: 1px solid #00171d; color: #a1adad; }
+  .lazy_filter_select .lfs_token::after { color: #a1adad; }
+  .lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #a1adad; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #a1adad !important; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item { color: #2aa198 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+  #message_edit_form .emo_menu { color: rgba(161, 173, 173, 0.3); }
+  #message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #003f50; }
+  #message_edit_form.focus .emo_menu { color: rgba(161, 173, 173, 0.6); }
+  #message_edit_form.focus #primary_file_button:not(:hover) { border-color: #00232c; }
+  #message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #00232c !important; }
+  #message_edit_form.offline #primary_file_button { border-color: #002b36; color: #2aa198; }
+  #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #00232c; }
+  #msg_form #msg_input { background: padding-box #003340; border-color: #002b36; border-left: 0; color: #a1adad; }
+  #msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #a1adad; }
+  #msg_form .msg_mentions_button { color: #2aa198; }
+  #msg_form .msg_mentions_button:hover { color: #a1adad; }
+  #msg_input { background: #003340; border-color: #002b36; color: #a1adad; }
+  #msg_input::-webkit-input-placeholder { color: #a1adad !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  #msg_input::-moz-placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  #msg_input::placeholder { color: #a1adad !important; filter: none; opacity: 0.5; }
+  #msg_input[data-placeholder]:empty::before { color: #a1adad !important; }
+  #msg_input:focus, #msg_input.focus { border-color: #00232c; }
+  #msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #00232c; }
+  #msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #002b36; }
+  #msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #002b36; }
+  #msg_input.offline:not(.pretend-to-be-online) { background-color: #00232c !important; color: #2aa198; }
+  #msg_input.disabled, #msg_input.ql-disabled { background-color: #00232c; border-color: #00232c; color: #2aa198; }
+  #msg_input_message { background-color: #00232c; color: #a1adad; }
+  #primary_file_button { background: padding-box #003340; border-color: #002b36; color: #2aa198; }
+  #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #002b36; border-color: #00232c; color: #a1adad; }
+  #footer, #footer.footer_msg_input { background: #002b36; box-shadow: inset 1px 0 0 0 #002b36; }
+  #footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #00232c !important; border-color: #00232c !important; }
+  #footer_archives_table { color: #2aa198; }
+  #typing_text { color: #2aa198; filter: none; }
+  #notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+  #special_formatting_text { color: #2aa198; }
+  #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #003340; border-color: #00232c; color: #a1adad; }
+  .inline_message_input_container .ql-container { border-color: #003340; }
+  .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #003f50; }
+  .c-message--editing { background: #00232c; border-color: #00232c; color: #a1adad; }
+  .c-message__editor__input { background: #003340; border-color: #00232c; color: #a1adad; }
+  .c-message__editor__input.focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-message__editor__warning { color: #dc322f; }
+  #message_edit_container .message_input { background: #003340; border-color: #00232c; color: #a1adad; }
+  #message_edit_container .message_input.focus { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 51, 64, 0.5); color: #002b36; }
+  .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 51, 64, 0.8); }
+  .ql-placeholder, .texty_legacy .ql-placeholder { color: #a1adad; filter: none; }
+  .ql-container.texty_single_line_input { background: #003340; border: 1px solid #00232c; color: #a1adad; }
+  .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #00232c; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-input_select { background: #003340; border-color: #00232c; color: #a1adad; }
+  .p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #a1adad; }
+  .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #003340; border-color: #00232c; color: #a1adad; }
+  .c-input_select_options_list__option { color: #a1adad; }
+  .menu { background: #00232c; border: 1px solid #002b36; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #a1adad; }
+  .menu .menu_content { background: #00232c !important; }
+  .menu .menu_filter_container { background: #002b36; }
+  .menu .menu_filter_container input.menu_filter { border: 1px solid #002b36; }
+  .menu .menu_filter_container input.menu_filter:focus { border-color: #003340; }
+  .menu .menu_filter_container .icon_search { color: #2aa198; }
+  .menu .menu_filter_container .icon_close { color: #2aa198 !important; }
+  .menu #menu_header .menu_simple_header { background: #00171d; border-color: #00232c; color: #a1adad; }
+  .menu #menu_header .menu_simple_header a { color: #268bd2; }
+  .menu #menu_header .menu_simple_header a:hover { color: #dc322f; }
+  .menu #menu_header .menu_close { color: #a1adad; }
+  .menu .section_header .header_label { background-color: #00232c; color: #2aa198; }
+  .menu .section_header > div.header_label_container { color: #2aa198; }
+  .menu ul li a { background: #00232c; border-bottom: 0; color: #a1adad; }
+  .menu ul li a.delete_link { color: #dc322f; }
+  .menu ul li a:not(.inline_menu_link) { color: #a1adad; }
+  .menu ul li.highlighted a { background: #002b36; border-bottom-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #a1adad; }
+  .menu ul li.highlighted a.delete_link { color: #dc322f; }
+  .menu ul li.disabled a { color: #2aa198; }
+  .menu ul li i { color: #2aa198; }
+  .menu ul li.divider { border-bottom-color: #002b36; }
+  .menu ul li .menu_item_details { color: #2aa198; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #002b36; border-bottom-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #a1adad; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #dc322f; }
+  .menu input { background: #00232c; border: 1px solid #003340; }
+  .menu textarea { background: #00232c; border: 1px solid #003340; }
+  .menu #menu_footer .menu_footer { background: #00171d; border-top: 1px solid #00232c; }
+  .menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #00232c; }
+  .menu #menu_list_container #menu_list .menu_list_item a { color: #a1adad; }
+  .menu #menu_list_container #menu_list .menu_list_item.active a { background: #003340; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu { color: #a1adad; }
+  #autocomplete_menu header { background-color: #002b36; }
+  #autocomplete_menu header .header_label { color: #2aa198; }
+  #autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #00171d; }
+  #autocomplete_menu h2 { color: #a1adad; }
+  #autocomplete_menu .no_results { color: #a1adad; }
+  #autocomplete_menu .keyword_match .modifier { color: #2aa198; }
+  #autocomplete_menu .boxed { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu .pickmeup { border-bottom: 1px solid #00232c; }
+  #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #003340; }
+  #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #a1adad; }
+  #autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #00232c; }
+  #autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+  #autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #a1adad; }
+  #autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #00232c; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #a1adad; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #268bd2; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #dc322f; }
+  #autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #00232c; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #a1adad; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #268bd2; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #dc322f; }
+  #autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #00232c; }
+  #autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #a1adad; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #a1adad; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #002b36; color: #a1adad; }
+  #autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+  #autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(0, 51, 64, 0.25); border: #003f50; }
+  #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #00232c; border: 1px solid #00171d; }
+  .search_light_grey { color: #a1adad !important; }
+  .highlighter_underlay .keyword::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+  .highlighter_underlay .modifier::before { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+  .highlighter_underlay .modifier.incomplete::before { background: #00232c; border: 1px solid #00171d; }
+  .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(0, 63, 80, 0.25); border: #003340; }
+  .highlighter_underlay .ghost_text { color: #a1adad; }
+  .pickmeup { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+  .pickmeup .pmu-instance .pmu-button { color: #a1adad; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #00232c !important; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #003f50; color: #a1adad !important; }
+  .pickmeup .pmu-instance .pmu-today-border { border: 2px solid #003340 !important; color: #003f50 !important; }
+  .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #003340; color: #a1adad; }
+  .pickmeup .pmu-instance .pmu-not-in-month { background: #002b36; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #003340; }
+  .pickmeup .pmu-instance .pmu-disabled { background: #002b36; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-disabled:hover { background: #002b36; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-selected { background: #003340; color: #a1adad; }
+  .pickmeup .pmu-instance nav { color: #268bd2; }
+  .pickmeup .pmu-instance nav :first-child :hover { color: #dc322f; }
+  .pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #00232c; }
+  .pickmeup .pmu-instance .pmu-day-of-week { color: #a1adad; }
+  .pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #00232c; }
+  .pickmeup .pmu-instance .pmu-days * { border: 1px solid #00232c; }
+  .p-block_kit_date_picker_calendar_wrapper { background: #00232c; border-color: #003340; color: #a1adad; }
+  .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #003340; border-color: #00232c; color: #a1adad; }
+  .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #003340; color: #003f50; }
+  #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #003340; }
+  #menu.date_picker li.date_picker_item a { color: #a1adad; }
+  #menu.date_picker li.date_picker_item a:hover { color: #a1adad; }
+  #menu.date_picker li.date_picker_item.highlighted a { color: #2aa198; }
+  #file_member_filter { background: #00171d; }
+  #client-ui .member_filter { border: 1px solid #003340; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #002b36; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #a1adad; }
+  #client-ui #team_list_container #team_filter .member_filter { background-color: #002b36; border-left: 1px solid #00171d; }
+  #client-ui #file_member_filter { border-color: #003340; }
+  #client-ui #file_member_filter .member_filter { border-color: #003340; }
+  #client-ui .team_tabs_container { border-bottom: 1px solid #00171d; }
+  #team_filter .icon_search { color: #2aa198; }
+  #team_filter a.icon_close { color: #268bd2; }
+  #team_filter a.icon_close:hover { color: #dc322f; }
+  .filter_header { background-color: #002b36; }
+  .popover_menu { background-color: #002b36; border-top: 1px solid #003340; }
+  .popover_menu .arrow::after { background-color: #00171d; }
+  .popover_menu .arrow_shadow::after { background-color: #002b36; box-shadow: 0 0 0 1px #003340, 0 0 3px rgba(0, 0, 0, 0.08); }
+  .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #002b36 !important; }
+  .popover_menu .content { background-color: #002b36; }
+  .tab_complete_ui { background: #002b36; border: 1px solid #00232c; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+  .tab_complete_ui .tab_complete_ui_header { background: padding-box #00171d; border-bottom: 1px solid #00232c; color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui ul.type_emoji li { color: #a1adad; }
+  .tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #a1adad; }
+  .tab_complete_ui ul.type_members .unify_broadcast { color: #a1adad; }
+  .tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #2aa198; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #a1adad !important; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #00232c; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #2aa198; }
+  .tab_complete_ui ul.type_cmds .cmdname { color: #a1adad; }
+  .tab_complete_ui ul.type_cmds .cmddesc { color: #2aa198; }
+  .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #00232c; }
+  .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #003340; border-bottom-color: #00232c; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #a1adad !important; }
+  .tab_complete_ui .not_in_channel { color: #2aa198; }
+  #team_menu { background: #00232c; border-bottom: 2px solid #00232c; color: #a1adad; }
+  #team_menu.active, #team_menu:hover { background: #00232c !important; border-bottom-color: #00232c !important; }
+  #team_menu.active i, #team_menu:hover i { color: #a1adad; }
+  #team_menu i { color: #2aa198; }
+  #team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  #team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #a1adad !important; }
+  #team_menu_user { color: #2aa198; }
+  #team_menu_user_name, #team_menu_user_details { color: #a1adad !important; opacity: 0.75; }
+  .slack_menu_section::before { border-top-color: #002b36; }
+  .slack_menu_header_secondary { color: #2aa198; }
+  .slack_menu_download { background-color: #00232c; }
+  .slack_menu_download ts-icon { color: #2aa198; }
+  #menu_items_scroller::-webkit-scrollbar-track { background: #002b36 !important; }
+  #limit_meter:hover #limit_meter_message_body { color: #a1adad; }
+  #limit_meter_message_body { color: #2aa198; }
+  .channel_header { background: #002b36; box-shadow: inset 1px 0 0 0 #002b36; }
+  .channel_header .blue_on_hover:hover { color: #a1adad; }
+  #client_body:not(.onboarding)::before { background: #002b36; border-bottom: 1px solid #00232c; box-shadow: inset 1px 0 0 0 #002b36; }
+  .messages_header { color: #a1adad; }
+  .channel_title .channel_name_container .channel_name { color: #a1adad; }
+  .channel_title .channel_name_container .channel_name.muted { color: #2aa198; }
+  .channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #2aa198; }
+  .channel_title .channel_name_container .muted_icon { color: #2aa198; }
+  .channel_title .channel_name_container .muted_icon:hover { color: #dc322f; }
+  #im_title.away { color: #2aa198; }
+  .channel_header_info button { color: #268bd2; }
+  .channel_header_icon { color: #a1adad; }
+  .channel_calls_button .call_icon.call_window_offline { color: #2aa198; }
+  .channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #a1adad; }
+  #flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #a1adad; }
+  #flex_menu_toggle .flex_menu_download_circle { background: #002b36; }
+  #flex_menu_toggle .flex_menu_download_circle canvas { background: #002b36; }
+  #flex_menu_toggle.unread #help_icon_circle_count { background-color: #dc322f; color: #fff; }
+  #flex_menu_toggle.open #help_icon_circle_count { background-color: #00171d; color: #a1adad; }
+  #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #00232c; color: #a1adad; }
+  #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #003340; color: #a1adad; }
+  #recent_mentions_toggle:hover { color: #dc322f; }
+  #rxn_toast_div { background: #00171d; border: 1px solid #003340; }
+  .presence { color: #2aa198; }
+  #edit_topic_inner:not(.unable_to_post)::before { background: #002b36; border-color: #00232c; }
+  #edit_topic_trigger { color: #268bd2; }
+  .c-message_list__day_divider__label { color: #2aa198; }
+  .c-message_list__day_divider__label__pill { background: #002b36; position: relative; }
+  .c-message_list__day_divider__line { border-top-color: #00232c; }
+  .day_divider, .mention_day_container_div .day_divider { background: #002b36; color: #2aa198; }
+  .day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #00232c; }
+  .day_divider .day_divider_label { background: #002b36; }
+  .day_container .day_msgs { border-top: 1px solid #00232c; }
+  .day_container.unread_day_container .day_msgs { border-color: #003f50; }
+  .day_container .day_divider { background: none; color: #2aa198; }
+  .day_container .day_divider .day_divider_label { background: #002b36; }
+  .search_form { border-color: #003340; }
+  .search_form .search_input { background: transparent; }
+  .search_form:hover { border-color: #003f50; }
+  .search_focused .search_form { border-color: #003f50; }
+  .search_clear_icon .ts_icon_times_circle { color: #2aa198; }
+  #search_spinner { color: #a1adad; }
+  #search_container .search_input { background: transparent; }
+  #search_container .icon_search { color: #2aa198; }
+  #search_container .icon_close { color: #268bd2; }
+  #team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #2aa198; }
+  #team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #268bd2; }
+  #team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #dc322f; }
+  .c-search { background: transparent; }
+  .c-search_message__body { color: #a1adad; }
+  .p-search_filter__more_link { color: #a1adad; }
+  .p-search_filter__title_text { background: #00232c; color: #a1adad; }
+  .p-search_filter__datepicker_trigger { background: #00232c; border-color: #003340; color: #a1adad; }
+  .p-search_filter__datepicker_trigger:hover { color: #2aa198; }
+  .c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #00232c; border-color: #003340; color: #a1adad; }
+  .c-search_autocomplete footer { background: #00232c; border-color: #003340; color: #a1adad; }
+  .c-search_autocomplete__suggestion_item { color: #a1adad; }
+  .c-search_autocomplete__suggestion_item--selected { background-color: #002b36; }
+  .c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #a1adad; }
+  .c-search__input_and_close { border-bottom-color: #00171d; }
+  .c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #a1adad; }
+  #msgs_overlay_div { background: #002b36; }
+  #col_messages { box-shadow: inset 1px 0 0 0 #002b36; }
+  .c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #2aa198 !important; }
+  .c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(0, 23, 29, 0.1); }
+  .c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #2aa198; }
+  .c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #2aa198; }
+  .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(0, 23, 29, 0.1); }
+  .c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(0, 23, 29, 0.2); }
+  .c-message--custom_response { background: rgba(0, 23, 29, 0.15); }
+  .c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(0, 23, 29, 0.1); }
+  .c-message--pinned .c-message__label__icon { color: #dc322f; }
+  .c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #a1adad; }
+  .c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #2aa198; }
+  .c-message--sli_highlight_negative .c-message__label { background: rgba(0, 23, 29, 0.1); }
+  .c-message--resend .c-message__body { color: #2aa198; }
+  .c-message--deleting { background: rgba(220, 50, 47, 0.6); }
+  .c-message--standalone { border-color: rgba(0, 51, 64, 0.1); }
+  .c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+  .c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message__sender { color: #a1adad; }
+  .c-message__sender a { color: #a1adad; }
+  .c-message__sender .c-emoji__text_mode_icon { color: #2aa198; }
+  .c-message__body { color: #a1adad; }
+  .c-message__body--unknown { background: rgba(0, 51, 64, 0.1); }
+  .c-message__body--automated { color: #2aa198; }
+  .c-message__body--tombstone { color: #2aa198; }
+  .c-message__label { color: #2aa198; }
+  .c-message__label__highlight_title { color: #a1adad; }
+  .c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #2aa198; }
+  .c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #a1adad; }
+  .c-message__resend_controls { color: #2aa198; }
+  .c-message__resend_column { background-color: rgba(0, 51, 64, 0.1); }
+  .c-message__resend, .c-message__cancel { color: #a1adad; }
+  .c-message__edited_label { color: #2aa198; }
+  .c-message__tombstone_icon { background: rgba(0, 51, 64, 0.1); color: #2aa198; }
+  .c-message__bot_label { background: rgba(0, 51, 64, 0.1); color: #2aa198; }
+  .c-message__comment:before { color: #2aa198; }
+  .c-message__call_attachment { background: #002b36; border-color: rgba(0, 51, 64, 0.1); }
+  .c-message__call_icon { color: #a1adad; }
+  .c-message__call--ended .c-message__call_icon { color: #2aa198; }
+  .c-message__call_info { color: #a1adad; }
+  .c-message__call_name--linked { color: #a1adad; }
+  .c-message__call_name + .c-message__call_description::before { color: #2aa198; }
+  .c-message__call_sub { color: #2aa198; }
+  .c-message_actions__container { background: #002b36; border-color: #00232c; }
+  .c-message_actions__container:hover { border-color: #003340; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  .c-message_actions__button { border-right-color: #00232c; color: #268bd2; }
+  .c-message_actions__button:hover { color: #a1adad; }
+  .c-message_actions__button:active { background: #00232c; }
+  .c-message_group { background-color: #002b36; border-color: #00232c; }
+  .c-message_group:hover .c-message_group__header { color: #2aa198; }
+  .c-message_group__header { color: #a1adad; }
+  .c-message_group__divider_text { background-color: #002b36; color: #a1adad; }
+  .c-message_list__unread_divider__separator { border-color: #003340; }
+  .c-message_list__unread_divider__label { background: #002b36; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #003340; }
+  .c-message_list__spinner { color: #2aa198; }
+  .c-message_list .c-scrollbar__bar { background: #002b36; }
+  .c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(0, 63, 80, 0.8); }
+  ts-message { color: #a1adad; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(0, 23, 29, 0.1); box-shadow: inset 1px 0 0 0 #002b36; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(0, 23, 29, 0.2); }
+  ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #2aa198; }
+  ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #2aa198 !important; }
+  ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+  ts-message.is_pinned { background: rgba(0, 23, 29, 0.15); }
+  ts-message .timestamp { color: #268bd2; }
+  ts-message .temp_msg_controls { color: #2aa198; }
+  ts-message .edited { color: rgba(42, 161, 152, 0.8); }
+  ts-message:hover .edited { color: #2aa198; }
+  ts-message .only_visible_to_user { color: #2aa198; }
+  ts-message.ephemeral { color: #a1adad; }
+  ts-message .bot_label { background: #00171d; color: #2aa198; }
+  ts-message .in_reply_to { background: #00171d; color: #2aa198; }
+  ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #00232c; }
+  ts-message.unprocessed { color: rgba(161, 173, 173, 0.75); }
+  ts-message.highlight { background: rgba(220, 50, 47, 0.4); }
+  ts-message.highlight:hover { background: rgba(220, 50, 47, 0.4); }
+  ts-message .is_highlights_holder { color: #2aa198; }
+  ts-message .is_highlights_holder ts-icon { color: #2aa198; }
+  ts-message .is_highlights_holder .highlights_feedback_link { color: #2aa198; }
+  ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #a1adad; }
+  ts-message .recap_highlight { background: rgba(220, 50, 47, 0.4); }
+  ts-message .recap_highlight a { color: #a1adad; }
+  ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(220, 50, 47, 0.75); }
+  ts-message.automated .message_body { color: rgba(161, 173, 173, 0.8); }
+  ts-message .action_hover_container { border: 1px solid #00232c; }
+  ts-message .action_hover_container:hover { border-color: #003340; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  ts-message .action_hover_container:hover a { background: #00232c; border-right: 1px solid #003340; }
+  ts-message .action_hover_container .btn_msg_action { background: #002b36; border-right: 1px solid #00232c; color: #268bd2; }
+  ts-message .action_hover_container .btn_msg_action:hover { color: #a1adad; }
+  ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #00232c; color: #a1adad; }
+  ts-message.selected { background: #002b36; }
+  ts-message.selected:not(.delete_mode) { background: #002b36; }
+  ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+  ts-message .meta { color: #2aa198; }
+  ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #268bd2 !important; }
+  ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+  ts-message .pinned_item_message_header { color: #2aa198; }
+  ts-message .mention { background: #003f50 !important; color: #a1adad !important; }
+  ts-message .internal_member_link { background: #002b36 !important; border: 0; color: #268bd2 !important; }
+  ts-message .internal_member_link:hover { color: #dc322f !important; }
+  ts-message.show_recap:not(.is_pinned) { background: rgba(0, 23, 29, 0.15); }
+  ts-message.show_recap:not(.is_pinned):hover { background: rgba(0, 23, 29, 0.15); }
+  .ephemeral.message .message_content { color: #a1adad; }
+  ts-mention { background: rgba(0, 63, 80, 0.1) !important; color: #a1adad !important; }
+  .selecting_messages ts-message:hover { background: #00171d; }
+  .selecting_messages ts-message.multi_delete_mode:hover { background: rgba(220, 50, 47, 0.75); }
+  #convo_container { background-color: #002b36; }
+  #convo_container #message_edit_container { border-bottom: 1px solid #003340; border-top: 1px solid #003340; }
+  #convo_container ts-conversation::after { background: rgba(0, 23, 29, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(0, 23, 29, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(0, 23, 29, 0.08) 100%); }
+  #convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(0, 23, 29, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(0, 23, 29, 0.08) 0, transparent 100%); }
+  #convo_container ts-conversation ts-message.selected { background: #002b36; }
+  #convo_container ts-conversation ts-relatives::after { background: #003340; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #003340; color: #2aa198; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #a1adad; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #002b36; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #003f50; }
+  #msgs_div .unread_divider hr { border-top: 1px solid #003340; }
+  #msgs_div .unread_divider .divider_label { background: #002b36; color: #003340; }
+  #msgs_div .unread_divider.no_unreads hr { border-top-color: #00232c; }
+  #msgs_div .unread_divider.no_unreads .divider_label { color: #2aa198; }
+  .channel_archive_messages.card .col:first-child { border-right: 1px solid #003340; }
+  .star { color: #2aa198; }
+  .star_item { border-bottom: 1px solid #00171d; }
+  .star_item .star_meta { color: #2aa198; }
+  .bot_message .message_sender { color: #a1adad; }
+  .bot_message .message_sender a { color: #a1adad; }
+  .color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #a1adad; }
+  #msgs_scroller_div #end_display_div #end_display_status { color: #2aa198; }
+  #msgs_scroller_div #end_display_div #end_display_meta { color: #2aa198; }
+  #msgs_scroller_div #end_display_div #end_display_meta h1 { color: #a1adad; }
+  #msgs_scroller_div #end_display_div p { color: #a1adad; }
+  .member_mentions_options { background-color: #00171d; border-top: 1px solid #00232c; }
+  .dm_badge .dm_badge_meta { color: #a1adad; }
+  .dm_badge a { color: #268bd2; }
+  .dm_badge a.member_preview_link { color: #268bd2; }
+  .dm_badge .dm_badge:hover a { color: #268bd2; }
+  .dm_badge .hint { color: #2aa198; }
+  #toggle-subscription-status .subscription_desc { color: #2aa198; }
+  .bot_label { background: #00171d; color: #2aa198; }
+  @keyframes to-grey { 0% { color: inherit; }
+    100% { color: #2aa198; } }
+  @keyframes fade-background-highlight { 0% { background: #003340; }
+    100% { background: transparent; } }
+  @keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #003340, 0 0 0 0.5px #003f50; }
+    100% { box-shadow: 0 0 4px 0 #003340, 0 0 0 0 #003f50; } }
+  .c-message_attachment { color: #a1adad; }
+  .c-message_attachment__border { background-color: #003340; }
+  .c-message_attachment__delete { color: #268bd2; }
+  .c-message_attachment__delete:hover { color: #dc322f; }
+  .c-message_attachment__pretext { color: #a1adad; }
+  .c-message_attachment__part + .c-message_attachment__part::before { color: #003340; }
+  .c-message_attachment__author .c-message_attachment__autor--distinct { color: #268bd2; }
+  .c-message_attachment__author_link + .c-message_attachment__author_link { color: #268bd2; }
+  .c-message_attachment__title_link span { color: #a1adad; }
+  .c-message_attachment__text_expander { color: #268bd2; }
+  .c-message_attachment__footer { color: #268bd2; }
+  .c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(0, 23, 29, 0.1) inset; }
+  .c-message_attachment__video_html { background-color: rgba(0, 43, 54, 0.4); }
+  .c-message_attachment__video_buttons { background: rgba(0, 23, 29, 0.4); }
+  .c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #a1adad; }
+  .c-message_attachment__video_play, .c-message_attachment__video_link { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+  .c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #a1adad; }
+  .c-message_attachment__media_trigger .c-expandable_trigger { color: #268bd2; }
+  .c-message_attachment__media_trigger--too_large { color: #268bd2; }
+  .c-message_attachment__select { border-color: #00171d; }
+  .c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #003340; }
+  .c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #002b36; border-color: #00171d; }
+  .c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #2aa198; }
+  .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #003340; }
+  .c-message__reply_bar_description { color: #2aa198; }
+  .c-message__file_meta { color: #2aa198; }
+  .c-message__image_container { background: rgba(0, 23, 29, 0.1); }
+  .c-message__image_wrapper:after { border-color: transparent; }
+  .attachment_group.has_container { background: #002b36; border: 1px solid #00232c; }
+  .attachment_group.has_container .inline_attachment::after { background-color: #00232c; }
+  .attachment_group.has_container.has_link:hover { border-bottom-color: #00232c; border-left-color: #00232c; border-right-color: #00232c; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .attachment_group .media_caret { color: #2aa198; }
+  .attachment_group .attachment_source span { color: #2aa198 !important; }
+  .attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #2aa198; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #2aa198; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #00232c; }
+  .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #2aa198; }
+  .attachment_group .attachment_title a { color: #a1adad; }
+  .attachment_group .attachment_footer_text + .attachment_ts::before { color: #2aa198; }
+  .attachment_group .delete_attachment_link ts-icon::before { color: #268bd2; }
+  .attachment_group .delete_attachment_link:hover ts-icon::before { color: #dc322f; }
+  .attachment_still_pending ts-inline-saver { color: #2aa198; }
+  .msg_inline_attachment_column.column_border { background-color: #003340; }
+  .msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #00171d; }
+  .msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #268bd2; }
+  .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #dc322f; }
+  .msg_inline_img { background: #003340; }
+  .msg_inline_room_preview_collapser { color: #2aa198; }
+  .msg_inline_room_preview_collapser:hover { color: #2aa198; }
+  .inline_attachment span.attachment_author_name { color: #268bd2; }
+  .inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #268bd2; }
+  .inline_attachment a span:active, .inline_attachment a span:hover { color: #dc322f !important; }
+  .inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #268bd2; }
+  .inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #268bd2; }
+  .inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #dc322f !important; }
+  .inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #dc322f !important; }
+  .inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #00171d; }
+  .meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #268bd2 !important; }
+  .meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #268bd2 !important; }
+  .meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #dc322f !important; }
+  .meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #dc322f !important; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #a1adad; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #2aa198; }
+  .meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #268bd2 !important; }
+  .delete_attachment_link { color: #268bd2; }
+  .delete_attachment_link:hover { color: #dc322f; }
+  .file_container, .c-file_container { background: #00171d; border: 1px solid #00232c; color: #a1adad; }
+  .file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #00232c; border-left-color: #00232c; border-right-color: #00232c; }
+  .file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: -moz-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: -o-linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); background-image: linear-gradient(top, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+  .file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #002b36; box-shadow: 0 0 0 3px #002b36; color: #a1adad; }
+  .file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #00232c; }
+  .file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #00171d; color: #a1adad; }
+  .file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #2aa198; }
+  .file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #00171d; }
+  .file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #00232c; color: #a1adad !important; }
+  .file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #00171d; }
+  .file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(0, 63, 80, 0.9); color: #a1adad !important; }
+  .file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #00171d; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #00232c; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #00232c; }
+  .file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #002b36; }
+  .file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(0, 63, 80, 0.9); }
+  .file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #00232c; }
+  .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(0, 63, 80, 0.9); border: 1px solid rgba(0, 23, 29, 0.1); }
+  .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(0, 51, 64, 0.8), rgba(0, 51, 64, 0.8)), linear-gradient(rgba(0, 63, 80, 0.3), rgba(0, 63, 80, 0.3)); color: #a1adad; }
+  .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(0, 51, 64, 0.8); color: #a1adad; }
+  .file_container .c-file__title, .c-file_container .c-file__title { color: #a1adad; }
+  .message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #003340; color: #a1adad; }
+  .msg_inline_video_buttons_div { background-color: rgba(0, 43, 54, 0.4); }
+  .msg_inline_video_buttons_div a { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+  .msg_inline_video_buttons_div a:visited { color: #a1adad; text-shadow: 0 1px 1px rgba(0, 23, 29, 0.5); }
+  .post_body ul.checklist { background-color: #00232c; }
+  .post_body ul.checklist li::before { background: #00232c; }
+  .post_body ul.checklist li.checked { color: #2aa198; }
+  .post_body ul.list.checklist li { border-bottom: 1px solid #003340; }
+  .post_body ul.list.checklist li.checked { color: #2aa198; }
+  .post_body .message { background-color: #a1adad; }
+  .post_body code, .post_body pre { background: #00232c; }
+  ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #2aa198; }
+  ts-message .reply_bar:hover { background: #002b36; border-color: #00171d; }
+  .inline_color_block { border-color: #003340; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #002b36; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #002b36; border-bottom: 1px solid #002b36; }
+  .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #002b36; }
+  .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #a1adad; }
+  .p-message_pane__limited_history_foreword { background: #00232c; background-image: none; color: #a1adad; }
+  .p-message_pane__unread_banner__banner { background: #003340; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner { color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner a { color: #a1adad; }
+  .messages_banner a:hover { color: #a1adad; }
+  #connection_div { background: #dc322f; }
+  #archives_return { background: padding-box #003f50; color: #a1adad; }
+  #archives_return.warning { background: #dc322f; }
+  #archives_return a { color: #a1adad; }
+  #archives_return a:hover { color: rgba(161, 173, 173, 0.8); }
+  #messages_unread_status { background: #003340; }
+  #messages_unread_status:hover { background: #003f50; }
+  #messages_unread_status:hover .clear_unread_messages { background: #003f50; }
+  #messages_unread_status:hover .clear_unread_messages:hover { background: #003340; }
+  #messages_unread_status.quiet { background: #003f50; color: #a1adad; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #messages_unread_status.quiet a { color: #a1adad; }
+  .clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+  #messages_container.has_top_messages_banner::before { background: none; }
+  .end_div_msg_lim { background-color: #00232c; background-image: none; }
+  #archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #a1adad; }
+  #archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(161, 173, 173, 0.8); }
+  code { background-color: #00171d; border: 1px solid #00232c; color: #a1adad; }
+  .file_list_item.snippet .snippet_preview { background: #00171d; }
+  .snippet_preview, .snippet_body { background: #00171d; }
+  .snippet_preview pre, .snippet_body pre { color: #a1adad !important; }
+  .file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #00232c; border-right: 1px solid #00232c; color: #2aa198; }
+  .c-snippet .c-file_container { background-color: #002b36; }
+  .c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #002b36); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+  .CodeMirror { background: #00171d; border: 1px solid #00232c; color: #a1adad !important; }
+  .CodeMirror pre { background: transparent !important; }
+  .CodeMirror div.CodeMirror-cursor { border-left: 1px solid #a1adad; }
+  .CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #a1adad; }
+  .CodeMirror .CodeMirror-gutters { background-color: #00232c; border-right: 1px solid #002b36; }
+  .CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #00232c; }
+  .CodeMirror-linenumber { color: #2aa198 !important; }
+  .CodeMirror-guttermarker { color: #2aa198; }
+  .CodeMirror-guttermarker-subtle { color: #2aa198; }
+  .CodeMirror-ruler { border-left: 1px solid #003f50; }
+  .cm-s-default .cm-keyword { color: #ce93d8; }
+  .cm-s-default .cm-atom { color: #9fa8da; }
+  .cm-s-default .cm-number { color: #a5d6a7; }
+  .cm-s-default .cm-def { color: #536dfe; }
+  .cm-s-default .cm-variable-2 { color: #9fa8da; }
+  .cm-s-default .cm-variable-3 { color: #c5e1a5; }
+  .cm-s-default .cm-comment { color: #ffcc80; }
+  .cm-s-default .cm-string { color: #ef9a9a; }
+  .cm-s-default .cm-string-2 { color: #ffab91; }
+  .cm-s-default .cm-meta { color: #eee; }
+  .cm-s-default .cm-qualifier { color: #eee; }
+  .cm-s-default .cm-builtin { color: #b39ddb; }
+  .cm-s-default .cm-bracket { color: #e6ee9c; }
+  .cm-s-default .cm-tag { color: #a5d6a7; }
+  .cm-s-default .cm-attribute { color: #40c4ff; }
+  .cm-s-default .cm-header { color: #80cbc4; }
+  .cm-s-default .cm-quote { color: #b0bec5; }
+  .cm-s-default .cm-hr { color: #00232c; }
+  .cm-s-default .cm-link { color: #268bd2; }
+  .cm-negative { color: #dc322f; }
+  .cm-positive { color: #859900; }
+  .cm-invalidchar, .cm-s-default .cm-error { color: #dc322f; }
+  div.CodeMirror span.CodeMirror-matchingbracket { color: #859900; }
+  div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #dc322f; }
+  .CodeMirror-matchingtag { background: #00171d; }
+  .CodeMirror-activeline-background { background: #003f50; }
+  .CodeMirror-selected { background: #003f50; }
+  .CodeMirror-focused .CodeMirror-selected { background: #003f50; }
+  .cm-searching { background: #003f50; }
+  .sssh-keyword { color: #ce93d8; }
+  .sssh-atom { color: #9fa8da; }
+  .sssh-number { color: #a5d6a7; }
+  .sssh-def { color: #536dfe; }
+  .sssh-variable { color: #9fa8da; }
+  .sssh-variable-2 { color: #c5e1a5; }
+  .sssh-variable-3 { color: #c1a5e1; }
+  .sssh-operator { color: #a1adad; }
+  .sssh-property { color: #a1adad; }
+  .sssh-comment { color: #ffcc80; }
+  .sssh-string { color: #ef9a9a; }
+  .sssh-string-2 { color: #ffab91; }
+  .sssh-meta { color: #eee; }
+  .sssh-error { color: #dc322f; }
+  .sssh-qualifier { color: #eee; }
+  .sssh-builtin { color: #b39ddb; }
+  .sssh-bracket { color: #e6ee9c; }
+  .sssh-tag { color: #a5d6a7; }
+  .sssh-attribute { color: #40c4ff; }
+  .sssh-header { color: #80cbc4; }
+  .sssh-quote { color: #b0bec5; }
+  .sssh-hr { color: #00232c; }
+  .sssh-link { color: #268bd2; }
+  .c-message--dense .c-timestamp__label { color: #268bd2; }
+  .c-message--dense .c-message__content_header .c-custom_status { border-color: #00232c; }
+  .dense_theme ts-message { color: #a1adad; }
+  .dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #268bd2; }
+  .dense_theme ts-message .message_content .message_current_status { border-color: #00232c; }
+  .c-message--light .c-message__sender .c-message__sender_link { color: #a1adad; }
+  .light_theme ts-message { color: #a1adad; }
+  .light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #a1adad !important; }
+  .light_theme ts-message .comment::before { color: #2aa198; }
+  .channel_overlay { border-color: #00232c; color: #2aa198; }
+  .channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #a1adad; }
+  .channel_overlay.channel_overlay_redesign li { color: #2aa198; }
+  .channel_overlay_title_wrap { border-color: #00232c; }
+  .channel_overlay_title_shared { color: #a1adad; }
+  pre { background: #00171d; border: 1px solid #00232c; color: #a1adad; }
+  pre span.mention { padding: 2px 0 !important; }
+  #page pre, body > pre { background: #00171d; color: #a1adad !important; }
+  body > pre { background: #003f50; }
+  .special_formatting_quote .quote_bar { background-color: #003340; }
+  #threads_msgs_scroller_div { background: #002b36; }
+  #threads_msgs_scroller_div:not(.loading)::before { background: #002b36; }
+  #threads_msgs_scroller_div.loading::before { color: #2aa198; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #00232c; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #003340; color: #a1adad; }
+  #threads_msgs_scroller_div.loading { background: none; }
+  #threads_msgs_scroller_div.loading::before { color: #a1adad; }
+  #threads_view_banner.messages_banner { background: #00232c; }
+  #threads_view_banner.messages_banner:hover { background: #003340; }
+  #threads_view_banner.messages_banner:hover .clear_unread_messages { background: #003340; }
+  #threads_msgs.new_banner_is_showing::before { background: #002b36; }
+  ts-thread { background: #002b36; }
+  ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #00232c; color: #a1adad; }
+  ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #00232c; border-color: #00232c; }
+  ts-thread .thread_messages { background: #00232c; border-color: #00232c; }
+  ts-thread ts-message.new_reply { background: #002b36; }
+  ts-thread ts-message.new_reply:hover { background: #00232c; }
+  ts-thread .thread_header .thread_channel_name a { color: #a1adad; }
+  ts-thread .thread_header .thread_action_btns button { color: #2aa198; }
+  ts-thread .new_reply_indicator .blue_dot { color: #dc322f; }
+  #convo_tab .thread_participants, ts-thread .thread_participants { color: #2aa198; }
+  #convo_loading_indicator { background-image: none; }
+  .reply_input_container .inline_message_input_container .ql-container { background-color: #003340; border: 1px solid #00232c; }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+  .reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #a1adad; }
+  .reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #2aa198; }
+  #file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #2aa198; }
+  #unread_msgs_scroller_div::after { background: transparent; }
+  #unread_msgs_scroller_div.loading { background-image: none; }
+  #unread_msgs_scroller_div.loading::before { color: #2aa198; }
+  #unread_msgs_div .day_divider .day_divider_line { border-top-color: #00232c; }
+  .unread_group.marked_as_read .unread_group_header { background: #002b36; }
+  .unread_group .unread_group_header { background: #00232c; border-top-color: #003340; color: #a1adad; }
+  .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #a1adad; }
+  .unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #2aa198; }
+  .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #002b36; }
+  .unread_group.active .unread_group_header { background: #00171d; border-top-color: #003340; color: #a1adad; }
+  .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #2aa198; }
+  .mark_as_read_checkmark { color: #2aa198; }
+  .bottom_mark_all_read { border-top-color: #00232c; }
+  .unread_group_header_name a { color: #a1adad; }
+  .unread_group_footer .unread_group_new .unread_group_new_text { color: #2aa198; }
+  .unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #2aa198; }
+  .unread_empty_state_message { color: #2aa198; }
+  .unread_empty_state_undo_inner { background: #00171d; color: #a1adad; }
+  .unread_empty_state_undo_action { color: #a1adad; }
+  .unread_empty_state_refresh { background: rgba(0, 43, 54, 0.97); }
+  .unread_msgs_loading { background: #002b36; background-image: none; }
+  #col_flex { background: transparent; }
+  #flex_contents { background: #002b36; }
+  #flex_contents .heading { background: #00171d; border-bottom-color: #00232c; color: #268bd2; }
+  #flex_contents .heading a { color: #268bd2; }
+  #flex_contents .heading a:hover { color: #dc322f; }
+  #flex_contents .heading a.close_flexpane { color: #268bd2; }
+  #flex_contents .heading .cancel_link { color: #268bd2; }
+  #flex_contents .heading .menu_heading:hover { color: #a1adad; }
+  #flex_contents .heading .menu_icon { color: #268bd2; }
+  #flex_contents .heading .menu_icon:hover { color: #dc322f; }
+  #flex_contents .heading_text { color: #268bd2; }
+  #flex_contents .subheading:not(.empty) { background: #002b36; border-top: 1px solid #00171d; color: #2aa198; }
+  #flex_contents .subheading:not(.empty) p a { color: #a1adad; }
+  #flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #2aa198; }
+  #flex_contents .toolbar_container { background: #002b36; }
+  #flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #268bd2; }
+  #flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #00232c; }
+  #flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #268bd2; }
+  #flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #00232c; }
+  #flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #268bd2; }
+  #flex_contents .help { border-top: 5px solid #00171d; color: #a1adad; }
+  #flex_contents i.callout { color: #2aa198; }
+  .close_flexpane { color: #2aa198; }
+  .close_flexpane:focus, .close_flexpane:hover { color: #a1adad; }
+  #client-ui.flex_pane_showing #col_flex { border-left-color: #00232c; }
+  .toolbar_container { background: #002b36; border-bottom: 1px solid #00171d; color: #a1adad; }
+  .msg_right_link { color: #268bd2; }
+  .message_location_label { color: #2aa198; }
+  .p-flexpane_header { background: #00232c; border-color: #003340; color: #a1adad; }
+  #client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #00232c; }
+  #details_tab .heading { background: #00171d; }
+  #details_tab .heading a.close_flexpane { color: #268bd2; }
+  #details_tab .heading a.close_flexpane:hover { color: #dc322f; }
+  #details_tab hr { border-top-color: #00232c; }
+  #details_tab .conversation_details .member_name:hover { color: #2aa198; }
+  #details_tab .conversation_details .member_username:hover { color: #a1adad; }
+  #details_tab .conversation_details .member_info_timezone { border-top-color: #003340; }
+  #details_tab .channel_page_section { background: #002b36; border-top: 1px solid #00232c; }
+  #details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #dc322f; }
+  #details_tab .channel_page_section .section_header a { color: #268bd2; }
+  #details_tab .channel_page_section .section_title { color: #a1adad; }
+  #details_tab .channel_page_section .disclosure_triangle { color: #268bd2; }
+  #details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(220, 50, 47, 0.25) !important; }
+  #details_tab .created_by { color: #a1adad; }
+  #details_tab .channel_page_member_tabs .icon_member_header { color: #2aa198; }
+  #details_tab .pinned_item:hover { border-color: #003340; }
+  #details_tab .channel_page_action .leave_link { color: #268bd2; }
+  #details_tab .channel_page_action .leave_link:hover { color: #dc322f; }
+  #details_tab .channel_section_label .ts_icon_info_circle { color: #2aa198; }
+  #details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #2aa198; }
+  .channel_page_member_row { color: #a1adad; }
+  .channel_page_member_row a { color: #268bd2; }
+  .channel_page_member_row.away { color: #a1adad; }
+  .channel_page_member_row.away a { color: #268bd2; }
+  .channel_page_member_row:hover { background-color: #003340; border-color: #00232c; }
+  .pinned_item { color: #a1adad; }
+  .pinned_item .pin_file_title { color: #268bd2; }
+  .pinned_item .pin_member_name a { color: #268bd2 !important; }
+  .pinned_item .pin_metadata { color: #2aa198; }
+  .pinned_item .remove_pin { color: #268bd2; }
+  .pinned_item .remove_pin:hover { color: #dc322f; }
+  .pinned_item .pinned_message_text .pin_truncate_fade { background: #002b36; }
+  .pinned_item.delete_mode { border-color: #dc322f !important; }
+  .c-channel_insights__title { color: #a1adad; }
+  .c-channel_insights__section:not(.c-channel_insights__section--no_border) { border-color: #003340; }
+  .c-channel_insights__drawer_title { color: #2aa198; }
+  .c-channel_insights__item--user .member_preview_link, .c-channel_insights__item--user .message_sender { color: #a1adad !important; }
+  .c-channel_insights__user_title { color: #2aa198; }
+  .c-channel_insights__channel .channel_link { color: #a1adad; }
+  .c-channel_insights__member_count { color: #2aa198; }
+  .c-channel_insights__member_count .ts_icon_user { color: #2aa198; }
+  .c-channel_insights .c-member__title { color: #2aa198; }
+  .c-channel_insights__activity { border-color: #003340; }
+  .c-channel_insights_activity_bar_container:hover { background-color: rgba(0, 23, 29, 0.05); }
+  .c-channel_insights_activity_bar_container:hover .c-channel_insights__activity_bar { background-color: #003340; }
+  .c-channel_insights__activity_bar { background-color: rgba(0, 51, 64, 0.5); }
+  .c-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #002b36; border-color: #003340; }
+  .c-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #002b36 90%); }
+  .c-channel_insights__highlights_description { color: #2aa198; }
+  .c-channel_insights__date_heading span { background-color: #002b36; color: #a1adad; }
+  .c-channel_insights__date_heading::before { background-color: #003340; }
+  #file_list_toggle_users { color: #268bd2; }
+  #file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #dc322f; }
+  #file_list_toggle_users.active { color: #2aa198; }
+  .file_list_item .icon, .file_reference .icon { background: #003f50; border: 1px solid #003340; color: #a1adad !important; }
+  .filetype_button { background: #003f50; border: 1px solid #003340; color: #a1adad !important; }
+  .filetype_button:hover { background: #003f50; }
+  .filetype_button:hover .file_download_label { background: #003340; color: #a1adad; }
+  .filetype_button .file_title { color: #a1adad; }
+  .filetype_button .file_download_label { background: #003f50; border-top: 1px solid #003340; }
+  a.filetype_button_web { background: #003f50; border: 1px solid #003340; color: #a1adad; }
+  a.filetype_button_web .filetype_icon { background-color: #003340; }
+  a.file_download_link { color: #268bd2; }
+  a.file_download_link:hover { color: #dc322f; }
+  a:hover .file_inline_icon { color: #2aa198; }
+  a.gsheet img, a.pdf img { background: #002b36 !important; }
+  html.no_touch a.filetype_button_web:hover { border-color: #003340; }
+  html.no_touch a.filetype_button_web:hover .file_title { color: #a1adad; }
+  .file_header_detailed { color: #2aa198; }
+  .file_header_detailed .member { color: #a1adad !important; }
+  .file_inline_icon { color: #2aa198; }
+  .file_header .member { color: #2aa198 !important; }
+  .file_header .title { color: #a1adad; }
+  .file_header .title a { color: #268bd2; }
+  .file_header .title a:hover { color: #dc322f; }
+  .flexpane_file_title .member, .flexpane_file_title .service_link { color: #268bd2 !important; }
+  .flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #268bd2; }
+  .flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #dc322f; }
+  .file_actions_cog { color: #268bd2 !important; }
+  .file_actions_cog:hover { color: #dc322f !important; }
+  .file_list_item { color: #a1adad; }
+  .file_list_item a { color: #268bd2; }
+  .file_list_item a.member { color: #dc322f; }
+  .file_list_item .bullet { color: #2aa198; }
+  .file_list_item .icon { background: #003f50; border-color: #003340; }
+  .file_list_item .ts_icon_comment { color: #2aa198; }
+  .file_list_item .file_comment_link:hover { color: #268bd2; }
+  .file_list_item .file_comment_link:hover .ts_icon_comment { color: #2aa198; }
+  .file_list_item .title a { color: #268bd2; }
+  .file_list_item .share_info .unshare_link { color: #268bd2; }
+  .file_list_item .share_info .unshare_link:hover { color: #dc322f; }
+  .file_list_item .actions a, .file_list_item .actions span { background-color: #00232c; border: 1px solid #003f50; color: #268bd2; }
+  .file_list_item .actions a:hover { background-color: #002b36 !important; border-color: #003f50; color: #dc322f; }
+  .file_list_item.post .preview, .file_list_item.space .preview { color: #a1adad; }
+  .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #00232c; border-color: #003340; }
+  .file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #268bd2; }
+  .file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+  .file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #00232c; }
+  .unshare_link { color: #268bd2 !important; }
+  .unshare_link i::before { color: #2aa198 !important; }
+  .unshare_link i.ts_icon_minus_circle_small:hover::before { color: #dc322f !important; }
+  .snippet_preview pre { color: #a1adad; }
+  .file_preview_wrapper .file_preview { background: #002b36; }
+  .file_preview_wrapper .file_preview:hover { background: #00232c; }
+  #file_preview_container .file_meta { color: #2aa198; }
+  .file_page_meta { color: #2aa198; }
+  #file_page_preview img { background: #002b36; border: 1px solid #00171d; }
+  #file_page_preview img:hover { background: #00232c; }
+  .comment_meta { color: #2aa198; }
+  .comment .special_formatting_quote .content { color: #a1adad; }
+  .comment .member { color: #a1adad !important; }
+  .comment_body { color: #a1adad; }
+  .comment_actions { color: #2aa198; }
+  .comment_actions:hover { color: #a1adad; }
+  .icon_quote { color: #a1adad; }
+  .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #003340; border-color: #00232c; color: #a1adad; }
+  .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #00232c; }
+  .tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #002b36; }
+  .tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #00232c; }
+  .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+  .tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #002b36; border-color: #00232c; }
+  .tab_container .file_list_item .star { color: #2aa198; }
+  .tab_container .file_list_item .contents .file_comment_link { color: #268bd2; }
+  .tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #268bd2; }
+  .tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #dc322f; }
+  .tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #dc322f; }
+  .tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #2aa198; }
+  .tab_container .file_list_item .filetype_image { background-color: #00171d; }
+  .active .tab_container .file_list_item { background-color: #002b36; }
+  .c-file__actions { background: #003340; }
+  .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #003340; border-color: #00232c; color: #fff; }
+  .p-file_details__name, .p-file_details__share_channel { color: #a1adad; }
+  .p-file_details__meta_container .c-file__action_button { color: #fff; }
+  .c-pillow_file_container { background: #003340; border-color: #00232c; color: #a1adad; }
+  .c-pillow_file__description, .c-pillow_file__title { color: #a1adad; }
+  #user_groups_pane .mention { background: rgba(220, 50, 47, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+  #user_groups_container .info_panel { background: #002b36; border: 1px solid #003340; }
+  #user_groups_container .mention { background-color: rgba(220, 50, 47, 0.25) !important; }
+  #user_groups_header .user_groups_search .icon_search { color: #2aa198; }
+  #user_groups_header a.icon_close { color: #268bd2; }
+  #user_groups_header a.icon_close:hover { color: #dc322f; }
+  .user_group_item { border-bottom: 1px solid #003340; }
+  .user_group_item a { color: #268bd2; }
+  #flex_contents .user_group_item:hover { background-color: #002b36; }
+  #flex_contents .user_group_item:hover h4 { color: #a1adad; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #002b36; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #a1adad; }
+  .user_group_invite_member_small .add_icon { color: #2aa198; }
+  #user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #003f50; border-color: #003f50; }
+  #flex_contents .subheading:not(.empty)#mentions_options { background-color: #002b36; border-bottom-color: #00232c; color: #a1adad; }
+  .mention_day_container_div .day_divider::before { background: none; border-color: #00232c; }
+  #member_mentions h3 a { color: #268bd2; }
+  a.internal_member_link { background: #00232c; color: #a1adad; }
+  a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #00232c; border: 1px solid #003340; color: #a1adad; }
+  a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #002b36; color: #a1adad; }
+  .mention_rxn .mention_rxn_summary { color: #a1adad; }
+  .mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #2aa198; }
+  .search_message_result { background: #002b36 !important; border-color: #00232c !important; color: #a1adad !important; }
+  .search_message_result .search_message_result_meta { color: #2aa198; }
+  .search_message_result .search_message_result_meta a { color: #268bd2; }
+  .search_message_result .search_message_result_meta .date_links a { color: #268bd2; }
+  .search_message_result_text .result_msg_format a { color: #268bd2; }
+  span.match { background: rgba(220, 50, 47, 0.25); }
+  #search_filters .tab { background: #002b36; color: #a1adad; }
+  #search_filters .tab:hover { border-bottom: 4px solid #00232c; }
+  #search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #00232c; color: #a1adad; }
+  #search_file_list_toggle_users.active:hover { border: 2px solid #dc322f; color: #dc322f !important; }
+  .no_results { color: #a1adad; }
+  #search_results_team .team_results_heading { color: #a1adad; }
+  #search_results_team .team_result { background-color: #003340; border-color: #003f50; color: #a1adad; }
+  #search_results_team .team_result a { color: #268bd2; }
+  #search_results_team .team_result:hover a { color: #dc322f; }
+  #search_results_team .team_result a:hover { color: #dc322f; }
+  #search_results_team .member_name { color: #a1adad !important; }
+  .suggestion { color: #a1adad; }
+  .suggestion.active, .suggestion:hover { background: #003340; }
+  #paging_in_options .search_paging { color: #2aa198; }
+  #search_results_items .search_paging { color: #a1adad; }
+  .search_paging i.disabled { color: #2aa198; }
+  .search_paging a { color: #268bd2; }
+  .search_paging a:hover { color: #dc322f; }
+  .search_sort_prefix { color: #a1adad; }
+  .search_segmented_control { border-color: #00232c; color: #268bd2 !important; }
+  .search_segmented_control:hover { color: #dc322f !important; }
+  .search_segmented_control.active { background: #00171d; color: #dc322f !important; }
+  .search_result_with_extract { background: #00232c; border-color: #003340; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+  .search_result_with_extract:hover { border-color: #003f50; }
+  .search_result_for_context::after { background: rgba(0, 43, 54, 0.1); }
+  .extract_expand_text, .extract_expand_icons { color: #268bd2; }
+  .search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #dc322f; }
+  .search_module_header { color: #a1adad; }
+  .search_module_footer { background-color: #00232c; border-bottom-color: #003340; border-left-color: #003340; border-right-color: #003340; }
+  .search_module_footer p { color: #a1adad; }
+  .search_module_footer #see_more { color: #a1adad; }
+  .search_module_footer #see_more a { color: #a1adad; }
+  .search_module_footer .top_results_feedback a { color: #a1adad; }
+  .search_module_footer ts-icon { color: #a1adad; }
+  .top_results_search_message_result { background-color: #00232c; border-bottom-color: #003340; border-left-color: #003340; border-right-color: #003340; }
+  .top_results_search_message_result.duplicate { background-color: #00232c; }
+  .top_results_search_message_result .timestamp { color: #2aa198; }
+  .top_results_search_message_result .channel { color: #2aa198; }
+  .top_results_search_message_result .channel a { color: #2aa198; }
+  .top_results_search_message_result .jump { color: #a1adad; }
+  .top_results_search_message_result:hover { border-color: rgba(0, 63, 80, 0.6) !important; border-top: 2px solid #003340 !important; }
+  .top_results_search_message_result:first-child { border-top: 2px solid #003340; }
+  .sli_expert_search { background-color: #002b36; color: #a1adad; }
+  .sli_expert_search__result { border-color: #003340; }
+  .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #a1adad !important; }
+  .sli_expert_search__fg_face::before { background-color: #002b36; }
+  .sli_expert_search_cta { border-color: #003340; }
+  .sli_expert_search_cta:hover { border-color: #003f50; }
+  .sli_expert_search_cta__text { color: #a1adad; }
+  .sli_expert_search_cta__text:hover { color: #a1adad; }
+  .sli_expert_search__plus_sign_overlay { background-color: #00232c; color: #2aa198; }
+  .sli_expert_search__arrow { color: #2aa198; }
+  .sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #2aa198; }
+  .sli_expert_search__partial_terms { color: #2aa198; }
+  .feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #00232c; color: #a1adad; }
+  .feature_sli_file_search #search_results .file_list_item { background-color: #002b36; border-color: #003340; }
+  .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #002b36; }
+  .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #002b36; border-color: #003340; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #003340; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #003340; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #003340; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #003340; }
+  .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #a1adad; }
+  .feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #a1adad; }
+  .feature_sli_file_search #search_results.all { background-color: #002b36; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #002b36; border-color: #003340; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #003340; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #003f50; }
+  .feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #003f50; }
+  .feature_sli_file_search #search_results.all .team_result { background-color: #002b36; border-color: #003340; }
+  .feature_sli_file_search #search_results.files { background-color: #002b36; }
+  .feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #a1adad; }
+  .feature_sli_file_search #search_results_loading { background-color: #002b36; }
+  .feature_sli_file_search #search_results_container #search_options { background-color: #002b36; }
+  .feature_sli_file_search #search_results_container .heading { background-color: #002b36; }
+  #client-ui .file_list_item.file_list_item--redesign { border-color: #003340; }
+  #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #2aa198; }
+  #client-ui .file_list_item.file_list_item--redesign .message_sender { color: #2aa198; }
+  .p-shortcuts_flexpane__shortcut { border-color: #00171d; }
+  .p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #00171d; }
+  .p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #a1adad; }
+  .p-shortcuts_flexpane__shortcut_title { color: #2aa198; }
+  .p-shortcuts_flexpane__title { color: #a1adad; }
+  .p-shortcuts_flexpane__tip { color: #2aa198; }
+  .p-shortcuts_flexpane__section_description { color: #2aa198; }
+  .p-shortcuts_flexpane__sub_heading { color: #2aa198; }
+  .c-keyboard_key { background: #003340; border-color: #003f50; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #a1adad; }
+  .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #268bd2; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #dc322f; }
+  #member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #268bd2; }
+  #member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #dc322f; }
+  #member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #268bd2 !important; }
+  #member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #003f50 !important; color: #dc322f !important; }
+  #member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #a1adad; }
+  #member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #268bd2 !important; }
+  #member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #dc322f !important; }
+  #member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #00171d; color: #2aa198; }
+  #member_preview_scroller { background-color: #00232c; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #00232c; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(161, 173, 173, 0.35) !important; }
+  #team_tab #member_preview_scroller { background-color: #002b36; }
+  #member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #a1adad; }
+  #member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #a1adad; }
+  #member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #2aa198; }
+  #member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #268bd2; }
+  #member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #dc322f; }
+  #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #268bd2; }
+  #member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #00232c; }
+  #disabled_members_tab a { color: #268bd2; }
+  #disabled_members_tab a:hover { background: #002b36; color: #dc322f; }
+  #disabled_members_tab.active a { color: #268bd2; }
+  .team_list_item { border-top: 1px solid #003340; color: #268bd2; }
+  .team_list_item .member_name { color: #a1adad; }
+  #client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #a1adad !important; }
+  #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #00232c !important; }
+  #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #003340 !important; }
+  #client-ui .searchable_member_list .team_list_item { border-bottom-color: #00171d; }
+  #client-ui .searchable_member_list .team_list_item:hover { background: #003340; }
+  .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #a1adad !important; }
+  #convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #a1adad; }
+  #convo_tab textarea.message_input { color: #a1adad; }
+  #reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #00232c; color: #a1adad; }
+  #reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #00171d; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #a1adad; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #2aa198 !important; }
+  #reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #002b36; color: #2aa198; }
+  #convo_container .convo_flexpane_divider { border-top-color: #00232c; color: #2aa198; }
+  #convo_container .convo_flexpane_divider .reply_count { background: #002b36; }
+  #convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #268bd2; }
+  #convo_tab .message_input, #convo_tab textarea#msg_text { color: #a1adad; }
+  ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+  ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+  #whats_new_tab p { color: #a1adad; }
+  #whats_new_tab .flex_heading_controls label { color: #2aa198; }
+  .c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #a1adad; }
+  .c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #a1adad; }
+  .c-member .external_team_badge { background-color: #003340; box-shadow: 0 0 0 2px #003340; }
+  .c-member .external_team_badge.default { background-color: #2aa198; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #003340; }
+  .c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #a1adad; }
+  .c-member--small .presence { color: #2aa198; }
+  .c-member--small .team_image.icon_16 { border-color: #00232c; }
+  .c-member--small .team_image.default { background-color: #2aa198; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member--dark .c-member__current-status { color: #2aa198; }
+  .c-member--dark .c-member__current-status::before { color: #2aa198; }
+  .c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #2aa198; }
+  .c-member--dark .c-member__display-name, .c-member--dark .presence { color: #a1adad; }
+  .c-member--medium { color: #2aa198; }
+  .c-member--medium .presence { color: #2aa198; }
+  .c-member__secondary-name--medium { color: #a1adad; }
+  .c-member--large { color: #2aa198; }
+  .c-member__display-name--large, .c-member__title--large { color: #a1adad; }
+  .c-member__other-names--large { color: #2aa198; }
+  .c-usergroup--small .c-usergroup__icon { background-color: #2aa198; color: #a1adad; }
+  .c-usergroup__not-in-channel-context--small { color: #2aa198; }
+  .p-emoji_picker { background: #00171d !important; color: #a1adad !important; }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #002b36; }
+  .p-emoji_picker__group_tabs { border-bottom-color: #002b36; }
+  .p-emoji_picker__group_tab { color: #268bd2; }
+  .p-emoji_picker__group_tab:hover { background: #00232c; color: #dc322f; }
+  .p-emoji_picker__group_tab--active { background: #003340; border-bottom-color: #002b36; color: #a1adad; }
+  .p-emoji_picker__icon_search { color: #2aa198; }
+  .p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #002b36; border-color: #002b36; }
+  .p-emoji_picker__skintone_options { background: #002b36; }
+  .p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #2aa198; }
+  .p-emoji_picker__tip { color: #a1adad; }
+  .p-emoji_picker__no_results { color: #2aa198; }
+  .p-emoji_picker__preview_text { background: #00171d; color: #a1adad; }
+  .p-emoji_picker__footer { background: #00171d; border-top-color: #00232c; }
+  .p-emoji_picker__footer .p-emoji_picker__heading { background: #00171d; }
+  .p-emoji_picker__emoji_deluxe_label { color: #2aa198; }
+  input[type="text"].p-emoji_picker__input:focus { border-color: #003340; box-shadow: none; }
+  #message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #2aa198; }
+  #message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #a1adad; }
+  #message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #a1adad; }
+  #message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #a1adad; }
+  .current_status_emoji_picker { border-right-color: #00232c; }
+  .current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #00171d; }
+  .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #2aa198; }
+  .rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #00232c; border: 1px solid #003340; }
+  .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #002b36; }
+  .rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #a1adad; }
+  .rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(0, 43, 54, 0.08); border-color: rgba(0, 63, 80, 0.4) !important; }
+  .rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #a1adad; }
+  .rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #a1adad; }
+  .rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(161, 173, 173, 0.25); }
+  a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #b58900; color: #00232c; }
+  .modal { background-color: #002b36; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  .modal .close, .modal label { color: #a1adad; }
+  .modal_input_note, .modal_input_note_full_width, .input_note_special { color: #2aa198; }
+  .modal-footer { background: padding-box #002b36; border-top: 1px solid transparent; box-shadow: none; }
+  .modal-header { background: padding-box #00171d; border-bottom: 1px solid #00232c; color: #a1adad; }
+  .modal-backdrop { background-color: #002b36; }
+  .close { color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  #fs_modal_bg { background: #002b36; }
+  #fs_modal { background: #002b36; }
+  #fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #a1adad; }
+  #fs_modal #fs_modal_sidebar a { color: #a1adad; }
+  #fs_modal #fs_modal_sidebar a:hover { background: #00232c; }
+  #fs_modal #fs_modal_sidebar a.active { background: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #fs_modal .fs_modal_btn { color: rgba(161, 173, 173, 0.5); }
+  #fs_modal .fs_modal_btn:hover { background: #003f50; color: #a1adad; }
+  #fs_modal .fs_modal_btn:active { background: #003f50; color: #a1adad; }
+  #fs_modal.fs_modal_header .fs_modal_btn:active { color: #a1adad; }
+  #fs_modal #fs_modal_footer { background-color: #00232c; }
+  .p-apps_browser__apps_list--loading::before { background-color: #00232c; }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #003340; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #00232c; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+  .p-apps_browser__category_header { background: #002b36; color: #2aa198; }
+  .p-apps_browser__app { border-top-color: #003340; }
+  .p-apps_browser__app--selected { background: #00232c; border-color: #003f50; }
+  .p-apps_browser__app_info { color: #a1adad; }
+  .p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #003340; border-color: #003f50; color: #a1adad; }
+  .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #003f50; color: #a1adad; }
+  .p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__app_description { color: #2aa198; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #2aa198; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #a1adad; }
+  #incoming_call { background-color: rgba(0, 23, 29, 0.97); color: #a1adad; }
+  #fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #00232c; }
+  #fs_modal.channel_options_modal .convert_to_shared label { color: #2aa198; }
+  #fs_modal.channel_options_modal .channel_option_item { border-top-color: #00232c; }
+  #fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #a1adad; }
+  #fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(0, 23, 29, 0.75); border-color: #00232c; }
+  #channel_invite_container .lfs_list_container .lfs_item { border-top-color: #00232c; }
+  #channel_invite_container .lfs_list_container .lfs_item.active { border-color: #00232c; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #00232c; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #2aa198; }
+  #channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #002b36; border-color: #00232c; }
+  #channel_prefs_dialog { color: #a1adad; }
+  #at_channel_warning_dialog { background-color: #002b36; }
+  #at_channel_warning_dialog.fullsize { background-color: #002b36; }
+  #at_channel_warning_dialog.fullsize .modal-body { background-color: #002b36; }
+  .channel_prefs_modal_header { color: #a1adad; }
+  .channel_prefs_body__section_header_title { color: #a1adad; }
+  .channel_prefs_body__section_header_icon::before { color: #a1adad; }
+  .channel_prefs_body__mute_help_text { color: #2aa198; }
+  .channel_prefs_notifications_table { border-bottom-color: #00232c; color: #a1adad; }
+  .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #003340 !important; }
+  .channel_prefs__muting_checkbox_label { color: #a1adad; }
+  .channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #a1adad !important; }
+  .notification_prefs_icon::before { color: #a1adad; }
+  .channel_modal_header { color: #a1adad; }
+  #channel_browser .channel_browser_row { border-top: 1px solid #00232c; color: #a1adad; }
+  #channel_browser .channel_browser_row_header { color: #a1adad; }
+  #channel_browser .channel_browser_creator_name { color: #2aa198; }
+  #channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #2aa198; }
+  #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #00171d; border: 1px solid #003340; }
+  #channel_browser .channel_browser_divider { background: transparent; color: #2aa198; }
+  #channel_browser .channel_browser_sort_container::after { color: #a1adad; }
+  #channel_browser .channel_browser_channel_purpose { color: #a1adad; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #268bd2; }
+  .channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #2aa198 !important; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #00171d; color: #a1adad; }
+  #invite_members_container .lfs_input_container { background: #003340; }
+  #notifications_not_working p.highlight_yellow_bg a { color: #a1adad; }
+  #im_browser .im_browser_row { border-top: 1px solid #003340; }
+  #im_browser .im_browser_row.multiparty { color: #a1adad; }
+  #im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #00171d; }
+  #im_browser .im_browser_row .im_unread_cnt { background: #dc322f; color: #a1adad; }
+  #im_browser .im_browser_row.disabled { color: #2aa198; }
+  #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser #im_browser .im_browser_row.highlighted { background: #00171d !important; border: 1px solid #003340 !important; }
+  #im_browser_tokens { background: #003340; border: 1px solid #003f50; }
+  #im_browser_tokens.active { border-color: #003f50; box-shadow: 0 0 7px rgba(0, 63, 80, 0.15); }
+  #im_browser_tokens .member_token { background: #002b36; border: 1px solid #00171d; color: #a1adad; }
+  #im_browser_tokens .member_token.ra { background: #dc322f; }
+  .fs_modal_file_viewer_header { background-color: #00232c; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .fs_modal_file_viewer_header .btn { color: #a1adad; }
+  .fs_modal_file_viewer_header .star { color: #2aa198; }
+  .fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #a1adad; }
+  .fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #a1adad; }
+  .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #2aa198; }
+  .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #003340; }
+  .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #2aa198; }
+  .fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #003340; }
+  .fs_modal_file_viewer_content .viewer { background-color: #00171d; color: #a1adad !important; }
+  .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #003340; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(0, 63, 80, 0.25); color: #a1adad; }
+  .fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(42, 161, 152, 0.8); }
+  .fs_modal_file_viewer_content .aside_panel { background-color: #002b36; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #00171d; }
+  .fs_modal_file_viewer_content .no_comment { background-color: #002b36; color: #2aa198; }
+  .fs_modal_file_viewer_content .aside_close_btn { color: #a1adad; }
+  .fs_modal_file_viewer_content #file_comment { color: #a1adad; }
+  #file_comment_textarea.texty_comment_input { background: #002b36; border-color: #00232c; color: #a1adad; }
+  #file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #00232c; }
+  #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #2aa198; }
+  #fs_modal.help_modal .help_modal_header { background-color: #00232c; border-color: #003340; }
+  #fs_modal.help_modal .help_modal_header a { color: #a1adad; }
+  #fs_modal.help_modal .help_modal_divider { color: #2aa198; }
+  #fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #00232c; }
+  #fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #2aa198; }
+  #fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #00232c; border-color: #00171d; }
+  .admin_invites_account_type_option { border-bottom: 1px solid #00232c; }
+  .admin_invites_account_type_option p { color: #a1adad; }
+  .admin_invites_account_type_option .option_arrow { color: #2aa198; }
+  .admin_invites_account_type_option:hover:not(.disabled) h3 { color: #a1adad; }
+  .admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+  .admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(0, 43, 54, 0.95); }
+  .admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #2aa198; }
+  .admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #dc322f; }
+  .admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(220, 50, 47, 0.4); }
+  #admin_invites_channel_picker_container { border-bottom: 1px solid #00232c; }
+  #admin_invites_add_row { background: #003340; border: 1px solid #00232c; }
+  #admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #003340; }
+  #channel_invite_tokens { background-color: #003340; border-color: #003f50; }
+  #channel_invite_tokens.active { border-color: #2aa198; box-shadow: 0 0 7px rgba(42, 161, 152, 0.15); }
+  #channel_invite_tokens .member_token { background: #002b36; color: #a1adad; }
+  #channel_invite_tokens .member_token.ra { background: rgba(220, 50, 47, 0.4); }
+  #admin_invites_alert { background: #003340; border-color: #003f50; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #a1adad; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #002b36; color: #a1adad; }
+  #shortcuts_dialog { background: rgba(0, 43, 54, 0.95); text-shadow: 0 1px 1px rgba(0, 23, 29, 0.7); }
+  #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #a1adad; }
+  #shortcuts_dialog.modal ul ul { border-left-color: #003340; }
+  #shortcuts_dialog.modal .info_block { color: #2aa198; }
+  #shortcuts_dialog.modal .close { background: #003340; border-color: #003f50; box-shadow: 0 1px 2px rgba(0, 23, 29, 0.5); color: #a1adad; }
+  #shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(0, 23, 29, 0.9); }
+  #fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #2aa198; }
+  #fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #00232c; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #00232c; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #002b36; border: 1px solid #00232c; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #dc322f; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+  #fs_modal.prefs_modal legend { color: #a1adad; }
+  #fs_modal.prefs_modal .global_notification_block { background: #002b36; border-color: #00171d; }
+  #fs_modal.prefs_modal .global_notification_block.selected { background: #00232c; border-color: #00171d; }
+  #fs_modal.prefs_modal .channel_overrides_row { border-top-color: #00171d; }
+  #fs_modal.prefs_modal .channel_overrides_row:hover { background: #00232c; border-color: #00171d; }
+  #fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #a1adad; }
+  #fs_modal.prefs_modal .notification_example.mac { background: #00171d; box-shadow: 0 1px 8px 2px #00232c; }
+  #fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #00171d; color: #a1adad; }
+  #fs_modal.prefs_modal .badge_example { background: #dc322f; }
+  #fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #00171d; border-top-color: #00171d; }
+  #fs_modal.prefs_modal .display_real_names_block_sample { background: #002b36; }
+  .sidebar_menu_list_item { border: 0; color: #a1adad; }
+  .sidebar_menu_list_item.is_active { background-color: #00171d; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .sidebar_menu_list_item:not(.is_active):hover { background-color: #00232c; }
+  .jumbomoji_pref_disabled { color: #2aa198; }
+  .jumbomoji_disabled_note { color: rgba(42, 161, 152, 0.6); }
+  #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #003340; border: 1px solid #00171d; }
+  #edit_team_profile_container .lazy_filter_select.disabled { background: #003340; }
+  #edit_team_profile_container .lazy_filter_select.disabled input { background: #003340; }
+  #edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #00232c; }
+  #edit_team_profile_list .row:nth-last-child(2):hover { border-color: #00232c !important; }
+  #edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #00232c; border: 1px solid #00171d; }
+  #edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #2aa198; }
+  #edit_team_profile_list .edit_team_profile_list_controls i { color: #a1adad; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #2aa198; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #2aa198; }
+  #edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #003340; }
+  #edit_team_profile_add .row:last-child { border-bottom: 1px solid #003340; }
+  #edit_team_profile_add .row:not(.header_row):hover { background: #00232c; border: 1px solid #00171d; }
+  #edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #a1adad; }
+  #edit_team_profile_add .row:not(.header_row):hover i { border-color: #00171d; color: #a1adad; }
+  #edit_team_profile_add i { color: #2aa198; }
+  #edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #2aa198; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #00171d; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #dc322f; border-color: #dc322f !important; color: #a1adad; }
+  #edit_team_profile_edit .row i { border: 1px solid #00171d; color: #a1adad; }
+  #edit_team_profile_custom .row .col .profile_field_preview { background: #00232c; border: 2px solid #00171d; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #00232c; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #2aa198; }
+  #edit_team_profile_custom .row .col input { background: #003340; border: 1px solid #00171d; }
+  #edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #2aa198; }
+  #edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #00171d; }
+  .profile_field_preview_protector .profile_field_preview { background: #002b36; border: 1px solid #003340; }
+  .profile_field_preview_protector .profile_field_preview::after { background-color: #002b36; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview::before { background-color: #002b36; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #003340; color: #2aa198; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #00171d, rgba(255, 255, 255, 0)); }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #00171d; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #00171d transparent transparent; }
+  ts-jumper ts-jumper-container { background: #002b36; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #002b36; color: #2aa198; }
+  ts-jumper input[type=text] { border: 1px solid #00171d !important; color: #a1adad; }
+  ts-jumper input[type=text]:focus { border: 1px solid rgba(0, 35, 44, 0.8) !important; color: #a1adad; }
+  ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #a1adad; }
+  ts-jumper ol li { color: #a1adad; }
+  ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #2aa198; }
+  ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #2aa198; }
+  ts-jumper ol li .unread_count { background: #dc322f; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  ts-jumper ol li.highlighted { background: #003f50 !important; color: #a1adad !important; }
+  ts-jumper ol:not(.keyboard_active) li:hover { background: #003f50 !important; color: #a1adad !important; }
+  ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #a1adad; }
+  .basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+  .share_dialog_attachment_container { color: #a1adad; }
+  #share_dialog .file_list_item { border-color: #00171d; }
+  #generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198; }
+  #share_dialog_input_container #file_comment_textarea.ql-container { border-color: #00232c; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #003340; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #a1adad; }
+  .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #003340; }
+  .ts_tip .ts_tip_tip { color: #a1adad; }
+  .ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #003340; }
+  .ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #003340; }
+  .ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #003340; }
+  .ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #003340; }
+  .ts_tip.success .ts_tip_tip { background: #003f50; }
+  .ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #003f50; }
+  .ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #003f50; }
+  .ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #003f50; }
+  .ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #003f50; }
+  .c-tooltip__tip { background-color: #003340; color: #a1adad; }
+  .c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #003340; }
+  .c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #003340; }
+  .c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #003340; }
+  .c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #003340; }
+  .c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+  .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+  .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #003340; }
+  .c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #003340; }
+  .c-tooltip__tip--success { background-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #859900; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #003340; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #003340; }
+  #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(0, 63, 80, 0.5) !important; }
+  #coachmark_interior { color: #a1adad; }
+  #coachmark_interior .coachmark_close_btn { color: #a1adad; }
+  .menu_member_header { background: #00171d; }
+  .menu_member_header .member_details .member_name_and_presence { color: #a1adad; }
+  .menu_member_header .member_details .member_name_and_presence .member_name { color: #a1adad; }
+  .menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+  .menu_member_header .member_details .member_title { color: #2aa198; }
+  .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #2aa198; }
+  .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #268bd2; }
+  .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #dc322f; }
+  .menu_member_header .member_details_divider { border-color: #003340; }
+  .menu_member_footer { background: #00171d; border-top: 1px solid #003340; }
+  .menu_member_footer p { color: #2aa198; }
+  .member_meta { color: #268bd2; }
+  .mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #a1adad !important; }
+  .greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #2aa198 !important; }
+  .clear_blue { color: #268bd2 !important; }
+  .moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #dc322f !important; }
+  .seafoam_green { color: #859900 !important; }
+  .candy_red_bg { background-color: #dc322f !important; }
+  .off_white_bg, .neutral_white_bg { background-color: #00232c !important; }
+  .yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #002b36 !important; }
+  .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #003340 !important; }
+  .sk_black { color: inherit; }
+  .monkey_scroll_bar { z-index: 99; }
+  .client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+  nav.top.persistent { background: #00232c; }
+  nav.top.persistent .logo { background-position: 50% 0 !important; }
+  .widescreen #header_team_name a i { margin-left: 1.5em; }
+  .widescreen #user_menu { border-right: none; }
+  header #menu_toggle { color: #268bd2; }
+  header #header_team_nav { background: #00232c; border: 1px solid #00171d; }
+  header #header_team_nav li.active a { background: #002b36; color: #a1adad; }
+  header .header_btns a { color: #268bd2; }
+  header .header_btns a .label { color: #2aa198; }
+  header .vert_divider { border-left: 1px solid #00171d; }
+  footer, #autocomplete_menu.search_menu footer.unified { background-color: #00232c; border-color: #00171d; color: #a1adad; }
+  footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #a1adad; }
+  footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #a1adad; }
+  .plastic_row h3 { color: #a1adad; }
+  .plastic_row h4 a { color: #a1adad; }
+  .plastic_row .icon { color: #a1adad; }
+  .plastic_row .chevron { color: #2aa198; }
+  .plastic_row .description { color: #a1adad; }
+  .plastic_row:active { background: #002b36; border-color: #00171d; }
+  .plastic_row:active .chevron { color: #a1adad; }
+  html.no_touch .plastic_row:hover { background: #002b36; border-color: #00171d; }
+  html.no_touch .plastic_row:hover .chevron { color: #a1adad; }
+  html.no_touch .pagination ul > li > a:hover { background-color: #00171d; }
+  html.no_touch .pagination ul > .disabled > a:hover { background: #00232c; color: #2aa198; }
+  html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #dc322f; }
+  .card, .tab_pane { background: #00232c; border: 1px solid #00171d; color: #a1adad; }
+  .card h3 a { color: #a1adad; }
+  #page_contents .card { background: rgba(0, 35, 44, 0.8) !important; }
+  #page_contents .card p { color: #a1adad; }
+  .tab_set a.secondary { color: #268bd2; }
+  .tab_set a.selected, .tab_set a.secondary.selected { background: #00232c; border: 1px solid #00171d; border-bottom-color: #00232c; color: #dc322f; }
+  .tab_actions { background: #00232c; border: 1px solid #00171d; border-color: #00171d; }
+  .accordion_section { border-bottom-color: #002b36; }
+  .accordion_section h4 { color: #a1adad; }
+  .accordion_section h4 a { color: #a1adad; }
+  .no_touch .accordion_section h4 a:hover { color: #a1adad; }
+  .accordion_section_fixed { border-bottom-color: #002b36 !important; }
+  .pager li > a, .pager li > span { background-color: #002b36; background-image: none; border-color: #00232c; color: #268bd2; }
+  .pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+  .pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+  .pager .disabled > a, .pager .disabled > span { color: #2aa198; }
+  .pagination ul > li > a, .pagination ul > li > span { background: #00232c; border: 1px solid #00171d; color: #a1adad; }
+  .pagination ul > li > a:focus { background-color: #00171d; }
+  .pagination ul > .active > a, .pagination ul > .active > span { background-color: #00171d; }
+  .pagination ul > .disabled > span { background: #00232c; color: #2aa198; }
+  .pagination ul > .disabled > a { background: #00232c; color: #268bd2; }
+  .pagination ul > .disabled > a:focus { background: #00232c; color: #dc322f; }
+  .loading_hash_animation img { display: none; }
+  .icon_search_close { color: #268bd2; }
+  .icon_search_close:hover { color: #dc322f; }
+  .help { border-top-color: #00171d; color: #2aa198; }
+  .two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+  .two_factor_choice { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  .two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  .two_factor_choice:hover .two_factor_link { color: #a1adad; }
+  a.two_factor_choice { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:link { background-color: #00232c; border: 1px solid #003340; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #a1adad; }
+  .backup_codes { background: #00171d; border-color: #003340; color: #a1adad; }
+  #channel_specific_settings tr { border-top-color: #002b36; }
+  #channel_specific_settings tr.channel_override_row.muted td { background: rgba(0, 43, 54, 0.5); }
+  #channel_specific_settings .extra_left_border { border-left-color: #002b36; }
+  #channel_specific_settings .extra_right_border { border-right-color: #002b36; }
+  #channel_specific_settings .revert_to_default { color: #2aa198; }
+  #channel_specific_settings .revert_to_default:hover { color: #dc322f; }
+  .admin_list_item { border-bottom-color: #002b36; color: #2aa198; }
+  .admin_list_item:hover { background-color: #00232c; }
+  .admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #a1adad; }
+  .admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #2aa198; }
+  .admin_list_item .pill.group { background: #002b36; }
+  .admin_list_item .two_factor_auth_badge:hover { background: #002b36; }
+  .admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+  .admin_list_item.invite_item.bouncing { background: #003f50; }
+  .admin_list_item.invite_item.bouncing .email { color: #dc322f; }
+  .admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #002b36; }
+  .admin_list_item.expanded .btn_outline { border-color: #002b36; color: #a1adad !important; }
+  .admin_list_item.expanded .btn_outline:hover { border-color: #00232c; color: #a1adad !important; }
+  .admin_list_item.expanded .sub_action { color: #268bd2; }
+  .admin_list_item.expanded .sub_action:hover { color: #dc322f; }
+  @media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #268bd2; } }
+  .billing_selection { border-color: #00171d; color: #a1adad !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection:hover { border-color: #003f50; }
+  .billing_selection.active { background: #003340; border-color: #003f50; }
+  .billing_selection.billing_selection--refactor { border-color: #003340; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection.billing_selection--refactor:hover { border-color: #003f50; }
+  .billing_selection.billing_selection--refactor.active { background: #003340; border-color: #003f50; }
+  .billing_selection .billing_selection__price { color: #a1adad; }
+  #billing_contacts_container { background: #00232c; border-top: 1px solid #00171d; }
+  .billing_contact { border-bottom: 1px solid #002b36; }
+  table.billing tr:hover td { background: #00232c; }
+  .link_billing_statement { color: #a1adad !important; }
+  .link_invoice_id, .link_statement_id { color: #268bd2 !important; }
+  .billing_invoice tbody tbody tr { color: #a1adad !important; }
+  .billing_settings_label_name { color: #a1adad; }
+  table tr { border-bottom-color: #002b36; }
+  table tr:first-child th:not(:only-of-type) { border-bottom-color: #00171d; }
+  .slackbot_response_fieldset .delete_response { color: #2aa198; }
+  .slackbot_response_fieldset .delete_response:hover { color: #dc322f; }
+  .author_cell { color: #a1adad; }
+  .message_cell.disabled { color: #2aa198; }
+  #message_container #msg_limit { color: #a1adad; }
+  .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #003340; }
+  .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #003340; }
+  .inactive { background-image: none; }
+  .c3 line, .c3 path { stroke: #003f50; }
+  .c3-chart-arc .c3-gauge-value { fill: #003f50; }
+  .c3-chart-arc path { stroke: #00232c; }
+  .c3-chart-arc text { fill: #00232c; }
+  .c3-chart-arcs .c3-chart-arcs-background { fill: #003340; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #00232c; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #003f50; }
+  .c3-circle._expanded_ { stroke: #00232c; }
+  .c3-grid line { stroke: #003f50; }
+  .c3-grid text { fill: #a1adad; }
+  .c3-legend-background { fill: #00232c; stroke: #003340; }
+  .c3-region { fill: #003340; }
+  .c3-selected-circle { fill: #00232c; }
+  .c3-tooltip { background-color: #00232c; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+  .c3-tooltip td { background-color: #00232c; border-left-color: #003340; }
+  .c3-tooltip th { background-color: #00232c; color: #a1adad; }
+  .c3-tooltip tr { border-color: #003340; }
+  .ent_alert a { color: #268bd2; }
+  .ent_alert a:link, .ent_alert a:visited { color: #dc322f; }
+  .ent_alert_page.ent_alert_error { background: #dc322f; }
+  .ent_alert_page.ent_alert_success { background: #859900; }
+  .ent_analytics__disclaimer { border-top-color: #003f50; color: #2aa198; }
+  .ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+  .ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+  .ent_avatar { background-color: #003340; }
+  .ent_callout__difference--increase { color: #859900; }
+  .ent_callout__icon_border { background-color: #00232c; border-color: #003f50; }
+  .ent_callout__icon_image, .ent_callout__icon--filled { border-color: #003f50; }
+  .ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #003340; }
+  .ent_callout__icon--limit_reached { border-color: #003f50; }
+  .ent_callout__insight { color: #2aa198; }
+  .ent_callout__limit { color: #2aa198; }
+  .ent_callout__meter_bar_container { background: #002b36; }
+  .ent_callout__meter_bar_border { border-color: #002b36; }
+  .ent_callout__meter_bar_fill--empty { background: #003f50; border-color: #003f50; }
+  .ent_callout__meter_bar_fill--filled { background: #003f50; border-color: #003f50; }
+  .ent_callout__meter_bar_fill--limit_reached { background: #dc322f; border-color: #dc322f; }
+  .ent_callout__meter_bar_gleam { background: rgba(0, 63, 80, 0.5); }
+  .ent_callout__title { color: #a1adad; }
+  .ent_copy_muted { color: #2aa198; }
+  .ent_copy { color: #a1adad; }
+  .ent_csv_popover__footer_text { color: #2aa198; }
+  .ent_csv_popover__footer { background: #00232c; border-top-color: #003f50; }
+  .ent_csv_popover__subtitle { color: #2aa198; }
+  .ent_csv_popover__title { color: #a1adad; }
+  .ent_data_table__cell--header { color: #2aa198; }
+  .ent_data_table__cell--positive { color: #a1adad; }
+  .ent_data_table__cell--sortable:hover { background-color: #00232c; }
+  .ent_data_table__cell--sorting { color: #2aa198; }
+  .ent_data_table__cell { border-bottom-color: #003f50; color: #a1adad; }
+  .ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #003f50; }
+  .ent_data_table__column_group { background-color: #00232c; }
+  .ent_data_table__data_link, a.ent_data_table__data_link { color: #a1adad; }
+  .ent_data_table__row--hovered { background-color: #002b36; }
+  .ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+  .ent_data_table__secondary_text { color: #2aa198; }
+  .ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #00232c; }
+  .ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #003f50; }
+  .ent_data_table--rounded_top { border-top-color: #003f50; }
+  .ent_data_table { border-bottom-color: #003f50; border-left-color: #003f50; border-right-color: #003f50; }
+  .ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #a1adad; }
+  .ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #2aa198; }
+  .ent_graph__legend_item--defocus { fill: #2aa198 !important; }
+  .ent_graph__legend_text { fill: #a1adad; }
+  .ent_graph__svg_container .c3-axis path { stroke: #003f50; }
+  .ent_graph__svg_container .c3-grid line { stroke: #003f50; }
+  .ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #003f50; }
+  .ent_graph__svg_container .c3-tooltip { border-color: #003f50; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+  .ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #00232c; color: #a1adad; }
+  .ent_graph__svg_container .c3-tooltip th { border-bottom-color: #003f50; }
+  .ent_graph__svg_container .c3-xgrid-focus line { stroke: #2aa198; }
+  .ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #00232c !important; }
+  .ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #00232c !important; }
+  .ent_graph__svg_container text { fill: #2aa198; }
+  .ent_graph__tooltip { color: #2aa198; }
+  .ent_graph_empty__overlay { background: #00232c; }
+  .ent_graph_empty__text { color: #a1adad; }
+  .ent_graph_header--primary { color: #a1adad; }
+  .ent_graph_header--secondary { color: #2aa198; }
+  .ent_graph_tabs__tab--selected { color: #a1adad; }
+  .ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #003f50; }
+  .ent_graph_tabs__tab { color: #2aa198; }
+  .ent_graph_tabs { border-bottom-color: #003f50; }
+  .ent_header { color: #a1adad; }
+  .ent_icon_button { color: #2aa198; }
+  .ent_icon_button:hover { color: #a1adad; }
+  .ent_infographic_container { border-top-color: #003f50; }
+  .ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(0, 35, 44, 0.8), #00232c); }
+  .ent_modal__title--small { color: #a1adad; }
+  .ent_modal_background { background-color: #002b36; }
+  .ent_modal_breadcrumb_animated_step { background: #003340; }
+  .ent_modal_breadcrumb_circle_icon { background: #002b36; }
+  .ent_modal_breadcrumb_line { background: #003340; }
+  .ent_modal_breadcrumb_text { color: #2aa198; }
+  .ent_modal_footer { background-color: #00232c; }
+  .ent_modal_title { color: #a1adad; }
+  .ent_table__header--title { color: #a1adad; }
+  .ent_table__header { background-color: #002b36; border-color: #003f50; }
+  .ent_table_banner__contents { background: #002b36; border-top-color: #003f50; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+  .ent_table_banner__header { color: #a1adad; }
+  .ent_table_banner__secondary_text { color: #2aa198; }
+  .ent_table_customizer__header_subtitle { color: #2aa198; }
+  .ent_table_customizer_disabled_list_header { color: #2aa198; }
+  .ent_table_customizer_footer { background-color: #002b36; border-top-color: #00171d; color: #2aa198; }
+  .ent_table_customizer_header { border-bottom-color: #002b36; }
+  .ent_table_customizer_list_item--disabled { color: #2aa198; }
+  .ent_updated_at { color: #2aa198; }
+  .enterprise { background-color: #00232c; }
+  .enterprise .btn.candy_red { color: #dc322f !important; }
+  .enterprise_analytics { background-color: #00232c; }
+  .enterprise_org { background-color: #00232c; }
+  .enterprise_search_bar .ent_clear_search_icon { color: #2aa198; }
+  .enterprise_search_bar::before { color: #a1adad; }
+  @keyframes color_fade { from { color: #2aa198; }
+    to { color: #a1adad; } }
+  .file_header .title a { color: #268bd2; }
+  .file_header .title a:hover { color: #dc322f; }
+  .file_actions_cog { color: #268bd2 !important; }
+  .file_actions_cog:hover { color: #dc322f !important; }
+  .file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #00171d; }
+  .action_cog { color: #268bd2; }
+  .action_cog i { color: #268bd2; }
+  html.no_touch .action_cog:hover { color: #dc322f; }
+  html.no_touch .action_cog:hover i { color: #dc322f; }
+  .help_pages.help_pages p { color: #a1adad; }
+  .help_pages.help_pages a { border-bottom-color: #003340; }
+  .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #002b36; }
+  .help_pages.help_pages .o-hero__header { color: #a1adad; }
+  .help_pages.help_pages .o-section--feature { background-color: #00232c; border-top-color: #003340; }
+  .help_pages.help_pages .c-form__container .c-form__feedback { color: #dc322f; }
+  .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #002b36; border-color: #003340; color: #a1adad; }
+  .help_pages.help_pages .drop_zone { background: #002b36; border-color: #003f50; }
+  .help_pages.help_pages .drop_zone_attachment { border-bottom-color: #003340; }
+  .help_pages.help_pages .drop_zone_remove_attachment { background-color: #002b36; }
+  .help_pages.help_pages .c-form__notice { background-color: #003340; border-color: #003f50; color: #a1adad; }
+  .help_pages.help_pages .c-form__notice.is-error { border-left-color: #dc322f; }
+  .help_pages.help_pages .c-nav--footer { border-top-color: #003340; }
+  @media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #002b36; } }
+  .widescreen:not(.nav_open) { color: #a1adad; }
+  @media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(0, 43, 54, 0.9); } }
+  .widescreen:not(.nav_open) nav#site_nav h3 { color: #a1adad; }
+  .widescreen:not(.nav_open) nav#site_nav ul a { color: #268bd2; }
+  .widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #dc322f; }
+  .widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #2aa198; }
+  nav#site_nav { background: #00232c; }
+  nav#site_nav #user_menu_contents:hover { background: #002b36; color: #a1adad; }
+  header { background: #00232c; }
+  header #header_team_nav li a { color: #a1adad; }
+  header #header_team_nav li a:hover { background: #002b36; color: #a1adad; }
+  header #header_team_nav li a .team_icon.ts_icon_plus { background: #00171d; color: #2aa198; }
+  header #header_team_nav #add_team_option { border-top: 1px solid #00171d; }
+  html.no_touch header #header_team_nav li a { color: #a1adad; }
+  html.no_touch header #header_team_nav li a:hover { background: #002b36; color: #a1adad; }
+  html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #dc322f; }
+  html.no_touch header .header_btns a:hover { color: #dc322f; }
+  html.no_touch header .header_btns a:hover .label { color: #2aa198; }
+  nav#site_nav h3, #header_team_name, header #header_team_name a { color: #268bd2; }
+  nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #dc322f; }
+  #home_footer a { color: #dc322f; }
+  .admin_pref:not(:first-of-type) { border-top-color: #002b36; }
+  .admin_pref.locked { background-color: rgba(220, 50, 47, 0.2); }
+  .admin_pref .admin_pref_locked_label { color: #2aa198; }
+  .tooltip-inner { background-color: #003f50; color: #a1adad; }
+  .tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #003f50; }
+  .tooltip.right .tooltip-arrow { border-right-color: #003f50; }
+  .tooltip.left .tooltip-arrow { border-left-color: #003f50; }
+  .tooltip.bottom .tooltip-arrow { border-bottom-color: #003f50; }
+  .api #header_logo img { display: none; }
+  body.api header .header_links a { color: #a1adad; }
+  body.api header .header_links a.active { background: #003340; }
+  body.api .reverse_header { background-color: #00171d; color: #a1adad; }
+  body.api pre { overflow-x: auto; }
+  body.api pre code { color: #a1adad; }
+  body.api #page_contents .card { background: #00232c; }
+  body.api .scopes_to_methods code { color: #a1adad; }
+  body.api .scopes_to_methods .selected code { color: #dc322f; }
+  body.api .scopes_to_methods li { color: #a1adad; }
+  body.api .scopes_to_methods .selected li { color: #a1adad; }
+  body.api .section_title { border-bottom: 2px solid #002b36; }
+  body.api .example { border: 1px solid #00171d; }
+  body.api .example h5 { background-color: #00171d; color: #a1adad; }
+  body.api .alert { background: #003340; }
+  body.api .hljs { background-image: none; }
+  body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+  body.api .hljs-number { color: #a5d6a7; }
+  body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+  body.api .hljs-variable { color: #9fa8da; }
+  body.api .hljs-template-variable { color: #c5e1a5; }
+  body.api .hljs-comment { color: #ffcc80; }
+  body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+  body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+  body.api .hljs-meta { color: #eee; }
+  body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+  body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+  body.api .hljs-tag { color: #a5d6a7; }
+  body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+  body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+  body.api .hljs-quote { color: #b0bec5; }
+  body.api .hljs-link, body.api .hljs-regexp { color: #268bd2; }
+  body.api span.btn { background-color: #002b36; }
+  body.api span.deprecation, body.api span.warning { background-color: #dc322f; border-color: #dc322f; }
+  nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #api_nav .footer_nav a { color: #268bd2; }
+  #api_nav .footer_nav a:hover { color: #dc322f; }
+  #api_nav .footer_nav .footer_signature { color: #dc322f; }
+  .api_articles .api_articles_section { border-bottom-color: #002b36; }
+  .api_articles .article_tag_count { color: #2aa198; }
+  .api.feature_related_content #api_related_content h2 { color: #a1adad; }
+  .api.feature_related_content #api_related_content .article_link_title_wrapper { color: #268bd2; }
+  .tab_menu { background-color: #00232c; }
+  .tab_menu.grey { background-color: #00232c; }
+  .tab_menu .tab { color: #a1adad; }
+  .tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(220, 50, 47, 0.4); }
+  .tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #dc322f; color: #a1adad; }
+  .tab_menu .tab:disabled { color: #2aa198; }
+  .page_faq h3, .page_scim h3 { background-color: #002b36; }
+  .application_config aside { color: #2aa198; }
+  .page_apps_directory_home { background-color: #002b36 !important; }
+  .page_apps_directory_home .nav_title { color: #a1adad !important; }
+  .page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #2aa198; }
+  .page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #003f50; }
+  .splash_container__background { background-color: #00232c; }
+  .splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+  .splash_interactive__button { border-color: #003340; }
+  .splash_interactive__button--active { box-shadow: 0 0 10px 1px #003f50; }
+  .splash_interactive__window { background-color: #002b36; border-color: #003340; }
+  .splash_interactive__window:hover .splash_interactive__window_headline { color: #a1adad; }
+  .splash_interactive__window::after { background: linear-gradient(to bottom, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+  .splash_interactive__window_response { background-color: #fff; }
+  a.splash_interactive__window_link { color: #a1adad; }
+  .splash_interactive__window_message_content_text--drive { color: #2aa198; }
+  .search_input.apps_search_input { border-color: #003f50; }
+  .menu_launcher, .menu_launcher_large { background-color: #003340; border-color: #002b36 !important; color: #a1adad; }
+  .menu_launcher_large { border-color: #002b36; }
+  .menu.avatar_menu ul li:hover ts-icon { background: #003340; color: #a1adad; }
+  .menu.avatar_menu ul li a { color: #a1adad; }
+  .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #003340; color: #2aa198; }
+  .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #a1adad; }
+  #page .media_list { background-color: #00232c; border: 1px solid #003340; }
+  #page .media_list > li + li::before { border-top-color: #003340; }
+  #page .media_list > li.interactive a { color: #a1adad; }
+  #page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #003340; border-color: #003f50; }
+  #page .media_list > li .media_list_text { color: #a1adad; }
+  #page .media_list.media_list_with_arrows a::before { color: #2aa198; }
+  #page .media_list_title { color: #a1adad; }
+  #page .media_list_subtitle { color: #2aa198; }
+  #page .sidebar_menu_list_item { color: #a1adad; }
+  #page .sidebar_menu_list_item.is_active { background-color: #002b36; border-color: #002b36; color: #a1adad; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #page .sidebar_menu_list_item.is_active a { color: #a1adad; }
+  #page .sidebar_menu_list_item:not(.is_active):hover { background-color: #002b36; border-color: #002b36; }
+  #page .sidebar_menu_list_item a { color: #a1adad; }
+  #page ul.breadcrumbs li { color: #2aa198; }
+  #page ul.breadcrumbs li:not(:first-child)::before { color: #2aa198; }
+  #page ul.navigation_list li a { color: #a1adad; }
+  #page ul.navigation_list li a:hover { background-color: #003340; }
+  #page ul.navigation_list li a::after { color: #a1adad; }
+  #page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+  #page .tag { background-color: #00171d; border: 1px solid #00232c; }
+  #page .tag:hover { background-color: #003340 !important; }
+  #page .app_desc_btn { background-color: #003340; color: #a1adad; }
+  #page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(0, 43, 54, 0) 0, #002b36 100%); }
+  #page .service_panel { background-color: #00232c; }
+  #page .service_card { background-color: #002b36; border: 1px solid #002b36; }
+  .app_card, .large_app_card { background-color: #002b36; border: 1px solid #00232c; }
+  nav.top.persistent ul a { color: #a1adad; }
+  nav.top.apps_nav { background: transparent; }
+  nav.top.apps_nav.persistent .nav_title { border-color: #003f50; }
+  nav.top.apps_nav.clear_nav .nav_title a { color: #a1adad; }
+  nav.top.apps_nav .nav_title a { color: #a1adad; }
+  nav.top.apps_nav ul a.active { color: #dc322f; }
+  .plastic_typeahead { background: #00232c; border: 1px solid #00232c; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+  .plastic_typeahead_item { color: #a1adad; }
+  .plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #003340; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #002b36; border-top-color: #00232c; color: #a1adad; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #2aa198; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #00171d; border-color: #003340; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #003340; }
+  a.plastic_typeahead_item { color: #a1adad; }
+  .apps_typeahead_item_media { background: #00171d; }
+  .search_input_container .search_input:focus ~ .icon_search_input { color: #a1adad; }
+  .icon_search_input { color: #2aa198; }
+  .quote_block { color: #a1adad; }
+  .quote_block::before { background-color: #003340; }
+  .well { background: #00171d; border-color: #000f12; color: #a1adad; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #2aa198; }
+  .c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #003340; }
+  .c-tabs__tab { color: #2aa198; }
+  .c-tabs__tab:hover { color: #a1adad; }
+  .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #003f50; color: #a1adad; }
+  .c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #003340; }
+  a.c-tabs__tab--plastic { color: #2aa198; }
+  a.c-tabs__tab--plastic:hover { color: #a1adad; }
+  a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #003f50; color: #a1adad; }
+  .p-detail_scope { box-shadow: inset 0 1px 0 0 #003340; }
+  .p-detail_scope:last-child { border-bottom-color: #003340; }
+  .p-detail_dangerous_scope { border-left-color: #dc322f; border-right-color: #003340; }
+  .p-detail_arrow_icon { color: #2aa198; }
+  .p-detail_arrow_icon:hover { color: #a1adad; }
+  .p-detail_permissions { background: #00232c; border-color: #003340; }
+  table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #003340; }
+  .section_rollup { border-bottom-color: #002b36; }
+  .section_rollup:first-of-type { border-top-color: #002b36; }
+  .section_rollup:hover:not(.is_active) { background: rgba(0, 43, 54, 0.5); color: #a1adad; }
+  .is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #859900; color: #00171d; }
+  .developer_apps_functionality_link:hover { border-color: #003340; box-shadow: 0 0 6px 0 rgba(0, 63, 80, 0.25); }
+  .developer_apps_functionality_link::before { background-color: #003340; }
+  .developer_apps_functionality_link_enabled::before { background-color: #859900; }
+  .legal-hero { background-color: #002b36; }
+  .legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #002b36; }
+  .legal-hero .o-hero__header__headline--larger { color: #a1adad; }
+  .legal-main { background-color: #00232c; }
+  .legal-main.v--no-switch { background-color: #00232c; border-bottom-color: #003340; border-top-color: #003340; }
+  .legal-main p { color: #a1adad; }
+  .legal-main a { border-bottom-color: #003340; }
+  @media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #a1adad; }
+    .legal-main .c-nav--sidebar__listitem a.is-selected { color: #2aa198; } }
+  .legal-main .t-contains-subtle-links a:not(.c-button) { color: #a1adad; }
+  .legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #2aa198; }
+  @media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #00232c; } }
+  .t-no-header .legal-hero.o-hero.v--short { background-color: #00232c; }
+  .c-oauth_scope_info__spacer_icon { color: #dc322f; }
+  .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #003340; }
+  .c-oauth_scope_info__dangerous_scopes { border-left-color: #dc322f; border-right-color: #003340; border-top-color: #003340; }
+  .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #003340; }
+  a.p-oauth_nav__anchor { color: #2aa198; }
+  .p-oauth_nav__team-switcher .menu_launcher { border-color: #00232c; }
+  .p-oauth_nav__team-switcher .menu_launcher:hover { border: #003340; }
+  .p-oauth_page, .p-oauth_page--error { background: #002b36; }
+  .p-oauth_page__title { color: #a1adad; }
+  .p-oauth_page_single_channel_picker { border-bottom-color: #00232c; }
+  ts-rocket { color: #a1adad; }
+  ts-rocket a { color: #268bd2; }
+  ts-rocket a caret::before { background-color: #00232c; border-color: #00232c; }
+  ts-rocket hr { border-color: #00232c; }
+  ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #00171d; }
+  ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #00171d; }
+  ts-rocket .cl.text { background-color: #00171d; border-bottom: 1px solid #00232c; }
+  ts-rocket .cl.text .checkbox.checked + li { color: #2aa198; }
+  ts-rocket > div > .checklist { background-color: #00171d; border-bottom: 1px solid #00232c; }
+  ts-rocket > div > .checklist .checkbox.checked + li { color: #2aa198; }
+  ts-rocket > div > .checklist li::before { background: #00232c; }
+  ts-rocket > div > .checklist li.checked { color: #2aa198; }
+  ts-rocket .unfurl .unfurl-container { background-color: #00171d; }
+  ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(220, 50, 47, 0.1); }
+  ts-rocket .unfurl .attachment_bar { background-color: #00232c !important; }
+  ts-rocket .unfurl .unfurl-remove::before { color: #2aa198; }
+  ts-rocket .unfurl .unfurl-remove:hover::before { color: #a1adad; }
+  ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(0, 63, 80, 0.5); }
+  ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(0, 63, 80, 0.5) !important; }
+  ts-rocket caret::before { background-color: #00232c; border: 1px solid #00232c; }
+  ts-rocket carriage { background-color: rgba(0, 63, 80, 0.5); }
+  ts-rocket selection { background-color: rgba(0, 63, 80, 0.5); }
+  ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(0, 63, 80, 0.5); }
+  ts-rocket ime { background-color: rgba(0, 63, 80, 0.5); }
+  ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(0, 63, 80, 0.5); }
+  .focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #00171d; }
+  nav { background: #00232c; }
+  nav .space { background-color: #00232c; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+  nav .space::after { border-left: 1px solid #003340; }
+  nav .comments { background-color: #00232c; }
+  nav .space_buttons .btn_outline { background-color: #002b36; }
+  nav .space_buttons .btn_outline::after { border-color: #003340; }
+  nav .space_btn_star { background: none; border: 0; }
+  nav .space_btn_star:hover { background: none !important; }
+  nav .space_btn_edit { background: #003340; }
+  nav .space_btn_edit.editing { background: #003f50; }
+  nav .star_info { color: #2aa198; }
+  nav #space_status { border-left: 1px solid #003340; color: #2aa198; }
+  nav #space_status.slightly_concerned { color: #dc322f; }
+  nav #edit_status { color: #2aa198; }
+  nav .comments_open.unread span.notif { background-color: #dc322f; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+  nav .comments_close { color: #2aa198; }
+  nav .comments_close:hover::before { color: #268bd2 !important; }
+  ts-space header { background: transparent; }
+  ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #a1adad; }
+  ts-space header .owner_detail .inline-edit { background: none; }
+  ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #a1adad; }
+  ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #a1adad; }
+  ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #2aa198; }
+  ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #2aa198; }
+  ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(0, 63, 80, 0.5); }
+  ts-space header .owner_detail small { color: #2aa198; }
+  ts-space header .divider { border-top: 1px solid #003340; }
+  ts-space a.feedback { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+  ts-space a.feedback:hover { background-color: #00232c; color: #a1adad; }
+  comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+  #space_alert { background-color: #00171d; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+  #space_alert.error { background-color: #dc322f; }
+  #space_alert span#space_alert_text { color: #a1adad; }
+  #space_alert a { color: #268bd2; }
+  #space_alert button#space_alert_close::before { color: #2aa198; }
+  #space_alert button#space_alert_close:hover::before { color: #2aa198; }
+  #space_alert .btn_outline.btn_transparent { background-color: #002b36 !important; color: #a1adad !important; }
+  #space_alert .btn_outline.btn_transparent::after { border-color: #003340; }
+  #space_find_bar { background-color: #00232c; border-bottom: 1px solid rgba(0, 63, 80, 0.1); border-left: 1px solid rgba(0, 63, 80, 0.07); border-right: 1px solid rgba(0, 63, 80, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #space_find_bar #space_find_info.no_matches { color: #dc322f; }
+  #space_find_bar #space_find_next .ts_icon { background-color: #003340; }
+  #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #a1adad; }
+  #space_find_bar #space_find_next:hover .ts_icon { background-color: #003f50; }
+  #space_find_bar #space_find_close::before { color: #2aa198; }
+  #space_find_bar #space_find_close:hover::before { color: #2aa198; }
+  #connected_members .connected_members_count { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+  #connected_members .toggle_more_members_popover { background: #002b36; color: #2aa198; }
+  #connected_members_overflow_popover { border-bottom: 1px solid #00232c; border-left: 1px solid rgba(0, 23, 29, 0.11); border-right: 1px solid rgba(0, 23, 29, 0.11); border-top: 1px solid rgba(0, 23, 29, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .arrow::after { background-color: #00232c; }
+  #connected_members_overflow_popover .arrow_shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .monkey_scroll_wrapper { background: #00232c; }
+  #connection_status #connection_label { color: #a1adad; text-shadow: -1px -1px 0 #00171d, -1px 1px 0 #00171d, 1px 1px 0 #00171d, 1px -1px 0 #00171d; }
+  #shortcuts_spaces_dialog { background-color: rgba(0, 23, 29, 0.8); text-shadow: 0 1px 1px rgba(0, 35, 44, 0.7); }
+  #shortcuts_spaces_dialog .modal-body { color: #a1adad; }
+  #shortcuts_spaces_dialog .col .keyboard { background-color: #003f50; border-bottom: 2px solid #002b36; box-shadow: 0 1px 2px rgba(0, 23, 29, 0.5); color: #a1adad; }
+  #shortcuts_spaces_dialog .close:hover { background-color: #003f50; }
+  #shortcuts_spaces_dialog .close .ts_icon::before { color: #2aa198 !important; }
+  .textstyle_menu .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #00232c; }
+  .textstyle_menu .arrow::after { background-color: #00232c; }
+  .textstyle_menu .content { background-color: #00232c; box-shadow: 0 0 0 1px #00232c, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .arrow-shadow::after { background-color: #00232c; }
+  .textstyle_menu.link .arrow::after { background-color: #00232c; }
+  .textstyle_menu.link .content { background-color: #00232c; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .content input[type=text] { background-color: #003340; }
+  .textstyle_menu.link .content > a.link { color: #268bd2; }
+  .textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #2aa198; }
+  .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #00232c; }
+  .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #003340; }
+  .textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #003340; border: 1px solid #003f50; }
+  .textstyle_menu.style a.deformat::before { border-left: 1px solid #003340; }
+  .textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #2aa198; }
+  .para_menu .insert .tip { color: #2aa198; }
+  .para_menu .insert .tooltip .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #003340; }
+  .para_menu .insert .tooltip .arrow::after { background-color: #00232c; }
+  .para_menu .insert .tooltip .content { background-color: #00232c; box-shadow: 0 0 0 1px #003340, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .arrow-shadow::after { background-color: #00232c; box-shadow: 0 0 0 1px #003340; }
+  .para_menu .format .options .arrow::after { background-color: #00232c; }
+  .para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #003340; }
+  .para_menu .format .options .content { background-color: #00232c; box-shadow: 0 0 0 1px #003340, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .content ul:first-child { border-bottom: 1px solid #00232c; }
+  .para_menu .format .options.show .tooltip > div { background-color: #00232c; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #a1adad; }
+  .para_menu .format .options.show .tooltip span { background-color: #003340; }
+  .para_menu .options a:hover { border: 1px solid #003340; }
+  .para_menu .options a.active { background-color: #002b36; border: 1px solid #00232c; }
+  .para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+  .para_menu .options a span { filter: grayscale(2) brightness(5); }
+  .para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+  .para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); } }

--- a/css/variants/solarized-light.css
+++ b/css/variants/solarized-light.css
@@ -1,0 +1,2036 @@
+@-moz-document regexp("https://[^./]*\\.slack\\.com/(?!pricing)(?!security).*") { body { background: #fdf6e3; color: #586e75; }
+  a { color: #268bd2; }
+  a:link, a:visited { color: #268bd2; }
+  a:hover, a:active, a:focus { color: #dc322f; }
+  hr { border-bottom: 1px solid #fdf6e3; border-top: 1px solid #fdf6e3; }
+  h1, h2, h3, h4 { color: #586e75; }
+  h1 a { color: #586e75; }
+  h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #586e75; }
+  .bordered { border: 1px solid #fcf3d9; }
+  .top_border { border-top: 1px solid #fcf3d9; }
+  .bottom_border { border-bottom: 1px solid #fcf3d9; }
+  .left_border { border-left: 1px solid #fcf3d9; }
+  .right_border { border-right: 1px solid #fcf3d9; }
+  .bullet { color: #2aa198; }
+  .alert, .c-alert, .c-alert--boxed { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .alert h4, .c-alert h4, .c-alert--boxed h4 { color: #586e75; }
+  .alert-info { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; }
+  .alert-info h4 { color: #586e75; }
+  ::-webkit-scrollbar-track { background: #fcf3d9 !important; border-left-color: #fcf3d9 !important; border-right-color: #fcf3d9 !important; color: #fcf3d9 !important; }
+  ::-webkit-scrollbar-thumb { background: #fef9ed !important; border-left-color: #fcf3d9 !important; border-right-color: #fcf3d9 !important; color: #fdf6e3 !important; }
+  ::-webkit-scrollbar-corner { background: #fdf6e3 !important; }
+  .supports_custom_scrollbar #messages_container::after { background: none !important; }
+  .monkey_scroll_bar { background: #fdf6e3; }
+  .monkey_scroll_handle_inner { background: #fef9ed; border: 1px solid #fffefb; }
+  .monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+  #client-ui .monkey_scroll_bar { background: #fdf6e3; }
+  #client-ui .monkey_scroll_handle_inner { background: #fef9ed; border: 3px solid #fdf6e3; }
+  .c-scrollbar--monkey .c-scrollbar__track { background: #fdf6e3; }
+  .c-scrollbar--monkey .c-scrollbar__bar { background: #fef9ed; box-shadow: 0 3px 0 #fdf6e3, 0 -3px 0 #fdf6e3; }
+  .client_channels_list_container { background-color: #fcf3d9; border-right-color: #fdf6e3; }
+  #col_channels { color: #586e75; }
+  .p-channel_sidebar { background-color: #fcf3d9; color: #586e75; }
+  .p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(88, 110, 117, 0.8) !important; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #586e75; }
+  .p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #fdf6e3 !important; }
+  .p-channel_sidebar__header { color: #586e75 !important; }
+  .p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #586e75; }
+  .p-channel_sidebar__channel--im .c-presence--away { color: #2aa198; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #fef9ed !important; }
+  .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #fef9ed !important; }
+  .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #586e75; }
+  .p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #586e75; }
+  .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #dc322f; }
+  .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #fef9ed; }
+  .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #657e86 !important; }
+  .p-channel_sidebar__close_container:hover { background: #fbeecb; }
+  .p-channel_sidebar__jumper { background: transparent !important; }
+  .channels_list_holder h2 { color: #586e75 !important; }
+  .channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #586e75; opacity: 0.8; }
+  .channels_list_holder ul { color: #586e75 !important; }
+  .channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #fcf3d9; color: rgba(88, 110, 117, 0.8) !important; }
+  .channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #fdf6e3 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+  .channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #fdf6e3; }
+  .channels_list_holder ul li.mention a { color: #586e75; }
+  .channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #657e86 !important; }
+  .channels_list_holder ul li.unread .prefix { color: #586e75 !important; opacity: 1; }
+  .channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #268bd2 !important; }
+  .channels_list_holder .unread_highlights { background: #dc322f; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .channels_list_holder .unread_msgs { background: #fdf6e3; color: #586e75; }
+  #channel_list_invites_link { border-bottom: 1px dotted #268bd2; color: #268bd2 !important; font-size: 0.9rem; }
+  #channel_list_invites_link:hover { border-bottom: 1px solid #268bd2; }
+  #quick_switcher_btn { background: #fcf3d9; border-top: 2px solid #fcf3d9; }
+  #quick_switcher_btn > i { color: #2aa198; }
+  #quick_switcher_btn:active, #quick_switcher_btn:hover { background: #fdf6e3; border-color: #fdf6e3; }
+  #quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #268bd2; }
+  #quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #268bd2; }
+  #quick_switcher_label { color: #2aa198; }
+  .loading #loading-zone { background: #fdf6e3; }
+  #loading_welcome { background-image: none; }
+  #loading_message p { color: #586e75; }
+  #loading_message #loading_message_attribution { color: #2aa198; }
+  #loading_team_menu_bg, #loading_user_menu_bg { background: #fdf6e3; border: none; }
+  .infinite_spinner_bg, .infinite_spinner_blue { stroke: #586e75; }
+  body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #fcf3d9; }
+  .p-degraded_list__loading { background-color: #fdf6e3; color: #586e75; }
+  input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #fef9ed; border-color: #fbeecb; color: #586e75; }
+  input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(252, 243, 217, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+  input[type=file]:focus { outline: #586e75 dotted thin; }
+  input[type=radio]:focus, input[type=checkbox]:focus { outline: #586e75 dotted thin; }
+  select { background: #fef9ed; }
+  select, textarea { border: 1px solid #fbeecb; color: #586e75; }
+  select:active, select:focus, textarea:active, textarea:focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(255, 254, 251, 0.15); }
+  input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #fdf6e3 !important; }
+  .no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #fcf3d9; }
+  .no_touch label.select:hover select { border-color: #fcf3d9; }
+  .no_touch label.select:not(.disabled):hover::after { color: #fcf3d9; }
+  label.disabled { color: #586e75; }
+  legend { border-bottom: 1px solid #fffefb; }
+  legend small { color: #2aa198; }
+  .uneditable-input, .uneditable-textarea { background-color: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+  .uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(255, 254, 251, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+  textarea { background-color: #fef9ed; border: 1px solid #fbeecb; color: #586e75; }
+  textarea:focus { border-color: rgba(255, 254, 251, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(255, 254, 251, 0.6); }
+  ::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  ::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  ::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  [data-placeholder]:empty::before { color: #586e75 !important; }
+  input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  input::-moz-placeholder, textarea::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  input::placeholder, textarea::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #586e75 !important; }
+  input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #fef9ed !important; }
+  .form-actions { background-color: #fdf6e3; border-top: 1px solid #fcf3d9; }
+  .help-block, .help-inline { color: #2aa198; }
+  .input-append .add-on, .input-prepend .add-on { background-color: #fffefb; border: 1px solid #fef9ed; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .btn { background-color: #fef9ed; color: #586e75 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #fef9ed; color: #586e75; }
+  .btn.btn_border { border: 2px solid #fdf6e3; }
+  .btn.disabled, .btn:disabled { background-color: #fbeecb !important; }
+  .btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #fbeecb !important; }
+  .btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #dc322f !important; color: #586e75 !important; }
+  .btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #fdf6e3 !important; border-color: #dc322f !important; color: #dc322f !important; }
+  .btn.btn_outline.disabled { background: #fdf6e3 !important; color: #268bd2 !important; }
+  .btn.btn_outline.disabled:hover { background: #fdf6e3 !important; color: #268bd2 !important; }
+  .btn.btn_attachment { border-color: #fef9ed; }
+  .btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #fcf3d9; border-color: #fffefb; }
+  .btn.btn_attachment.btn_danger { border-color: #dc322f; }
+  .btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e35d5b; }
+  .btn.btn_attachment.btn_primary { border-color: #fffefb; }
+  .btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: white; }
+  .btn_basic:focus, .btn_basic:hover { color: #586e75; }
+  .btn_outline { background: #fdf6e3; color: #268bd2 !important; }
+  .btn_outline::after { border: 1px solid #fdf6e3; }
+  .btn_outline.btn_transparent { color: rgba(254, 249, 237, 0.9) !important; }
+  .btn_outline.btn_transparent::after { border: 1px solid rgba(253, 246, 227, 0.5); }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(254, 249, 237, 0.9) !important; color: #dc322f !important; }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(254, 249, 237, 0.8) !important; }
+  .btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #fdf6e3; color: #dc322f !important; }
+  .btn_outline:active { color: #dc322f; }
+  .btn_outline.active { color: #dc322f !important; }
+  .btn_link { color: #268bd2; }
+  .btn_link:hover, .btn_link:focus { color: #dc322f; }
+  .btn-group.open .btn.dropdown-toggle { background-color: #fef9ed; }
+  .btn-group.open .btn-primary.dropdown-toggle { background-color: #fdf6e3; }
+  .btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+  .btn_info, .btn.btn_success { background-color: #fdf6e3 !important; }
+  .btn_warning, .btn_danger { background-color: #dc322f !important; }
+  .btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #586e75; border-top-color: #586e75; }
+  .input_note { color: #586e75; }
+  .c-enhanced_text_input { background-color: #fef9ed; border-color: #fcf3d9; color: #2aa198; }
+  .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #fef9ed; }
+  .lazy_filter_select.disabled { background: #fcf3d9; }
+  .lazy_filter_select.disabled input.lfs_input { background: #fffefb; }
+  .lazy_filter_select .lfs_input_container { background-color: #fef9ed; border-color: #fbeecb; }
+  .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #fcf3d9; }
+  .lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(253, 246, 227, 0.15); }
+  .lazy_filter_select .lfs_list_container { background: #fdf6e3; border-color: #fbeecb; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+  .lazy_filter_select .lfs_list .lfs_item.selected { color: #586e75; }
+  .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #586e75 !important; }
+  .lazy_filter_select .lfs_list .lfs_item.disabled { color: #2aa198; }
+  .lazy_filter_select .lfs_list .lfs_item.active { background-color: #fbeecb; border-color: #fcf3d9; color: #586e75; }
+  .lazy_filter_select .lfs_token { background: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+  .lazy_filter_select .lfs_token::after { color: #586e75; }
+  .lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #586e75; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #586e75 !important; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item { color: #2aa198 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198 !important; }
+  #message_edit_form .emo_menu { color: rgba(88, 110, 117, 0.3); }
+  #message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #fffefb; }
+  #message_edit_form.focus .emo_menu { color: rgba(88, 110, 117, 0.6); }
+  #message_edit_form.focus #primary_file_button:not(:hover) { border-color: #fcf3d9; }
+  #message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #fcf3d9 !important; }
+  #message_edit_form.offline #primary_file_button { border-color: #fdf6e3; color: #2aa198; }
+  #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #fcf3d9; }
+  #msg_form #msg_input { background: padding-box #fef9ed; border-color: #fdf6e3; border-left: 0; color: #586e75; }
+  #msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #586e75; }
+  #msg_form .msg_mentions_button { color: #2aa198; }
+  #msg_form .msg_mentions_button:hover { color: #586e75; }
+  #msg_input { background: #fef9ed; border-color: #fdf6e3; color: #586e75; }
+  #msg_input::-webkit-input-placeholder { color: #586e75 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  #msg_input::-moz-placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  #msg_input::placeholder { color: #586e75 !important; filter: none; opacity: 0.5; }
+  #msg_input[data-placeholder]:empty::before { color: #586e75 !important; }
+  #msg_input:focus, #msg_input.focus { border-color: #fcf3d9; }
+  #msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #fcf3d9; }
+  #msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #fdf6e3; }
+  #msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #fdf6e3; }
+  #msg_input.offline:not(.pretend-to-be-online) { background-color: #fcf3d9 !important; color: #2aa198; }
+  #msg_input.disabled, #msg_input.ql-disabled { background-color: #fcf3d9; border-color: #fcf3d9; color: #2aa198; }
+  #msg_input_message { background-color: #fcf3d9; color: #586e75; }
+  #primary_file_button { background: padding-box #fef9ed; border-color: #fdf6e3; color: #2aa198; }
+  #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #fdf6e3; border-color: #fcf3d9; color: #586e75; }
+  #footer, #footer.footer_msg_input { background: #fdf6e3; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+  #footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #fcf3d9 !important; border-color: #fcf3d9 !important; }
+  #footer_archives_table { color: #2aa198; }
+  #typing_text { color: #2aa198; filter: none; }
+  #notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+  #special_formatting_text { color: #2aa198; }
+  #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .inline_message_input_container .ql-container { border-color: #fef9ed; }
+  .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #fffefb; }
+  .c-message--editing { background: #fcf3d9; border-color: #fcf3d9; color: #586e75; }
+  .c-message__editor__input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .c-message__editor__input.focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-message__editor__warning { color: #dc322f; }
+  #message_edit_container .message_input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  #message_edit_container .message_input.focus { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(254, 249, 237, 0.5); color: #fdf6e3; }
+  .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(254, 249, 237, 0.8); }
+  .ql-placeholder, .texty_legacy .ql-placeholder { color: #586e75; filter: none; }
+  .ql-container.texty_single_line_input { background: #fef9ed; border: 1px solid #fcf3d9; color: #586e75; }
+  .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #fcf3d9; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-input_select { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #586e75; }
+  .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .c-input_select_options_list__option { color: #586e75; }
+  .menu { background: #fcf3d9; border: 1px solid #fdf6e3; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #586e75; }
+  .menu .menu_content { background: #fcf3d9 !important; }
+  .menu .menu_filter_container { background: #fdf6e3; }
+  .menu .menu_filter_container input.menu_filter { border: 1px solid #fdf6e3; }
+  .menu .menu_filter_container input.menu_filter:focus { border-color: #fef9ed; }
+  .menu .menu_filter_container .icon_search { color: #2aa198; }
+  .menu .menu_filter_container .icon_close { color: #2aa198 !important; }
+  .menu #menu_header .menu_simple_header { background: #fbeecb; border-color: #fcf3d9; color: #586e75; }
+  .menu #menu_header .menu_simple_header a { color: #268bd2; }
+  .menu #menu_header .menu_simple_header a:hover { color: #dc322f; }
+  .menu #menu_header .menu_close { color: #586e75; }
+  .menu .section_header .header_label { background-color: #fcf3d9; color: #2aa198; }
+  .menu .section_header > div.header_label_container { color: #2aa198; }
+  .menu ul li a { background: #fcf3d9; border-bottom: 0; color: #586e75; }
+  .menu ul li a.delete_link { color: #dc322f; }
+  .menu ul li a:not(.inline_menu_link) { color: #586e75; }
+  .menu ul li.highlighted a { background: #fdf6e3; border-bottom-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #586e75; }
+  .menu ul li.highlighted a.delete_link { color: #dc322f; }
+  .menu ul li.disabled a { color: #2aa198; }
+  .menu ul li i { color: #2aa198; }
+  .menu ul li.divider { border-bottom-color: #fdf6e3; }
+  .menu ul li .menu_item_details { color: #2aa198; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #fdf6e3; border-bottom-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #586e75; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #dc322f; }
+  .menu input { background: #fcf3d9; border: 1px solid #fef9ed; }
+  .menu textarea { background: #fcf3d9; border: 1px solid #fef9ed; }
+  .menu #menu_footer .menu_footer { background: #fbeecb; border-top: 1px solid #fcf3d9; }
+  .menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #fcf3d9; }
+  .menu #menu_list_container #menu_list .menu_list_item a { color: #586e75; }
+  .menu #menu_list_container #menu_list .menu_list_item.active a { background: #fef9ed; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu { color: #586e75; }
+  #autocomplete_menu header { background-color: #fdf6e3; }
+  #autocomplete_menu header .header_label { color: #2aa198; }
+  #autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #fbeecb; }
+  #autocomplete_menu h2 { color: #586e75; }
+  #autocomplete_menu .no_results { color: #586e75; }
+  #autocomplete_menu .keyword_match .modifier { color: #2aa198; }
+  #autocomplete_menu .boxed { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu .pickmeup { border-bottom: 1px solid #fcf3d9; }
+  #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #fef9ed; }
+  #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #586e75; }
+  #autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #fcf3d9; }
+  #autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+  #autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #586e75; }
+  #autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #fcf3d9; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #586e75; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #268bd2; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #dc322f; }
+  #autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #fcf3d9; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #586e75; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #268bd2; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #dc322f; }
+  #autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #2aa198; }
+  #autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #fcf3d9; }
+  #autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #586e75; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #586e75; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #fdf6e3; color: #586e75; }
+  #autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #2aa198; }
+  #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+  #autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(254, 249, 237, 0.25); border: #fffefb; }
+  #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #fcf3d9; border: 1px solid #fbeecb; }
+  .search_light_grey { color: #586e75 !important; }
+  .highlighter_underlay .keyword::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+  .highlighter_underlay .modifier::before { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+  .highlighter_underlay .modifier.incomplete::before { background: #fcf3d9; border: 1px solid #fbeecb; }
+  .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(255, 254, 251, 0.25); border: #fef9ed; }
+  .highlighter_underlay .ghost_text { color: #586e75; }
+  .pickmeup { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+  .pickmeup .pmu-instance .pmu-button { color: #586e75; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #fcf3d9 !important; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #fffefb; color: #586e75 !important; }
+  .pickmeup .pmu-instance .pmu-today-border { border: 2px solid #fef9ed !important; color: #fffefb !important; }
+  .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #fef9ed; color: #586e75; }
+  .pickmeup .pmu-instance .pmu-not-in-month { background: #fdf6e3; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #fef9ed; }
+  .pickmeup .pmu-instance .pmu-disabled { background: #fdf6e3; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-disabled:hover { background: #fdf6e3; color: #2aa198; }
+  .pickmeup .pmu-instance .pmu-selected { background: #fef9ed; color: #586e75; }
+  .pickmeup .pmu-instance nav { color: #268bd2; }
+  .pickmeup .pmu-instance nav :first-child :hover { color: #dc322f; }
+  .pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #fcf3d9; }
+  .pickmeup .pmu-instance .pmu-day-of-week { color: #586e75; }
+  .pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #fcf3d9; }
+  .pickmeup .pmu-instance .pmu-days * { border: 1px solid #fcf3d9; }
+  .p-block_kit_date_picker_calendar_wrapper { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+  .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #fef9ed; color: #fffefb; }
+  #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #fef9ed; }
+  #menu.date_picker li.date_picker_item a { color: #586e75; }
+  #menu.date_picker li.date_picker_item a:hover { color: #586e75; }
+  #menu.date_picker li.date_picker_item.highlighted a { color: #2aa198; }
+  #file_member_filter { background: #fbeecb; }
+  #client-ui .member_filter { border: 1px solid #fef9ed; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #fdf6e3; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #586e75; }
+  #client-ui #team_list_container #team_filter .member_filter { background-color: #fdf6e3; border-left: 1px solid #fbeecb; }
+  #client-ui #file_member_filter { border-color: #fef9ed; }
+  #client-ui #file_member_filter .member_filter { border-color: #fef9ed; }
+  #client-ui .team_tabs_container { border-bottom: 1px solid #fbeecb; }
+  #team_filter .icon_search { color: #2aa198; }
+  #team_filter a.icon_close { color: #268bd2; }
+  #team_filter a.icon_close:hover { color: #dc322f; }
+  .filter_header { background-color: #fdf6e3; }
+  .popover_menu { background-color: #fdf6e3; border-top: 1px solid #fef9ed; }
+  .popover_menu .arrow::after { background-color: #fbeecb; }
+  .popover_menu .arrow_shadow::after { background-color: #fdf6e3; box-shadow: 0 0 0 1px #fef9ed, 0 0 3px rgba(0, 0, 0, 0.08); }
+  .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #fdf6e3 !important; }
+  .popover_menu .content { background-color: #fdf6e3; }
+  .tab_complete_ui { background: #fdf6e3; border: 1px solid #fcf3d9; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+  .tab_complete_ui .tab_complete_ui_header { background: padding-box #fbeecb; border-bottom: 1px solid #fcf3d9; color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui ul.type_emoji li { color: #586e75; }
+  .tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #586e75; }
+  .tab_complete_ui ul.type_members .unify_broadcast { color: #586e75; }
+  .tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #2aa198; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #586e75 !important; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #fcf3d9; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #2aa198; }
+  .tab_complete_ui ul.type_cmds .cmdname { color: #586e75; }
+  .tab_complete_ui ul.type_cmds .cmddesc { color: #2aa198; }
+  .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #fcf3d9; }
+  .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #fef9ed; border-bottom-color: #fcf3d9; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #586e75 !important; }
+  .tab_complete_ui .not_in_channel { color: #2aa198; }
+  #team_menu { background: #fcf3d9; border-bottom: 2px solid #fcf3d9; color: #586e75; }
+  #team_menu.active, #team_menu:hover { background: #fcf3d9 !important; border-bottom-color: #fcf3d9 !important; }
+  #team_menu.active i, #team_menu:hover i { color: #586e75; }
+  #team_menu i { color: #2aa198; }
+  #team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  #team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #586e75 !important; }
+  #team_menu_user { color: #2aa198; }
+  #team_menu_user_name, #team_menu_user_details { color: #586e75 !important; opacity: 0.75; }
+  .slack_menu_section::before { border-top-color: #fdf6e3; }
+  .slack_menu_header_secondary { color: #2aa198; }
+  .slack_menu_download { background-color: #fcf3d9; }
+  .slack_menu_download ts-icon { color: #2aa198; }
+  #menu_items_scroller::-webkit-scrollbar-track { background: #fdf6e3 !important; }
+  #limit_meter:hover #limit_meter_message_body { color: #586e75; }
+  #limit_meter_message_body { color: #2aa198; }
+  .channel_header { background: #fdf6e3; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+  .channel_header .blue_on_hover:hover { color: #586e75; }
+  #client_body:not(.onboarding)::before { background: #fdf6e3; border-bottom: 1px solid #fcf3d9; box-shadow: inset 1px 0 0 0 #fdf6e3; }
+  .messages_header { color: #586e75; }
+  .channel_title .channel_name_container .channel_name { color: #586e75; }
+  .channel_title .channel_name_container .channel_name.muted { color: #2aa198; }
+  .channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #2aa198; }
+  .channel_title .channel_name_container .muted_icon { color: #2aa198; }
+  .channel_title .channel_name_container .muted_icon:hover { color: #dc322f; }
+  #im_title.away { color: #2aa198; }
+  .channel_header_info button { color: #268bd2; }
+  .channel_header_icon { color: #586e75; }
+  .channel_calls_button .call_icon.call_window_offline { color: #2aa198; }
+  .channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #586e75; }
+  #flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #586e75; }
+  #flex_menu_toggle .flex_menu_download_circle { background: #fdf6e3; }
+  #flex_menu_toggle .flex_menu_download_circle canvas { background: #fdf6e3; }
+  #flex_menu_toggle.unread #help_icon_circle_count { background-color: #dc322f; color: #fff; }
+  #flex_menu_toggle.open #help_icon_circle_count { background-color: #fbeecb; color: #586e75; }
+  #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #fcf3d9; color: #586e75; }
+  #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #fef9ed; color: #586e75; }
+  #recent_mentions_toggle:hover { color: #dc322f; }
+  #rxn_toast_div { background: #fbeecb; border: 1px solid #fef9ed; }
+  .presence { color: #2aa198; }
+  #edit_topic_inner:not(.unable_to_post)::before { background: #fdf6e3; border-color: #fcf3d9; }
+  #edit_topic_trigger { color: #268bd2; }
+  .c-message_list__day_divider__label { color: #2aa198; }
+  .c-message_list__day_divider__label__pill { background: #fdf6e3; position: relative; }
+  .c-message_list__day_divider__line { border-top-color: #fcf3d9; }
+  .day_divider, .mention_day_container_div .day_divider { background: #fdf6e3; color: #2aa198; }
+  .day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #fcf3d9; }
+  .day_divider .day_divider_label { background: #fdf6e3; }
+  .day_container .day_msgs { border-top: 1px solid #fcf3d9; }
+  .day_container.unread_day_container .day_msgs { border-color: #fffefb; }
+  .day_container .day_divider { background: none; color: #2aa198; }
+  .day_container .day_divider .day_divider_label { background: #fdf6e3; }
+  .search_form { border-color: #fef9ed; }
+  .search_form .search_input { background: transparent; }
+  .search_form:hover { border-color: #fffefb; }
+  .search_focused .search_form { border-color: #fffefb; }
+  .search_clear_icon .ts_icon_times_circle { color: #2aa198; }
+  #search_spinner { color: #586e75; }
+  #search_container .search_input { background: transparent; }
+  #search_container .icon_search { color: #2aa198; }
+  #search_container .icon_close { color: #268bd2; }
+  #team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #2aa198; }
+  #team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #268bd2; }
+  #team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #dc322f; }
+  .c-search { background: transparent; }
+  .c-search_message__body { color: #586e75; }
+  .p-search_filter__more_link { color: #586e75; }
+  .p-search_filter__title_text { background: #fcf3d9; color: #586e75; }
+  .p-search_filter__datepicker_trigger { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+  .p-search_filter__datepicker_trigger:hover { color: #2aa198; }
+  .c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+  .c-search_autocomplete footer { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+  .c-search_autocomplete__suggestion_item { color: #586e75; }
+  .c-search_autocomplete__suggestion_item--selected { background-color: #fdf6e3; }
+  .c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #586e75; }
+  .c-search__input_and_close { border-bottom-color: #fbeecb; }
+  .c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #586e75; }
+  #msgs_overlay_div { background: #fdf6e3; }
+  #col_messages { box-shadow: inset 1px 0 0 0 #fdf6e3; }
+  .c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #2aa198 !important; }
+  .c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(251, 238, 203, 0.1); }
+  .c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #2aa198; }
+  .c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #2aa198; }
+  .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(251, 238, 203, 0.1); }
+  .c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(251, 238, 203, 0.2); }
+  .c-message--custom_response { background: rgba(251, 238, 203, 0.15); }
+  .c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(251, 238, 203, 0.1); }
+  .c-message--pinned .c-message__label__icon { color: #dc322f; }
+  .c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #586e75; }
+  .c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #2aa198; }
+  .c-message--sli_highlight_negative .c-message__label { background: rgba(251, 238, 203, 0.1); }
+  .c-message--resend .c-message__body { color: #2aa198; }
+  .c-message--deleting { background: rgba(220, 50, 47, 0.6); }
+  .c-message--standalone { border-color: rgba(254, 249, 237, 0.1); }
+  .c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+  .c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #2aa198; }
+  .c-message__sender { color: #586e75; }
+  .c-message__sender a { color: #586e75; }
+  .c-message__sender .c-emoji__text_mode_icon { color: #2aa198; }
+  .c-message__body { color: #586e75; }
+  .c-message__body--unknown { background: rgba(254, 249, 237, 0.1); }
+  .c-message__body--automated { color: #2aa198; }
+  .c-message__body--tombstone { color: #2aa198; }
+  .c-message__label { color: #2aa198; }
+  .c-message__label__highlight_title { color: #586e75; }
+  .c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #2aa198; }
+  .c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #586e75; }
+  .c-message__resend_controls { color: #2aa198; }
+  .c-message__resend_column { background-color: rgba(254, 249, 237, 0.1); }
+  .c-message__resend, .c-message__cancel { color: #586e75; }
+  .c-message__edited_label { color: #2aa198; }
+  .c-message__tombstone_icon { background: rgba(254, 249, 237, 0.1); color: #2aa198; }
+  .c-message__bot_label { background: rgba(254, 249, 237, 0.1); color: #2aa198; }
+  .c-message__comment:before { color: #2aa198; }
+  .c-message__call_attachment { background: #fdf6e3; border-color: rgba(254, 249, 237, 0.1); }
+  .c-message__call_icon { color: #586e75; }
+  .c-message__call--ended .c-message__call_icon { color: #2aa198; }
+  .c-message__call_info { color: #586e75; }
+  .c-message__call_name--linked { color: #586e75; }
+  .c-message__call_name + .c-message__call_description::before { color: #2aa198; }
+  .c-message__call_sub { color: #2aa198; }
+  .c-message_actions__container { background: #fdf6e3; border-color: #fcf3d9; }
+  .c-message_actions__container:hover { border-color: #fef9ed; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  .c-message_actions__button { border-right-color: #fcf3d9; color: #268bd2; }
+  .c-message_actions__button:hover { color: #586e75; }
+  .c-message_actions__button:active { background: #fcf3d9; }
+  .c-message_group { background-color: #fdf6e3; border-color: #fcf3d9; }
+  .c-message_group:hover .c-message_group__header { color: #2aa198; }
+  .c-message_group__header { color: #586e75; }
+  .c-message_group__divider_text { background-color: #fdf6e3; color: #586e75; }
+  .c-message_list__unread_divider__separator { border-color: #fef9ed; }
+  .c-message_list__unread_divider__label { background: #fdf6e3; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #fef9ed; }
+  .c-message_list__spinner { color: #2aa198; }
+  .c-message_list .c-scrollbar__bar { background: #fdf6e3; }
+  .c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(255, 254, 251, 0.8); }
+  ts-message { color: #586e75; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(251, 238, 203, 0.1); box-shadow: inset 1px 0 0 0 #fdf6e3; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(251, 238, 203, 0.2); }
+  ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #2aa198; }
+  ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #2aa198 !important; }
+  ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+  ts-message.is_pinned { background: rgba(251, 238, 203, 0.15); }
+  ts-message .timestamp { color: #268bd2; }
+  ts-message .temp_msg_controls { color: #2aa198; }
+  ts-message .edited { color: rgba(42, 161, 152, 0.8); }
+  ts-message:hover .edited { color: #2aa198; }
+  ts-message .only_visible_to_user { color: #2aa198; }
+  ts-message.ephemeral { color: #586e75; }
+  ts-message .bot_label { background: #fbeecb; color: #2aa198; }
+  ts-message .in_reply_to { background: #fbeecb; color: #2aa198; }
+  ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #fcf3d9; }
+  ts-message.unprocessed { color: rgba(88, 110, 117, 0.75); }
+  ts-message.highlight { background: rgba(220, 50, 47, 0.4); }
+  ts-message.highlight:hover { background: rgba(220, 50, 47, 0.4); }
+  ts-message .is_highlights_holder { color: #2aa198; }
+  ts-message .is_highlights_holder ts-icon { color: #2aa198; }
+  ts-message .is_highlights_holder .highlights_feedback_link { color: #2aa198; }
+  ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #586e75; }
+  ts-message .recap_highlight { background: rgba(220, 50, 47, 0.4); }
+  ts-message .recap_highlight a { color: #586e75; }
+  ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(220, 50, 47, 0.75); }
+  ts-message.automated .message_body { color: rgba(88, 110, 117, 0.8); }
+  ts-message .action_hover_container { border: 1px solid #fcf3d9; }
+  ts-message .action_hover_container:hover { border-color: #fef9ed; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  ts-message .action_hover_container:hover a { background: #fcf3d9; border-right: 1px solid #fef9ed; }
+  ts-message .action_hover_container .btn_msg_action { background: #fdf6e3; border-right: 1px solid #fcf3d9; color: #268bd2; }
+  ts-message .action_hover_container .btn_msg_action:hover { color: #586e75; }
+  ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #fcf3d9; color: #586e75; }
+  ts-message.selected { background: #fdf6e3; }
+  ts-message.selected:not(.delete_mode) { background: #fdf6e3; }
+  ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+  ts-message .meta { color: #2aa198; }
+  ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #268bd2 !important; }
+  ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #2aa198 !important; }
+  ts-message .pinned_item_message_header { color: #2aa198; }
+  ts-message .mention { background: #fffefb !important; color: #586e75 !important; }
+  ts-message .internal_member_link { background: #fdf6e3 !important; border: 0; color: #268bd2 !important; }
+  ts-message .internal_member_link:hover { color: #dc322f !important; }
+  ts-message.show_recap:not(.is_pinned) { background: rgba(251, 238, 203, 0.15); }
+  ts-message.show_recap:not(.is_pinned):hover { background: rgba(251, 238, 203, 0.15); }
+  .ephemeral.message .message_content { color: #586e75; }
+  ts-mention { background: rgba(255, 254, 251, 0.1) !important; color: #586e75 !important; }
+  .selecting_messages ts-message:hover { background: #fbeecb; }
+  .selecting_messages ts-message.multi_delete_mode:hover { background: rgba(220, 50, 47, 0.75); }
+  #convo_container { background-color: #fdf6e3; }
+  #convo_container #message_edit_container { border-bottom: 1px solid #fef9ed; border-top: 1px solid #fef9ed; }
+  #convo_container ts-conversation::after { background: rgba(251, 238, 203, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(251, 238, 203, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(251, 238, 203, 0.08) 100%); }
+  #convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(251, 238, 203, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(251, 238, 203, 0.08) 0, transparent 100%); }
+  #convo_container ts-conversation ts-message.selected { background: #fdf6e3; }
+  #convo_container ts-conversation ts-relatives::after { background: #fef9ed; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #fef9ed; color: #2aa198; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #586e75; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #fdf6e3; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #fffefb; }
+  #msgs_div .unread_divider hr { border-top: 1px solid #fef9ed; }
+  #msgs_div .unread_divider .divider_label { background: #fdf6e3; color: #fef9ed; }
+  #msgs_div .unread_divider.no_unreads hr { border-top-color: #fcf3d9; }
+  #msgs_div .unread_divider.no_unreads .divider_label { color: #2aa198; }
+  .channel_archive_messages.card .col:first-child { border-right: 1px solid #fef9ed; }
+  .star { color: #2aa198; }
+  .star_item { border-bottom: 1px solid #fbeecb; }
+  .star_item .star_meta { color: #2aa198; }
+  .bot_message .message_sender { color: #586e75; }
+  .bot_message .message_sender a { color: #586e75; }
+  .color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #586e75; }
+  #msgs_scroller_div #end_display_div #end_display_status { color: #2aa198; }
+  #msgs_scroller_div #end_display_div #end_display_meta { color: #2aa198; }
+  #msgs_scroller_div #end_display_div #end_display_meta h1 { color: #586e75; }
+  #msgs_scroller_div #end_display_div p { color: #586e75; }
+  .member_mentions_options { background-color: #fbeecb; border-top: 1px solid #fcf3d9; }
+  .dm_badge .dm_badge_meta { color: #586e75; }
+  .dm_badge a { color: #268bd2; }
+  .dm_badge a.member_preview_link { color: #268bd2; }
+  .dm_badge .dm_badge:hover a { color: #268bd2; }
+  .dm_badge .hint { color: #2aa198; }
+  #toggle-subscription-status .subscription_desc { color: #2aa198; }
+  .bot_label { background: #fbeecb; color: #2aa198; }
+  @keyframes to-grey { 0% { color: inherit; }
+    100% { color: #2aa198; } }
+  @keyframes fade-background-highlight { 0% { background: #fef9ed; }
+    100% { background: transparent; } }
+  @keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #fef9ed, 0 0 0 0.5px #fffefb; }
+    100% { box-shadow: 0 0 4px 0 #fef9ed, 0 0 0 0 #fffefb; } }
+  .c-message_attachment { color: #586e75; }
+  .c-message_attachment__border { background-color: #fef9ed; }
+  .c-message_attachment__delete { color: #268bd2; }
+  .c-message_attachment__delete:hover { color: #dc322f; }
+  .c-message_attachment__pretext { color: #586e75; }
+  .c-message_attachment__part + .c-message_attachment__part::before { color: #fef9ed; }
+  .c-message_attachment__author .c-message_attachment__autor--distinct { color: #268bd2; }
+  .c-message_attachment__author_link + .c-message_attachment__author_link { color: #268bd2; }
+  .c-message_attachment__title_link span { color: #586e75; }
+  .c-message_attachment__text_expander { color: #268bd2; }
+  .c-message_attachment__footer { color: #268bd2; }
+  .c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(251, 238, 203, 0.1) inset; }
+  .c-message_attachment__video_html { background-color: rgba(253, 246, 227, 0.4); }
+  .c-message_attachment__video_buttons { background: rgba(251, 238, 203, 0.4); }
+  .c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #586e75; }
+  .c-message_attachment__video_play, .c-message_attachment__video_link { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+  .c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #586e75; }
+  .c-message_attachment__media_trigger .c-expandable_trigger { color: #268bd2; }
+  .c-message_attachment__media_trigger--too_large { color: #268bd2; }
+  .c-message_attachment__select { border-color: #fbeecb; }
+  .c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #fef9ed; }
+  .c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #fdf6e3; border-color: #fbeecb; }
+  .c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #2aa198; }
+  .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #fef9ed; }
+  .c-message__reply_bar_description { color: #2aa198; }
+  .c-message__file_meta { color: #2aa198; }
+  .c-message__image_container { background: rgba(251, 238, 203, 0.1); }
+  .c-message__image_wrapper:after { border-color: transparent; }
+  .attachment_group.has_container { background: #fdf6e3; border: 1px solid #fcf3d9; }
+  .attachment_group.has_container .inline_attachment::after { background-color: #fcf3d9; }
+  .attachment_group.has_container.has_link:hover { border-bottom-color: #fcf3d9; border-left-color: #fcf3d9; border-right-color: #fcf3d9; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .attachment_group .media_caret { color: #2aa198; }
+  .attachment_group .attachment_source span { color: #2aa198 !important; }
+  .attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #2aa198; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #2aa198; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #fcf3d9; }
+  .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #2aa198; }
+  .attachment_group .attachment_title a { color: #586e75; }
+  .attachment_group .attachment_footer_text + .attachment_ts::before { color: #2aa198; }
+  .attachment_group .delete_attachment_link ts-icon::before { color: #268bd2; }
+  .attachment_group .delete_attachment_link:hover ts-icon::before { color: #dc322f; }
+  .attachment_still_pending ts-inline-saver { color: #2aa198; }
+  .msg_inline_attachment_column.column_border { background-color: #fef9ed; }
+  .msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #fbeecb; }
+  .msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #268bd2; }
+  .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #dc322f; }
+  .msg_inline_img { background: #fef9ed; }
+  .msg_inline_room_preview_collapser { color: #2aa198; }
+  .msg_inline_room_preview_collapser:hover { color: #2aa198; }
+  .inline_attachment span.attachment_author_name { color: #268bd2; }
+  .inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #268bd2; }
+  .inline_attachment a span:active, .inline_attachment a span:hover { color: #dc322f !important; }
+  .inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #268bd2; }
+  .inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #268bd2; }
+  .inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #dc322f !important; }
+  .inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #dc322f !important; }
+  .inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #fbeecb; }
+  .meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #268bd2 !important; }
+  .meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #268bd2 !important; }
+  .meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #dc322f !important; }
+  .meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #dc322f !important; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #586e75; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #2aa198; }
+  .meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #dc322f !important; }
+  .meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #268bd2 !important; }
+  .delete_attachment_link { color: #268bd2; }
+  .delete_attachment_link:hover { color: #dc322f; }
+  .file_container, .c-file_container { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+  .file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #fcf3d9; border-left-color: #fcf3d9; border-right-color: #fcf3d9; }
+  .file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: -moz-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: -o-linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); background-image: linear-gradient(top, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+  .file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #fdf6e3; box-shadow: 0 0 0 3px #fdf6e3; color: #586e75; }
+  .file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #fcf3d9; }
+  .file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #fbeecb; color: #586e75; }
+  .file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #2aa198; }
+  .file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #fbeecb; }
+  .file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #fcf3d9; color: #586e75 !important; }
+  .file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #fbeecb; }
+  .file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(255, 254, 251, 0.9); color: #586e75 !important; }
+  .file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #fbeecb; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #fcf3d9; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #fcf3d9; }
+  .file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #fdf6e3; }
+  .file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(255, 254, 251, 0.9); }
+  .file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #fcf3d9; }
+  .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(255, 254, 251, 0.9); border: 1px solid rgba(251, 238, 203, 0.1); }
+  .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(254, 249, 237, 0.8), rgba(254, 249, 237, 0.8)), linear-gradient(rgba(255, 254, 251, 0.3), rgba(255, 254, 251, 0.3)); color: #586e75; }
+  .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(254, 249, 237, 0.8); color: #586e75; }
+  .file_container .c-file__title, .c-file_container .c-file__title { color: #586e75; }
+  .message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #fef9ed; color: #586e75; }
+  .msg_inline_video_buttons_div { background-color: rgba(253, 246, 227, 0.4); }
+  .msg_inline_video_buttons_div a { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+  .msg_inline_video_buttons_div a:visited { color: #586e75; text-shadow: 0 1px 1px rgba(251, 238, 203, 0.5); }
+  .post_body ul.checklist { background-color: #fcf3d9; }
+  .post_body ul.checklist li::before { background: #fcf3d9; }
+  .post_body ul.checklist li.checked { color: #2aa198; }
+  .post_body ul.list.checklist li { border-bottom: 1px solid #fef9ed; }
+  .post_body ul.list.checklist li.checked { color: #2aa198; }
+  .post_body .message { background-color: #586e75; }
+  .post_body code, .post_body pre { background: #fcf3d9; }
+  ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #2aa198; }
+  ts-message .reply_bar:hover { background: #fdf6e3; border-color: #fbeecb; }
+  .inline_color_block { border-color: #fef9ed; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #fdf6e3; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #fdf6e3; border-bottom: 1px solid #fdf6e3; }
+  .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #fdf6e3; }
+  .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #586e75; }
+  .p-message_pane__limited_history_foreword { background: #fcf3d9; background-image: none; color: #586e75; }
+  .p-message_pane__unread_banner__banner { background: #fef9ed; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner { color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner a { color: #586e75; }
+  .messages_banner a:hover { color: #586e75; }
+  #connection_div { background: #dc322f; }
+  #archives_return { background: padding-box #fffefb; color: #586e75; }
+  #archives_return.warning { background: #dc322f; }
+  #archives_return a { color: #586e75; }
+  #archives_return a:hover { color: rgba(88, 110, 117, 0.8); }
+  #messages_unread_status { background: #fef9ed; }
+  #messages_unread_status:hover { background: #fffefb; }
+  #messages_unread_status:hover .clear_unread_messages { background: #fffefb; }
+  #messages_unread_status:hover .clear_unread_messages:hover { background: #fef9ed; }
+  #messages_unread_status.quiet { background: #fffefb; color: #586e75; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #messages_unread_status.quiet a { color: #586e75; }
+  .clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+  #messages_container.has_top_messages_banner::before { background: none; }
+  .end_div_msg_lim { background-color: #fcf3d9; background-image: none; }
+  #archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #586e75; }
+  #archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(88, 110, 117, 0.8); }
+  code { background-color: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+  .file_list_item.snippet .snippet_preview { background: #fbeecb; }
+  .snippet_preview, .snippet_body { background: #fbeecb; }
+  .snippet_preview pre, .snippet_body pre { color: #586e75 !important; }
+  .file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #fcf3d9; border-right: 1px solid #fcf3d9; color: #2aa198; }
+  .c-snippet .c-file_container { background-color: #fdf6e3; }
+  .c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #fdf6e3); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+  .CodeMirror { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75 !important; }
+  .CodeMirror pre { background: transparent !important; }
+  .CodeMirror div.CodeMirror-cursor { border-left: 1px solid #586e75; }
+  .CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #586e75; }
+  .CodeMirror .CodeMirror-gutters { background-color: #fcf3d9; border-right: 1px solid #fdf6e3; }
+  .CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #fcf3d9; }
+  .CodeMirror-linenumber { color: #2aa198 !important; }
+  .CodeMirror-guttermarker { color: #2aa198; }
+  .CodeMirror-guttermarker-subtle { color: #2aa198; }
+  .CodeMirror-ruler { border-left: 1px solid #fffefb; }
+  .cm-s-default .cm-keyword { color: #ce93d8; }
+  .cm-s-default .cm-atom { color: #9fa8da; }
+  .cm-s-default .cm-number { color: #a5d6a7; }
+  .cm-s-default .cm-def { color: #536dfe; }
+  .cm-s-default .cm-variable-2 { color: #9fa8da; }
+  .cm-s-default .cm-variable-3 { color: #c5e1a5; }
+  .cm-s-default .cm-comment { color: #ffcc80; }
+  .cm-s-default .cm-string { color: #ef9a9a; }
+  .cm-s-default .cm-string-2 { color: #ffab91; }
+  .cm-s-default .cm-meta { color: #eee; }
+  .cm-s-default .cm-qualifier { color: #eee; }
+  .cm-s-default .cm-builtin { color: #b39ddb; }
+  .cm-s-default .cm-bracket { color: #e6ee9c; }
+  .cm-s-default .cm-tag { color: #a5d6a7; }
+  .cm-s-default .cm-attribute { color: #40c4ff; }
+  .cm-s-default .cm-header { color: #80cbc4; }
+  .cm-s-default .cm-quote { color: #b0bec5; }
+  .cm-s-default .cm-hr { color: #fcf3d9; }
+  .cm-s-default .cm-link { color: #268bd2; }
+  .cm-negative { color: #dc322f; }
+  .cm-positive { color: #859900; }
+  .cm-invalidchar, .cm-s-default .cm-error { color: #dc322f; }
+  div.CodeMirror span.CodeMirror-matchingbracket { color: #859900; }
+  div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #dc322f; }
+  .CodeMirror-matchingtag { background: #fbeecb; }
+  .CodeMirror-activeline-background { background: #fffefb; }
+  .CodeMirror-selected { background: #fffefb; }
+  .CodeMirror-focused .CodeMirror-selected { background: #fffefb; }
+  .cm-searching { background: #fffefb; }
+  .sssh-keyword { color: #ce93d8; }
+  .sssh-atom { color: #9fa8da; }
+  .sssh-number { color: #a5d6a7; }
+  .sssh-def { color: #536dfe; }
+  .sssh-variable { color: #9fa8da; }
+  .sssh-variable-2 { color: #c5e1a5; }
+  .sssh-variable-3 { color: #c1a5e1; }
+  .sssh-operator { color: #586e75; }
+  .sssh-property { color: #586e75; }
+  .sssh-comment { color: #ffcc80; }
+  .sssh-string { color: #ef9a9a; }
+  .sssh-string-2 { color: #ffab91; }
+  .sssh-meta { color: #eee; }
+  .sssh-error { color: #dc322f; }
+  .sssh-qualifier { color: #eee; }
+  .sssh-builtin { color: #b39ddb; }
+  .sssh-bracket { color: #e6ee9c; }
+  .sssh-tag { color: #a5d6a7; }
+  .sssh-attribute { color: #40c4ff; }
+  .sssh-header { color: #80cbc4; }
+  .sssh-quote { color: #b0bec5; }
+  .sssh-hr { color: #fcf3d9; }
+  .sssh-link { color: #268bd2; }
+  .c-message--dense .c-timestamp__label { color: #268bd2; }
+  .c-message--dense .c-message__content_header .c-custom_status { border-color: #fcf3d9; }
+  .dense_theme ts-message { color: #586e75; }
+  .dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #268bd2; }
+  .dense_theme ts-message .message_content .message_current_status { border-color: #fcf3d9; }
+  .c-message--light .c-message__sender .c-message__sender_link { color: #586e75; }
+  .light_theme ts-message { color: #586e75; }
+  .light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #586e75 !important; }
+  .light_theme ts-message .comment::before { color: #2aa198; }
+  .channel_overlay { border-color: #fcf3d9; color: #2aa198; }
+  .channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #586e75; }
+  .channel_overlay.channel_overlay_redesign li { color: #2aa198; }
+  .channel_overlay_title_wrap { border-color: #fcf3d9; }
+  .channel_overlay_title_shared { color: #586e75; }
+  pre { background: #fbeecb; border: 1px solid #fcf3d9; color: #586e75; }
+  pre span.mention { padding: 2px 0 !important; }
+  #page pre, body > pre { background: #fbeecb; color: #586e75 !important; }
+  body > pre { background: #fffefb; }
+  .special_formatting_quote .quote_bar { background-color: #fef9ed; }
+  #threads_msgs_scroller_div { background: #fdf6e3; }
+  #threads_msgs_scroller_div:not(.loading)::before { background: #fdf6e3; }
+  #threads_msgs_scroller_div.loading::before { color: #2aa198; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #fcf3d9; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #fef9ed; color: #586e75; }
+  #threads_msgs_scroller_div.loading { background: none; }
+  #threads_msgs_scroller_div.loading::before { color: #586e75; }
+  #threads_view_banner.messages_banner { background: #fcf3d9; }
+  #threads_view_banner.messages_banner:hover { background: #fef9ed; }
+  #threads_view_banner.messages_banner:hover .clear_unread_messages { background: #fef9ed; }
+  #threads_msgs.new_banner_is_showing::before { background: #fdf6e3; }
+  ts-thread { background: #fdf6e3; }
+  ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #fcf3d9; color: #586e75; }
+  ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #fcf3d9; border-color: #fcf3d9; }
+  ts-thread .thread_messages { background: #fcf3d9; border-color: #fcf3d9; }
+  ts-thread ts-message.new_reply { background: #fdf6e3; }
+  ts-thread ts-message.new_reply:hover { background: #fcf3d9; }
+  ts-thread .thread_header .thread_channel_name a { color: #586e75; }
+  ts-thread .thread_header .thread_action_btns button { color: #2aa198; }
+  ts-thread .new_reply_indicator .blue_dot { color: #dc322f; }
+  #convo_tab .thread_participants, ts-thread .thread_participants { color: #2aa198; }
+  #convo_loading_indicator { background-image: none; }
+  .reply_input_container .inline_message_input_container .ql-container { background-color: #fef9ed; border: 1px solid #fcf3d9; }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+  .reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #586e75; }
+  .reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #2aa198; }
+  #file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #2aa198; }
+  #unread_msgs_scroller_div::after { background: transparent; }
+  #unread_msgs_scroller_div.loading { background-image: none; }
+  #unread_msgs_scroller_div.loading::before { color: #2aa198; }
+  #unread_msgs_div .day_divider .day_divider_line { border-top-color: #fcf3d9; }
+  .unread_group.marked_as_read .unread_group_header { background: #fdf6e3; }
+  .unread_group .unread_group_header { background: #fcf3d9; border-top-color: #fef9ed; color: #586e75; }
+  .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #586e75; }
+  .unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #2aa198; }
+  .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #fdf6e3; }
+  .unread_group.active .unread_group_header { background: #fbeecb; border-top-color: #fef9ed; color: #586e75; }
+  .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #2aa198; }
+  .mark_as_read_checkmark { color: #2aa198; }
+  .bottom_mark_all_read { border-top-color: #fcf3d9; }
+  .unread_group_header_name a { color: #586e75; }
+  .unread_group_footer .unread_group_new .unread_group_new_text { color: #2aa198; }
+  .unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #2aa198; }
+  .unread_empty_state_message { color: #2aa198; }
+  .unread_empty_state_undo_inner { background: #fbeecb; color: #586e75; }
+  .unread_empty_state_undo_action { color: #586e75; }
+  .unread_empty_state_refresh { background: rgba(253, 246, 227, 0.97); }
+  .unread_msgs_loading { background: #fdf6e3; background-image: none; }
+  #col_flex { background: transparent; }
+  #flex_contents { background: #fdf6e3; }
+  #flex_contents .heading { background: #fbeecb; border-bottom-color: #fcf3d9; color: #268bd2; }
+  #flex_contents .heading a { color: #268bd2; }
+  #flex_contents .heading a:hover { color: #dc322f; }
+  #flex_contents .heading a.close_flexpane { color: #268bd2; }
+  #flex_contents .heading .cancel_link { color: #268bd2; }
+  #flex_contents .heading .menu_heading:hover { color: #586e75; }
+  #flex_contents .heading .menu_icon { color: #268bd2; }
+  #flex_contents .heading .menu_icon:hover { color: #dc322f; }
+  #flex_contents .heading_text { color: #268bd2; }
+  #flex_contents .subheading:not(.empty) { background: #fdf6e3; border-top: 1px solid #fbeecb; color: #2aa198; }
+  #flex_contents .subheading:not(.empty) p a { color: #586e75; }
+  #flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #2aa198; }
+  #flex_contents .toolbar_container { background: #fdf6e3; }
+  #flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #268bd2; }
+  #flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #fcf3d9; }
+  #flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #268bd2; }
+  #flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #fcf3d9; }
+  #flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #268bd2; }
+  #flex_contents .help { border-top: 5px solid #fbeecb; color: #586e75; }
+  #flex_contents i.callout { color: #2aa198; }
+  .close_flexpane { color: #2aa198; }
+  .close_flexpane:focus, .close_flexpane:hover { color: #586e75; }
+  #client-ui.flex_pane_showing #col_flex { border-left-color: #fcf3d9; }
+  .toolbar_container { background: #fdf6e3; border-bottom: 1px solid #fbeecb; color: #586e75; }
+  .msg_right_link { color: #268bd2; }
+  .message_location_label { color: #2aa198; }
+  .p-flexpane_header { background: #fcf3d9; border-color: #fef9ed; color: #586e75; }
+  #client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #fcf3d9; }
+  #details_tab .heading { background: #fbeecb; }
+  #details_tab .heading a.close_flexpane { color: #268bd2; }
+  #details_tab .heading a.close_flexpane:hover { color: #dc322f; }
+  #details_tab hr { border-top-color: #fcf3d9; }
+  #details_tab .conversation_details .member_name:hover { color: #2aa198; }
+  #details_tab .conversation_details .member_username:hover { color: #586e75; }
+  #details_tab .conversation_details .member_info_timezone { border-top-color: #fef9ed; }
+  #details_tab .channel_page_section { background: #fdf6e3; border-top: 1px solid #fcf3d9; }
+  #details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #dc322f; }
+  #details_tab .channel_page_section .section_header a { color: #268bd2; }
+  #details_tab .channel_page_section .section_title { color: #586e75; }
+  #details_tab .channel_page_section .disclosure_triangle { color: #268bd2; }
+  #details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(220, 50, 47, 0.25) !important; }
+  #details_tab .created_by { color: #586e75; }
+  #details_tab .channel_page_member_tabs .icon_member_header { color: #2aa198; }
+  #details_tab .pinned_item:hover { border-color: #fef9ed; }
+  #details_tab .channel_page_action .leave_link { color: #268bd2; }
+  #details_tab .channel_page_action .leave_link:hover { color: #dc322f; }
+  #details_tab .channel_section_label .ts_icon_info_circle { color: #2aa198; }
+  #details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #2aa198; }
+  .channel_page_member_row { color: #586e75; }
+  .channel_page_member_row a { color: #268bd2; }
+  .channel_page_member_row.away { color: #586e75; }
+  .channel_page_member_row.away a { color: #268bd2; }
+  .channel_page_member_row:hover { background-color: #fef9ed; border-color: #fcf3d9; }
+  .pinned_item { color: #586e75; }
+  .pinned_item .pin_file_title { color: #268bd2; }
+  .pinned_item .pin_member_name a { color: #268bd2 !important; }
+  .pinned_item .pin_metadata { color: #2aa198; }
+  .pinned_item .remove_pin { color: #268bd2; }
+  .pinned_item .remove_pin:hover { color: #dc322f; }
+  .pinned_item .pinned_message_text .pin_truncate_fade { background: #fdf6e3; }
+  .pinned_item.delete_mode { border-color: #dc322f !important; }
+  .c-channel_insights__title { color: #586e75; }
+  .c-channel_insights__section:not(.c-channel_insights__section--no_border) { border-color: #fef9ed; }
+  .c-channel_insights__drawer_title { color: #2aa198; }
+  .c-channel_insights__item--user .member_preview_link, .c-channel_insights__item--user .message_sender { color: #586e75 !important; }
+  .c-channel_insights__user_title { color: #2aa198; }
+  .c-channel_insights__channel .channel_link { color: #586e75; }
+  .c-channel_insights__member_count { color: #2aa198; }
+  .c-channel_insights__member_count .ts_icon_user { color: #2aa198; }
+  .c-channel_insights .c-member__title { color: #2aa198; }
+  .c-channel_insights__activity { border-color: #fef9ed; }
+  .c-channel_insights_activity_bar_container:hover { background-color: rgba(251, 238, 203, 0.05); }
+  .c-channel_insights_activity_bar_container:hover .c-channel_insights__activity_bar { background-color: #fef9ed; }
+  .c-channel_insights__activity_bar { background-color: rgba(254, 249, 237, 0.5); }
+  .c-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #fdf6e3; border-color: #fef9ed; }
+  .c-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #fdf6e3 90%); }
+  .c-channel_insights__highlights_description { color: #2aa198; }
+  .c-channel_insights__date_heading span { background-color: #fdf6e3; color: #586e75; }
+  .c-channel_insights__date_heading::before { background-color: #fef9ed; }
+  #file_list_toggle_users { color: #268bd2; }
+  #file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #dc322f; }
+  #file_list_toggle_users.active { color: #2aa198; }
+  .file_list_item .icon, .file_reference .icon { background: #fffefb; border: 1px solid #fef9ed; color: #586e75 !important; }
+  .filetype_button { background: #fffefb; border: 1px solid #fef9ed; color: #586e75 !important; }
+  .filetype_button:hover { background: #fffefb; }
+  .filetype_button:hover .file_download_label { background: #fef9ed; color: #586e75; }
+  .filetype_button .file_title { color: #586e75; }
+  .filetype_button .file_download_label { background: #fffefb; border-top: 1px solid #fef9ed; }
+  a.filetype_button_web { background: #fffefb; border: 1px solid #fef9ed; color: #586e75; }
+  a.filetype_button_web .filetype_icon { background-color: #fef9ed; }
+  a.file_download_link { color: #268bd2; }
+  a.file_download_link:hover { color: #dc322f; }
+  a:hover .file_inline_icon { color: #2aa198; }
+  a.gsheet img, a.pdf img { background: #fdf6e3 !important; }
+  html.no_touch a.filetype_button_web:hover { border-color: #fef9ed; }
+  html.no_touch a.filetype_button_web:hover .file_title { color: #586e75; }
+  .file_header_detailed { color: #2aa198; }
+  .file_header_detailed .member { color: #586e75 !important; }
+  .file_inline_icon { color: #2aa198; }
+  .file_header .member { color: #2aa198 !important; }
+  .file_header .title { color: #586e75; }
+  .file_header .title a { color: #268bd2; }
+  .file_header .title a:hover { color: #dc322f; }
+  .flexpane_file_title .member, .flexpane_file_title .service_link { color: #268bd2 !important; }
+  .flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #268bd2; }
+  .flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #dc322f; }
+  .file_actions_cog { color: #268bd2 !important; }
+  .file_actions_cog:hover { color: #dc322f !important; }
+  .file_list_item { color: #586e75; }
+  .file_list_item a { color: #268bd2; }
+  .file_list_item a.member { color: #dc322f; }
+  .file_list_item .bullet { color: #2aa198; }
+  .file_list_item .icon { background: #fffefb; border-color: #fef9ed; }
+  .file_list_item .ts_icon_comment { color: #2aa198; }
+  .file_list_item .file_comment_link:hover { color: #268bd2; }
+  .file_list_item .file_comment_link:hover .ts_icon_comment { color: #2aa198; }
+  .file_list_item .title a { color: #268bd2; }
+  .file_list_item .share_info .unshare_link { color: #268bd2; }
+  .file_list_item .share_info .unshare_link:hover { color: #dc322f; }
+  .file_list_item .actions a, .file_list_item .actions span { background-color: #fcf3d9; border: 1px solid #fffefb; color: #268bd2; }
+  .file_list_item .actions a:hover { background-color: #fdf6e3 !important; border-color: #fffefb; color: #dc322f; }
+  .file_list_item.post .preview, .file_list_item.space .preview { color: #586e75; }
+  .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #fcf3d9; border-color: #fef9ed; }
+  .file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #268bd2; }
+  .file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+  .file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #fcf3d9; }
+  .unshare_link { color: #268bd2 !important; }
+  .unshare_link i::before { color: #2aa198 !important; }
+  .unshare_link i.ts_icon_minus_circle_small:hover::before { color: #dc322f !important; }
+  .snippet_preview pre { color: #586e75; }
+  .file_preview_wrapper .file_preview { background: #fdf6e3; }
+  .file_preview_wrapper .file_preview:hover { background: #fcf3d9; }
+  #file_preview_container .file_meta { color: #2aa198; }
+  .file_page_meta { color: #2aa198; }
+  #file_page_preview img { background: #fdf6e3; border: 1px solid #fbeecb; }
+  #file_page_preview img:hover { background: #fcf3d9; }
+  .comment_meta { color: #2aa198; }
+  .comment .special_formatting_quote .content { color: #586e75; }
+  .comment .member { color: #586e75 !important; }
+  .comment_body { color: #586e75; }
+  .comment_actions { color: #2aa198; }
+  .comment_actions:hover { color: #586e75; }
+  .icon_quote { color: #586e75; }
+  .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #fcf3d9; }
+  .tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #fdf6e3; }
+  .tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #fcf3d9; }
+  .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+  .tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #fdf6e3; border-color: #fcf3d9; }
+  .tab_container .file_list_item .star { color: #2aa198; }
+  .tab_container .file_list_item .contents .file_comment_link { color: #268bd2; }
+  .tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #268bd2; }
+  .tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #dc322f; }
+  .tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #dc322f; }
+  .tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #2aa198; }
+  .tab_container .file_list_item .filetype_image { background-color: #fbeecb; }
+  .active .tab_container .file_list_item { background-color: #fdf6e3; }
+  .c-file__actions { background: #fef9ed; }
+  .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #fef9ed; border-color: #fcf3d9; color: #fff; }
+  .p-file_details__name, .p-file_details__share_channel { color: #586e75; }
+  .p-file_details__meta_container .c-file__action_button { color: #fff; }
+  .c-pillow_file_container { background: #fef9ed; border-color: #fcf3d9; color: #586e75; }
+  .c-pillow_file__description, .c-pillow_file__title { color: #586e75; }
+  #user_groups_pane .mention { background: rgba(220, 50, 47, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+  #user_groups_container .info_panel { background: #fdf6e3; border: 1px solid #fef9ed; }
+  #user_groups_container .mention { background-color: rgba(220, 50, 47, 0.25) !important; }
+  #user_groups_header .user_groups_search .icon_search { color: #2aa198; }
+  #user_groups_header a.icon_close { color: #268bd2; }
+  #user_groups_header a.icon_close:hover { color: #dc322f; }
+  .user_group_item { border-bottom: 1px solid #fef9ed; }
+  .user_group_item a { color: #268bd2; }
+  #flex_contents .user_group_item:hover { background-color: #fdf6e3; }
+  #flex_contents .user_group_item:hover h4 { color: #586e75; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #fdf6e3; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #586e75; }
+  .user_group_invite_member_small .add_icon { color: #2aa198; }
+  #user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #fffefb; border-color: #fffefb; }
+  #flex_contents .subheading:not(.empty)#mentions_options { background-color: #fdf6e3; border-bottom-color: #fcf3d9; color: #586e75; }
+  .mention_day_container_div .day_divider::before { background: none; border-color: #fcf3d9; }
+  #member_mentions h3 a { color: #268bd2; }
+  a.internal_member_link { background: #fcf3d9; color: #586e75; }
+  a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #fcf3d9; border: 1px solid #fef9ed; color: #586e75; }
+  a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #fdf6e3; color: #586e75; }
+  .mention_rxn .mention_rxn_summary { color: #586e75; }
+  .mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #2aa198; }
+  .search_message_result { background: #fdf6e3 !important; border-color: #fcf3d9 !important; color: #586e75 !important; }
+  .search_message_result .search_message_result_meta { color: #2aa198; }
+  .search_message_result .search_message_result_meta a { color: #268bd2; }
+  .search_message_result .search_message_result_meta .date_links a { color: #268bd2; }
+  .search_message_result_text .result_msg_format a { color: #268bd2; }
+  span.match { background: rgba(220, 50, 47, 0.25); }
+  #search_filters .tab { background: #fdf6e3; color: #586e75; }
+  #search_filters .tab:hover { border-bottom: 4px solid #fcf3d9; }
+  #search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #fcf3d9; color: #586e75; }
+  #search_file_list_toggle_users.active:hover { border: 2px solid #dc322f; color: #dc322f !important; }
+  .no_results { color: #586e75; }
+  #search_results_team .team_results_heading { color: #586e75; }
+  #search_results_team .team_result { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+  #search_results_team .team_result a { color: #268bd2; }
+  #search_results_team .team_result:hover a { color: #dc322f; }
+  #search_results_team .team_result a:hover { color: #dc322f; }
+  #search_results_team .member_name { color: #586e75 !important; }
+  .suggestion { color: #586e75; }
+  .suggestion.active, .suggestion:hover { background: #fef9ed; }
+  #paging_in_options .search_paging { color: #2aa198; }
+  #search_results_items .search_paging { color: #586e75; }
+  .search_paging i.disabled { color: #2aa198; }
+  .search_paging a { color: #268bd2; }
+  .search_paging a:hover { color: #dc322f; }
+  .search_sort_prefix { color: #586e75; }
+  .search_segmented_control { border-color: #fcf3d9; color: #268bd2 !important; }
+  .search_segmented_control:hover { color: #dc322f !important; }
+  .search_segmented_control.active { background: #fbeecb; color: #dc322f !important; }
+  .search_result_with_extract { background: #fcf3d9; border-color: #fef9ed; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+  .search_result_with_extract:hover { border-color: #fffefb; }
+  .search_result_for_context::after { background: rgba(253, 246, 227, 0.1); }
+  .extract_expand_text, .extract_expand_icons { color: #268bd2; }
+  .search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #dc322f; }
+  .search_module_header { color: #586e75; }
+  .search_module_footer { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-left-color: #fef9ed; border-right-color: #fef9ed; }
+  .search_module_footer p { color: #586e75; }
+  .search_module_footer #see_more { color: #586e75; }
+  .search_module_footer #see_more a { color: #586e75; }
+  .search_module_footer .top_results_feedback a { color: #586e75; }
+  .search_module_footer ts-icon { color: #586e75; }
+  .top_results_search_message_result { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-left-color: #fef9ed; border-right-color: #fef9ed; }
+  .top_results_search_message_result.duplicate { background-color: #fcf3d9; }
+  .top_results_search_message_result .timestamp { color: #2aa198; }
+  .top_results_search_message_result .channel { color: #2aa198; }
+  .top_results_search_message_result .channel a { color: #2aa198; }
+  .top_results_search_message_result .jump { color: #586e75; }
+  .top_results_search_message_result:hover { border-color: rgba(255, 254, 251, 0.6) !important; border-top: 2px solid #fef9ed !important; }
+  .top_results_search_message_result:first-child { border-top: 2px solid #fef9ed; }
+  .sli_expert_search { background-color: #fdf6e3; color: #586e75; }
+  .sli_expert_search__result { border-color: #fef9ed; }
+  .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #586e75 !important; }
+  .sli_expert_search__fg_face::before { background-color: #fdf6e3; }
+  .sli_expert_search_cta { border-color: #fef9ed; }
+  .sli_expert_search_cta:hover { border-color: #fffefb; }
+  .sli_expert_search_cta__text { color: #586e75; }
+  .sli_expert_search_cta__text:hover { color: #586e75; }
+  .sli_expert_search__plus_sign_overlay { background-color: #fcf3d9; color: #2aa198; }
+  .sli_expert_search__arrow { color: #2aa198; }
+  .sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #2aa198; }
+  .sli_expert_search__partial_terms { color: #2aa198; }
+  .feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #fcf3d9; color: #586e75; }
+  .feature_sli_file_search #search_results .file_list_item { background-color: #fdf6e3; border-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #fdf6e3; }
+  .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #fdf6e3; border-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #586e75; }
+  .feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #586e75; }
+  .feature_sli_file_search #search_results.all { background-color: #fdf6e3; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #fdf6e3; border-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #2aa198; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #fef9ed; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #fffefb; }
+  .feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #fffefb; }
+  .feature_sli_file_search #search_results.all .team_result { background-color: #fdf6e3; border-color: #fef9ed; }
+  .feature_sli_file_search #search_results.files { background-color: #fdf6e3; }
+  .feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #586e75; }
+  .feature_sli_file_search #search_results_loading { background-color: #fdf6e3; }
+  .feature_sli_file_search #search_results_container #search_options { background-color: #fdf6e3; }
+  .feature_sli_file_search #search_results_container .heading { background-color: #fdf6e3; }
+  #client-ui .file_list_item.file_list_item--redesign { border-color: #fef9ed; }
+  #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #2aa198; }
+  #client-ui .file_list_item.file_list_item--redesign .message_sender { color: #2aa198; }
+  .p-shortcuts_flexpane__shortcut { border-color: #fbeecb; }
+  .p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #fbeecb; }
+  .p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #586e75; }
+  .p-shortcuts_flexpane__shortcut_title { color: #2aa198; }
+  .p-shortcuts_flexpane__title { color: #586e75; }
+  .p-shortcuts_flexpane__tip { color: #2aa198; }
+  .p-shortcuts_flexpane__section_description { color: #2aa198; }
+  .p-shortcuts_flexpane__sub_heading { color: #2aa198; }
+  .c-keyboard_key { background: #fef9ed; border-color: #fffefb; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #586e75; }
+  .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #2aa198; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #268bd2; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #dc322f; }
+  #member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #268bd2; }
+  #member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #dc322f; }
+  #member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #268bd2 !important; }
+  #member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #fffefb !important; color: #dc322f !important; }
+  #member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #586e75; }
+  #member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #268bd2 !important; }
+  #member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #dc322f !important; }
+  #member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #fbeecb; color: #2aa198; }
+  #member_preview_scroller { background-color: #fcf3d9; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #fcf3d9; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(88, 110, 117, 0.35) !important; }
+  #team_tab #member_preview_scroller { background-color: #fdf6e3; }
+  #member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #586e75; }
+  #member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #586e75; }
+  #member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #2aa198; }
+  #member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #268bd2; }
+  #member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #dc322f; }
+  #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #268bd2; }
+  #member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #fcf3d9; }
+  #disabled_members_tab a { color: #268bd2; }
+  #disabled_members_tab a:hover { background: #fdf6e3; color: #dc322f; }
+  #disabled_members_tab.active a { color: #268bd2; }
+  .team_list_item { border-top: 1px solid #fef9ed; color: #268bd2; }
+  .team_list_item .member_name { color: #586e75; }
+  #client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #586e75 !important; }
+  #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #fcf3d9 !important; }
+  #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #fef9ed !important; }
+  #client-ui .searchable_member_list .team_list_item { border-bottom-color: #fbeecb; }
+  #client-ui .searchable_member_list .team_list_item:hover { background: #fef9ed; }
+  .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #586e75 !important; }
+  #convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #586e75; }
+  #convo_tab textarea.message_input { color: #586e75; }
+  #reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #fcf3d9; color: #586e75; }
+  #reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #fbeecb; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #586e75; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #2aa198 !important; }
+  #reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #fdf6e3; color: #2aa198; }
+  #convo_container .convo_flexpane_divider { border-top-color: #fcf3d9; color: #2aa198; }
+  #convo_container .convo_flexpane_divider .reply_count { background: #fdf6e3; }
+  #convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #268bd2; }
+  #convo_tab .message_input, #convo_tab textarea#msg_text { color: #586e75; }
+  ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+  ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+  #whats_new_tab p { color: #586e75; }
+  #whats_new_tab .flex_heading_controls label { color: #2aa198; }
+  .c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #586e75; }
+  .c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #586e75; }
+  .c-member .external_team_badge { background-color: #fef9ed; box-shadow: 0 0 0 2px #fef9ed; }
+  .c-member .external_team_badge.default { background-color: #2aa198; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #fef9ed; }
+  .c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #586e75; }
+  .c-member--small .presence { color: #2aa198; }
+  .c-member--small .team_image.icon_16 { border-color: #fcf3d9; }
+  .c-member--small .team_image.default { background-color: #2aa198; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member--dark .c-member__current-status { color: #2aa198; }
+  .c-member--dark .c-member__current-status::before { color: #2aa198; }
+  .c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #2aa198; }
+  .c-member--dark .c-member__display-name, .c-member--dark .presence { color: #586e75; }
+  .c-member--medium { color: #2aa198; }
+  .c-member--medium .presence { color: #2aa198; }
+  .c-member__secondary-name--medium { color: #586e75; }
+  .c-member--large { color: #2aa198; }
+  .c-member__display-name--large, .c-member__title--large { color: #586e75; }
+  .c-member__other-names--large { color: #2aa198; }
+  .c-usergroup--small .c-usergroup__icon { background-color: #2aa198; color: #586e75; }
+  .c-usergroup__not-in-channel-context--small { color: #2aa198; }
+  .p-emoji_picker { background: #fbeecb !important; color: #586e75 !important; }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #fdf6e3; }
+  .p-emoji_picker__group_tabs { border-bottom-color: #fdf6e3; }
+  .p-emoji_picker__group_tab { color: #268bd2; }
+  .p-emoji_picker__group_tab:hover { background: #fcf3d9; color: #dc322f; }
+  .p-emoji_picker__group_tab--active { background: #fef9ed; border-bottom-color: #fdf6e3; color: #586e75; }
+  .p-emoji_picker__icon_search { color: #2aa198; }
+  .p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #fdf6e3; border-color: #fdf6e3; }
+  .p-emoji_picker__skintone_options { background: #fdf6e3; }
+  .p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #2aa198; }
+  .p-emoji_picker__tip { color: #586e75; }
+  .p-emoji_picker__no_results { color: #2aa198; }
+  .p-emoji_picker__preview_text { background: #fbeecb; color: #586e75; }
+  .p-emoji_picker__footer { background: #fbeecb; border-top-color: #fcf3d9; }
+  .p-emoji_picker__footer .p-emoji_picker__heading { background: #fbeecb; }
+  .p-emoji_picker__emoji_deluxe_label { color: #2aa198; }
+  input[type="text"].p-emoji_picker__input:focus { border-color: #fef9ed; box-shadow: none; }
+  #message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #2aa198; }
+  #message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #586e75; }
+  #message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #586e75; }
+  #message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #586e75; }
+  .current_status_emoji_picker { border-right-color: #fcf3d9; }
+  .current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #fbeecb; }
+  .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #2aa198; }
+  .rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #fcf3d9; border: 1px solid #fef9ed; }
+  .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #fdf6e3; }
+  .rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #586e75; }
+  .rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(253, 246, 227, 0.08); border-color: rgba(255, 254, 251, 0.4) !important; }
+  .rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #586e75; }
+  .rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #586e75; }
+  .rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(88, 110, 117, 0.25); }
+  a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #b58900; color: #fcf3d9; }
+  .modal { background-color: #fdf6e3; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  .modal .close, .modal label { color: #586e75; }
+  .modal_input_note, .modal_input_note_full_width, .input_note_special { color: #2aa198; }
+  .modal-footer { background: padding-box #fdf6e3; border-top: 1px solid transparent; box-shadow: none; }
+  .modal-header { background: padding-box #fbeecb; border-bottom: 1px solid #fcf3d9; color: #586e75; }
+  .modal-backdrop { background-color: #fdf6e3; }
+  .close { color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  #fs_modal_bg { background: #fdf6e3; }
+  #fs_modal { background: #fdf6e3; }
+  #fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #586e75; }
+  #fs_modal #fs_modal_sidebar a { color: #586e75; }
+  #fs_modal #fs_modal_sidebar a:hover { background: #fcf3d9; }
+  #fs_modal #fs_modal_sidebar a.active { background: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #fs_modal .fs_modal_btn { color: rgba(88, 110, 117, 0.5); }
+  #fs_modal .fs_modal_btn:hover { background: #fffefb; color: #586e75; }
+  #fs_modal .fs_modal_btn:active { background: #fffefb; color: #586e75; }
+  #fs_modal.fs_modal_header .fs_modal_btn:active { color: #586e75; }
+  #fs_modal #fs_modal_footer { background-color: #fcf3d9; }
+  .p-apps_browser__apps_list--loading::before { background-color: #fcf3d9; }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #fef9ed; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #fcf3d9; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+  .p-apps_browser__category_header { background: #fdf6e3; color: #2aa198; }
+  .p-apps_browser__app { border-top-color: #fef9ed; }
+  .p-apps_browser__app--selected { background: #fcf3d9; border-color: #fffefb; }
+  .p-apps_browser__app_info { color: #586e75; }
+  .p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+  .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #fffefb; color: #586e75; }
+  .p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__app_description { color: #2aa198; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #2aa198; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #586e75; }
+  #incoming_call { background-color: rgba(251, 238, 203, 0.97); color: #586e75; }
+  #fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #fcf3d9; }
+  #fs_modal.channel_options_modal .convert_to_shared label { color: #2aa198; }
+  #fs_modal.channel_options_modal .channel_option_item { border-top-color: #fcf3d9; }
+  #fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #586e75; }
+  #fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(251, 238, 203, 0.75); border-color: #fcf3d9; }
+  #channel_invite_container .lfs_list_container .lfs_item { border-top-color: #fcf3d9; }
+  #channel_invite_container .lfs_list_container .lfs_item.active { border-color: #fcf3d9; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #fcf3d9; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #2aa198; }
+  #channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #fdf6e3; border-color: #fcf3d9; }
+  #channel_prefs_dialog { color: #586e75; }
+  #at_channel_warning_dialog { background-color: #fdf6e3; }
+  #at_channel_warning_dialog.fullsize { background-color: #fdf6e3; }
+  #at_channel_warning_dialog.fullsize .modal-body { background-color: #fdf6e3; }
+  .channel_prefs_modal_header { color: #586e75; }
+  .channel_prefs_body__section_header_title { color: #586e75; }
+  .channel_prefs_body__section_header_icon::before { color: #586e75; }
+  .channel_prefs_body__mute_help_text { color: #2aa198; }
+  .channel_prefs_notifications_table { border-bottom-color: #fcf3d9; color: #586e75; }
+  .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #fef9ed !important; }
+  .channel_prefs__muting_checkbox_label { color: #586e75; }
+  .channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #586e75 !important; }
+  .notification_prefs_icon::before { color: #586e75; }
+  .channel_modal_header { color: #586e75; }
+  #channel_browser .channel_browser_row { border-top: 1px solid #fcf3d9; color: #586e75; }
+  #channel_browser .channel_browser_row_header { color: #586e75; }
+  #channel_browser .channel_browser_creator_name { color: #2aa198; }
+  #channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #2aa198; }
+  #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #fbeecb; border: 1px solid #fef9ed; }
+  #channel_browser .channel_browser_divider { background: transparent; color: #2aa198; }
+  #channel_browser .channel_browser_sort_container::after { color: #586e75; }
+  #channel_browser .channel_browser_channel_purpose { color: #586e75; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #268bd2; }
+  .channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #2aa198 !important; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #fbeecb; color: #586e75; }
+  #invite_members_container .lfs_input_container { background: #fef9ed; }
+  #notifications_not_working p.highlight_yellow_bg a { color: #586e75; }
+  #im_browser .im_browser_row { border-top: 1px solid #fef9ed; }
+  #im_browser .im_browser_row.multiparty { color: #586e75; }
+  #im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #fbeecb; }
+  #im_browser .im_browser_row .im_unread_cnt { background: #dc322f; color: #586e75; }
+  #im_browser .im_browser_row.disabled { color: #2aa198; }
+  #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser #im_browser .im_browser_row.highlighted { background: #fbeecb !important; border: 1px solid #fef9ed !important; }
+  #im_browser_tokens { background: #fef9ed; border: 1px solid #fffefb; }
+  #im_browser_tokens.active { border-color: #fffefb; box-shadow: 0 0 7px rgba(255, 254, 251, 0.15); }
+  #im_browser_tokens .member_token { background: #fdf6e3; border: 1px solid #fbeecb; color: #586e75; }
+  #im_browser_tokens .member_token.ra { background: #dc322f; }
+  .fs_modal_file_viewer_header { background-color: #fcf3d9; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .fs_modal_file_viewer_header .btn { color: #586e75; }
+  .fs_modal_file_viewer_header .star { color: #2aa198; }
+  .fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #586e75; }
+  .fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #586e75; }
+  .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #2aa198; }
+  .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #fef9ed; }
+  .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #2aa198; }
+  .fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #fef9ed; }
+  .fs_modal_file_viewer_content .viewer { background-color: #fbeecb; color: #586e75 !important; }
+  .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #fef9ed; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(255, 254, 251, 0.25); color: #586e75; }
+  .fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(42, 161, 152, 0.8); }
+  .fs_modal_file_viewer_content .aside_panel { background-color: #fdf6e3; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #fbeecb; }
+  .fs_modal_file_viewer_content .no_comment { background-color: #fdf6e3; color: #2aa198; }
+  .fs_modal_file_viewer_content .aside_close_btn { color: #586e75; }
+  .fs_modal_file_viewer_content #file_comment { color: #586e75; }
+  #file_comment_textarea.texty_comment_input { background: #fdf6e3; border-color: #fcf3d9; color: #586e75; }
+  #file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #fcf3d9; }
+  #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #2aa198; }
+  #fs_modal.help_modal .help_modal_header { background-color: #fcf3d9; border-color: #fef9ed; }
+  #fs_modal.help_modal .help_modal_header a { color: #586e75; }
+  #fs_modal.help_modal .help_modal_divider { color: #2aa198; }
+  #fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #fcf3d9; }
+  #fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #2aa198; }
+  #fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #fcf3d9; border-color: #fbeecb; }
+  .admin_invites_account_type_option { border-bottom: 1px solid #fcf3d9; }
+  .admin_invites_account_type_option p { color: #586e75; }
+  .admin_invites_account_type_option .option_arrow { color: #2aa198; }
+  .admin_invites_account_type_option:hover:not(.disabled) h3 { color: #586e75; }
+  .admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+  .admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(253, 246, 227, 0.95); }
+  .admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #2aa198; }
+  .admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #dc322f; }
+  .admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(220, 50, 47, 0.4); }
+  #admin_invites_channel_picker_container { border-bottom: 1px solid #fcf3d9; }
+  #admin_invites_add_row { background: #fef9ed; border: 1px solid #fcf3d9; }
+  #admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #fef9ed; }
+  #channel_invite_tokens { background-color: #fef9ed; border-color: #fffefb; }
+  #channel_invite_tokens.active { border-color: #2aa198; box-shadow: 0 0 7px rgba(42, 161, 152, 0.15); }
+  #channel_invite_tokens .member_token { background: #fdf6e3; color: #586e75; }
+  #channel_invite_tokens .member_token.ra { background: rgba(220, 50, 47, 0.4); }
+  #admin_invites_alert { background: #fef9ed; border-color: #fffefb; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #586e75; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #fdf6e3; color: #586e75; }
+  #shortcuts_dialog { background: rgba(253, 246, 227, 0.95); text-shadow: 0 1px 1px rgba(251, 238, 203, 0.7); }
+  #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #586e75; }
+  #shortcuts_dialog.modal ul ul { border-left-color: #fef9ed; }
+  #shortcuts_dialog.modal .info_block { color: #2aa198; }
+  #shortcuts_dialog.modal .close { background: #fef9ed; border-color: #fffefb; box-shadow: 0 1px 2px rgba(251, 238, 203, 0.5); color: #586e75; }
+  #shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(251, 238, 203, 0.9); }
+  #fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #2aa198; }
+  #fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #fcf3d9; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #fcf3d9; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #fdf6e3; border: 1px solid #fcf3d9; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #dc322f; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+  #fs_modal.prefs_modal legend { color: #586e75; }
+  #fs_modal.prefs_modal .global_notification_block { background: #fdf6e3; border-color: #fbeecb; }
+  #fs_modal.prefs_modal .global_notification_block.selected { background: #fcf3d9; border-color: #fbeecb; }
+  #fs_modal.prefs_modal .channel_overrides_row { border-top-color: #fbeecb; }
+  #fs_modal.prefs_modal .channel_overrides_row:hover { background: #fcf3d9; border-color: #fbeecb; }
+  #fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #586e75; }
+  #fs_modal.prefs_modal .notification_example.mac { background: #fbeecb; box-shadow: 0 1px 8px 2px #fcf3d9; }
+  #fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #fbeecb; color: #586e75; }
+  #fs_modal.prefs_modal .badge_example { background: #dc322f; }
+  #fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #fbeecb; border-top-color: #fbeecb; }
+  #fs_modal.prefs_modal .display_real_names_block_sample { background: #fdf6e3; }
+  .sidebar_menu_list_item { border: 0; color: #586e75; }
+  .sidebar_menu_list_item.is_active { background-color: #fbeecb; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .sidebar_menu_list_item:not(.is_active):hover { background-color: #fcf3d9; }
+  .jumbomoji_pref_disabled { color: #2aa198; }
+  .jumbomoji_disabled_note { color: rgba(42, 161, 152, 0.6); }
+  #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #fef9ed; border: 1px solid #fbeecb; }
+  #edit_team_profile_container .lazy_filter_select.disabled { background: #fef9ed; }
+  #edit_team_profile_container .lazy_filter_select.disabled input { background: #fef9ed; }
+  #edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #fcf3d9; }
+  #edit_team_profile_list .row:nth-last-child(2):hover { border-color: #fcf3d9 !important; }
+  #edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #fcf3d9; border: 1px solid #fbeecb; }
+  #edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #2aa198; }
+  #edit_team_profile_list .edit_team_profile_list_controls i { color: #586e75; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #2aa198; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #2aa198; }
+  #edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #fef9ed; }
+  #edit_team_profile_add .row:last-child { border-bottom: 1px solid #fef9ed; }
+  #edit_team_profile_add .row:not(.header_row):hover { background: #fcf3d9; border: 1px solid #fbeecb; }
+  #edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #586e75; }
+  #edit_team_profile_add .row:not(.header_row):hover i { border-color: #fbeecb; color: #586e75; }
+  #edit_team_profile_add i { color: #2aa198; }
+  #edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #2aa198; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #fbeecb; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #dc322f; border-color: #dc322f !important; color: #586e75; }
+  #edit_team_profile_edit .row i { border: 1px solid #fbeecb; color: #586e75; }
+  #edit_team_profile_custom .row .col .profile_field_preview { background: #fcf3d9; border: 2px solid #fbeecb; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #fcf3d9; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #2aa198; }
+  #edit_team_profile_custom .row .col input { background: #fef9ed; border: 1px solid #fbeecb; }
+  #edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #2aa198; }
+  #edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #fbeecb; }
+  .profile_field_preview_protector .profile_field_preview { background: #fdf6e3; border: 1px solid #fef9ed; }
+  .profile_field_preview_protector .profile_field_preview::after { background-color: #fdf6e3; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview::before { background-color: #fdf6e3; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #fef9ed; color: #2aa198; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #fbeecb, rgba(255, 255, 255, 0)); }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #fbeecb; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #fbeecb transparent transparent; }
+  ts-jumper ts-jumper-container { background: #fdf6e3; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #fdf6e3; color: #2aa198; }
+  ts-jumper input[type=text] { border: 1px solid #fbeecb !important; color: #586e75; }
+  ts-jumper input[type=text]:focus { border: 1px solid rgba(252, 243, 217, 0.8) !important; color: #586e75; }
+  ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #586e75; }
+  ts-jumper ol li { color: #586e75; }
+  ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #2aa198; }
+  ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #2aa198; }
+  ts-jumper ol li .unread_count { background: #dc322f; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  ts-jumper ol li.highlighted { background: #fffefb !important; color: #586e75 !important; }
+  ts-jumper ol:not(.keyboard_active) li:hover { background: #fffefb !important; color: #586e75 !important; }
+  ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #586e75; }
+  .basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+  .share_dialog_attachment_container { color: #586e75; }
+  #share_dialog .file_list_item { border-color: #fbeecb; }
+  #generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #2aa198; }
+  #share_dialog_input_container #file_comment_textarea.ql-container { border-color: #fcf3d9; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #fef9ed; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #586e75; }
+  .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #fef9ed; }
+  .ts_tip .ts_tip_tip { color: #586e75; }
+  .ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #fef9ed; }
+  .ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #fef9ed; }
+  .ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #fef9ed; }
+  .ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #fef9ed; }
+  .ts_tip.success .ts_tip_tip { background: #fffefb; }
+  .ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #fffefb; }
+  .ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #fffefb; }
+  .ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #fffefb; }
+  .ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #fffefb; }
+  .c-tooltip__tip { background-color: #fef9ed; color: #586e75; }
+  .c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+  .c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+  .c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #fef9ed; }
+  .c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #fef9ed; }
+  .c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+  .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+  .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #fef9ed; }
+  .c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #fef9ed; }
+  .c-tooltip__tip--success { background-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #859900; }
+  .c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #859900; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #fef9ed; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #fef9ed; }
+  #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(255, 254, 251, 0.5) !important; }
+  #coachmark_interior { color: #586e75; }
+  #coachmark_interior .coachmark_close_btn { color: #586e75; }
+  .menu_member_header { background: #fbeecb; }
+  .menu_member_header .member_details .member_name_and_presence { color: #586e75; }
+  .menu_member_header .member_details .member_name_and_presence .member_name { color: #586e75; }
+  .menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+  .menu_member_header .member_details .member_title { color: #2aa198; }
+  .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #2aa198; }
+  .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #268bd2; }
+  .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #dc322f; }
+  .menu_member_header .member_details_divider { border-color: #fef9ed; }
+  .menu_member_footer { background: #fbeecb; border-top: 1px solid #fef9ed; }
+  .menu_member_footer p { color: #2aa198; }
+  .member_meta { color: #268bd2; }
+  .mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #586e75 !important; }
+  .greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #2aa198 !important; }
+  .clear_blue { color: #268bd2 !important; }
+  .moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #dc322f !important; }
+  .seafoam_green { color: #859900 !important; }
+  .candy_red_bg { background-color: #dc322f !important; }
+  .off_white_bg, .neutral_white_bg { background-color: #fcf3d9 !important; }
+  .yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #fdf6e3 !important; }
+  .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #fef9ed !important; }
+  .sk_black { color: inherit; }
+  .monkey_scroll_bar { z-index: 99; }
+  .client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+  nav.top.persistent { background: #fcf3d9; }
+  nav.top.persistent .logo { background-position: 50% 0 !important; }
+  .widescreen #header_team_name a i { margin-left: 1.5em; }
+  .widescreen #user_menu { border-right: none; }
+  header #menu_toggle { color: #268bd2; }
+  header #header_team_nav { background: #fcf3d9; border: 1px solid #fbeecb; }
+  header #header_team_nav li.active a { background: #fdf6e3; color: #586e75; }
+  header .header_btns a { color: #268bd2; }
+  header .header_btns a .label { color: #2aa198; }
+  header .vert_divider { border-left: 1px solid #fbeecb; }
+  footer, #autocomplete_menu.search_menu footer.unified { background-color: #fcf3d9; border-color: #fbeecb; color: #586e75; }
+  footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #586e75; }
+  footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #586e75; }
+  .plastic_row h3 { color: #586e75; }
+  .plastic_row h4 a { color: #586e75; }
+  .plastic_row .icon { color: #586e75; }
+  .plastic_row .chevron { color: #2aa198; }
+  .plastic_row .description { color: #586e75; }
+  .plastic_row:active { background: #fdf6e3; border-color: #fbeecb; }
+  .plastic_row:active .chevron { color: #586e75; }
+  html.no_touch .plastic_row:hover { background: #fdf6e3; border-color: #fbeecb; }
+  html.no_touch .plastic_row:hover .chevron { color: #586e75; }
+  html.no_touch .pagination ul > li > a:hover { background-color: #fbeecb; }
+  html.no_touch .pagination ul > .disabled > a:hover { background: #fcf3d9; color: #2aa198; }
+  html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #dc322f; }
+  .card, .tab_pane { background: #fcf3d9; border: 1px solid #fbeecb; color: #586e75; }
+  .card h3 a { color: #586e75; }
+  #page_contents .card { background: rgba(252, 243, 217, 0.8) !important; }
+  #page_contents .card p { color: #586e75; }
+  .tab_set a.secondary { color: #268bd2; }
+  .tab_set a.selected, .tab_set a.secondary.selected { background: #fcf3d9; border: 1px solid #fbeecb; border-bottom-color: #fcf3d9; color: #dc322f; }
+  .tab_actions { background: #fcf3d9; border: 1px solid #fbeecb; border-color: #fbeecb; }
+  .accordion_section { border-bottom-color: #fdf6e3; }
+  .accordion_section h4 { color: #586e75; }
+  .accordion_section h4 a { color: #586e75; }
+  .no_touch .accordion_section h4 a:hover { color: #586e75; }
+  .accordion_section_fixed { border-bottom-color: #fdf6e3 !important; }
+  .pager li > a, .pager li > span { background-color: #fdf6e3; background-image: none; border-color: #fcf3d9; color: #268bd2; }
+  .pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+  .pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+  .pager .disabled > a, .pager .disabled > span { color: #2aa198; }
+  .pagination ul > li > a, .pagination ul > li > span { background: #fcf3d9; border: 1px solid #fbeecb; color: #586e75; }
+  .pagination ul > li > a:focus { background-color: #fbeecb; }
+  .pagination ul > .active > a, .pagination ul > .active > span { background-color: #fbeecb; }
+  .pagination ul > .disabled > span { background: #fcf3d9; color: #2aa198; }
+  .pagination ul > .disabled > a { background: #fcf3d9; color: #268bd2; }
+  .pagination ul > .disabled > a:focus { background: #fcf3d9; color: #dc322f; }
+  .loading_hash_animation img { display: none; }
+  .icon_search_close { color: #268bd2; }
+  .icon_search_close:hover { color: #dc322f; }
+  .help { border-top-color: #fbeecb; color: #2aa198; }
+  .two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+  .two_factor_choice { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  .two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  .two_factor_choice:hover .two_factor_link { color: #586e75; }
+  a.two_factor_choice { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:link { background-color: #fcf3d9; border: 1px solid #fef9ed; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #586e75; }
+  .backup_codes { background: #fbeecb; border-color: #fef9ed; color: #586e75; }
+  #channel_specific_settings tr { border-top-color: #fdf6e3; }
+  #channel_specific_settings tr.channel_override_row.muted td { background: rgba(253, 246, 227, 0.5); }
+  #channel_specific_settings .extra_left_border { border-left-color: #fdf6e3; }
+  #channel_specific_settings .extra_right_border { border-right-color: #fdf6e3; }
+  #channel_specific_settings .revert_to_default { color: #2aa198; }
+  #channel_specific_settings .revert_to_default:hover { color: #dc322f; }
+  .admin_list_item { border-bottom-color: #fdf6e3; color: #2aa198; }
+  .admin_list_item:hover { background-color: #fcf3d9; }
+  .admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #586e75; }
+  .admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #2aa198; }
+  .admin_list_item .pill.group { background: #fdf6e3; }
+  .admin_list_item .two_factor_auth_badge:hover { background: #fdf6e3; }
+  .admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+  .admin_list_item.invite_item.bouncing { background: #fffefb; }
+  .admin_list_item.invite_item.bouncing .email { color: #dc322f; }
+  .admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #fdf6e3; }
+  .admin_list_item.expanded .btn_outline { border-color: #fdf6e3; color: #586e75 !important; }
+  .admin_list_item.expanded .btn_outline:hover { border-color: #fcf3d9; color: #586e75 !important; }
+  .admin_list_item.expanded .sub_action { color: #268bd2; }
+  .admin_list_item.expanded .sub_action:hover { color: #dc322f; }
+  @media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #268bd2; } }
+  .billing_selection { border-color: #fbeecb; color: #586e75 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection:hover { border-color: #fffefb; }
+  .billing_selection.active { background: #fef9ed; border-color: #fffefb; }
+  .billing_selection.billing_selection--refactor { border-color: #fef9ed; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection.billing_selection--refactor:hover { border-color: #fffefb; }
+  .billing_selection.billing_selection--refactor.active { background: #fef9ed; border-color: #fffefb; }
+  .billing_selection .billing_selection__price { color: #586e75; }
+  #billing_contacts_container { background: #fcf3d9; border-top: 1px solid #fbeecb; }
+  .billing_contact { border-bottom: 1px solid #fdf6e3; }
+  table.billing tr:hover td { background: #fcf3d9; }
+  .link_billing_statement { color: #586e75 !important; }
+  .link_invoice_id, .link_statement_id { color: #268bd2 !important; }
+  .billing_invoice tbody tbody tr { color: #586e75 !important; }
+  .billing_settings_label_name { color: #586e75; }
+  table tr { border-bottom-color: #fdf6e3; }
+  table tr:first-child th:not(:only-of-type) { border-bottom-color: #fbeecb; }
+  .slackbot_response_fieldset .delete_response { color: #2aa198; }
+  .slackbot_response_fieldset .delete_response:hover { color: #dc322f; }
+  .author_cell { color: #586e75; }
+  .message_cell.disabled { color: #2aa198; }
+  #message_container #msg_limit { color: #586e75; }
+  .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #fef9ed; }
+  .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #fef9ed; }
+  .inactive { background-image: none; }
+  .c3 line, .c3 path { stroke: #fffefb; }
+  .c3-chart-arc .c3-gauge-value { fill: #fffefb; }
+  .c3-chart-arc path { stroke: #fcf3d9; }
+  .c3-chart-arc text { fill: #fcf3d9; }
+  .c3-chart-arcs .c3-chart-arcs-background { fill: #fef9ed; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #fcf3d9; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #fffefb; }
+  .c3-circle._expanded_ { stroke: #fcf3d9; }
+  .c3-grid line { stroke: #fffefb; }
+  .c3-grid text { fill: #586e75; }
+  .c3-legend-background { fill: #fcf3d9; stroke: #fef9ed; }
+  .c3-region { fill: #fef9ed; }
+  .c3-selected-circle { fill: #fcf3d9; }
+  .c3-tooltip { background-color: #fcf3d9; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+  .c3-tooltip td { background-color: #fcf3d9; border-left-color: #fef9ed; }
+  .c3-tooltip th { background-color: #fcf3d9; color: #586e75; }
+  .c3-tooltip tr { border-color: #fef9ed; }
+  .ent_alert a { color: #268bd2; }
+  .ent_alert a:link, .ent_alert a:visited { color: #dc322f; }
+  .ent_alert_page.ent_alert_error { background: #dc322f; }
+  .ent_alert_page.ent_alert_success { background: #859900; }
+  .ent_analytics__disclaimer { border-top-color: #fffefb; color: #2aa198; }
+  .ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+  .ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+  .ent_avatar { background-color: #fef9ed; }
+  .ent_callout__difference--increase { color: #859900; }
+  .ent_callout__icon_border { background-color: #fcf3d9; border-color: #fffefb; }
+  .ent_callout__icon_image, .ent_callout__icon--filled { border-color: #fffefb; }
+  .ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #fef9ed; }
+  .ent_callout__icon--limit_reached { border-color: #fffefb; }
+  .ent_callout__insight { color: #2aa198; }
+  .ent_callout__limit { color: #2aa198; }
+  .ent_callout__meter_bar_container { background: #fdf6e3; }
+  .ent_callout__meter_bar_border { border-color: #fdf6e3; }
+  .ent_callout__meter_bar_fill--empty { background: #fffefb; border-color: #fffefb; }
+  .ent_callout__meter_bar_fill--filled { background: #fffefb; border-color: #fffefb; }
+  .ent_callout__meter_bar_fill--limit_reached { background: #dc322f; border-color: #dc322f; }
+  .ent_callout__meter_bar_gleam { background: rgba(255, 254, 251, 0.5); }
+  .ent_callout__title { color: #586e75; }
+  .ent_copy_muted { color: #2aa198; }
+  .ent_copy { color: #586e75; }
+  .ent_csv_popover__footer_text { color: #2aa198; }
+  .ent_csv_popover__footer { background: #fcf3d9; border-top-color: #fffefb; }
+  .ent_csv_popover__subtitle { color: #2aa198; }
+  .ent_csv_popover__title { color: #586e75; }
+  .ent_data_table__cell--header { color: #2aa198; }
+  .ent_data_table__cell--positive { color: #586e75; }
+  .ent_data_table__cell--sortable:hover { background-color: #fcf3d9; }
+  .ent_data_table__cell--sorting { color: #2aa198; }
+  .ent_data_table__cell { border-bottom-color: #fffefb; color: #586e75; }
+  .ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #fffefb; }
+  .ent_data_table__column_group { background-color: #fcf3d9; }
+  .ent_data_table__data_link, a.ent_data_table__data_link { color: #586e75; }
+  .ent_data_table__row--hovered { background-color: #fdf6e3; }
+  .ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+  .ent_data_table__secondary_text { color: #2aa198; }
+  .ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #fcf3d9; }
+  .ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #fffefb; }
+  .ent_data_table--rounded_top { border-top-color: #fffefb; }
+  .ent_data_table { border-bottom-color: #fffefb; border-left-color: #fffefb; border-right-color: #fffefb; }
+  .ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #586e75; }
+  .ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #2aa198; }
+  .ent_graph__legend_item--defocus { fill: #2aa198 !important; }
+  .ent_graph__legend_text { fill: #586e75; }
+  .ent_graph__svg_container .c3-axis path { stroke: #fffefb; }
+  .ent_graph__svg_container .c3-grid line { stroke: #fffefb; }
+  .ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #fffefb; }
+  .ent_graph__svg_container .c3-tooltip { border-color: #fffefb; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+  .ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #fcf3d9; color: #586e75; }
+  .ent_graph__svg_container .c3-tooltip th { border-bottom-color: #fffefb; }
+  .ent_graph__svg_container .c3-xgrid-focus line { stroke: #2aa198; }
+  .ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #fcf3d9 !important; }
+  .ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #fcf3d9 !important; }
+  .ent_graph__svg_container text { fill: #2aa198; }
+  .ent_graph__tooltip { color: #2aa198; }
+  .ent_graph_empty__overlay { background: #fcf3d9; }
+  .ent_graph_empty__text { color: #586e75; }
+  .ent_graph_header--primary { color: #586e75; }
+  .ent_graph_header--secondary { color: #2aa198; }
+  .ent_graph_tabs__tab--selected { color: #586e75; }
+  .ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #fffefb; }
+  .ent_graph_tabs__tab { color: #2aa198; }
+  .ent_graph_tabs { border-bottom-color: #fffefb; }
+  .ent_header { color: #586e75; }
+  .ent_icon_button { color: #2aa198; }
+  .ent_icon_button:hover { color: #586e75; }
+  .ent_infographic_container { border-top-color: #fffefb; }
+  .ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(252, 243, 217, 0.8), #fcf3d9); }
+  .ent_modal__title--small { color: #586e75; }
+  .ent_modal_background { background-color: #fdf6e3; }
+  .ent_modal_breadcrumb_animated_step { background: #fef9ed; }
+  .ent_modal_breadcrumb_circle_icon { background: #fdf6e3; }
+  .ent_modal_breadcrumb_line { background: #fef9ed; }
+  .ent_modal_breadcrumb_text { color: #2aa198; }
+  .ent_modal_footer { background-color: #fcf3d9; }
+  .ent_modal_title { color: #586e75; }
+  .ent_table__header--title { color: #586e75; }
+  .ent_table__header { background-color: #fdf6e3; border-color: #fffefb; }
+  .ent_table_banner__contents { background: #fdf6e3; border-top-color: #fffefb; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+  .ent_table_banner__header { color: #586e75; }
+  .ent_table_banner__secondary_text { color: #2aa198; }
+  .ent_table_customizer__header_subtitle { color: #2aa198; }
+  .ent_table_customizer_disabled_list_header { color: #2aa198; }
+  .ent_table_customizer_footer { background-color: #fdf6e3; border-top-color: #fbeecb; color: #2aa198; }
+  .ent_table_customizer_header { border-bottom-color: #fdf6e3; }
+  .ent_table_customizer_list_item--disabled { color: #2aa198; }
+  .ent_updated_at { color: #2aa198; }
+  .enterprise { background-color: #fcf3d9; }
+  .enterprise .btn.candy_red { color: #dc322f !important; }
+  .enterprise_analytics { background-color: #fcf3d9; }
+  .enterprise_org { background-color: #fcf3d9; }
+  .enterprise_search_bar .ent_clear_search_icon { color: #2aa198; }
+  .enterprise_search_bar::before { color: #586e75; }
+  @keyframes color_fade { from { color: #2aa198; }
+    to { color: #586e75; } }
+  .file_header .title a { color: #268bd2; }
+  .file_header .title a:hover { color: #dc322f; }
+  .file_actions_cog { color: #268bd2 !important; }
+  .file_actions_cog:hover { color: #dc322f !important; }
+  .file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #fbeecb; }
+  .action_cog { color: #268bd2; }
+  .action_cog i { color: #268bd2; }
+  html.no_touch .action_cog:hover { color: #dc322f; }
+  html.no_touch .action_cog:hover i { color: #dc322f; }
+  .help_pages.help_pages p { color: #586e75; }
+  .help_pages.help_pages a { border-bottom-color: #fef9ed; }
+  .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #fdf6e3; }
+  .help_pages.help_pages .o-hero__header { color: #586e75; }
+  .help_pages.help_pages .o-section--feature { background-color: #fcf3d9; border-top-color: #fef9ed; }
+  .help_pages.help_pages .c-form__container .c-form__feedback { color: #dc322f; }
+  .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #fdf6e3; border-color: #fef9ed; color: #586e75; }
+  .help_pages.help_pages .drop_zone { background: #fdf6e3; border-color: #fffefb; }
+  .help_pages.help_pages .drop_zone_attachment { border-bottom-color: #fef9ed; }
+  .help_pages.help_pages .drop_zone_remove_attachment { background-color: #fdf6e3; }
+  .help_pages.help_pages .c-form__notice { background-color: #fef9ed; border-color: #fffefb; color: #586e75; }
+  .help_pages.help_pages .c-form__notice.is-error { border-left-color: #dc322f; }
+  .help_pages.help_pages .c-nav--footer { border-top-color: #fef9ed; }
+  @media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #fdf6e3; } }
+  .widescreen:not(.nav_open) { color: #586e75; }
+  @media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(253, 246, 227, 0.9); } }
+  .widescreen:not(.nav_open) nav#site_nav h3 { color: #586e75; }
+  .widescreen:not(.nav_open) nav#site_nav ul a { color: #268bd2; }
+  .widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #dc322f; }
+  .widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #2aa198; }
+  nav#site_nav { background: #fcf3d9; }
+  nav#site_nav #user_menu_contents:hover { background: #fdf6e3; color: #586e75; }
+  header { background: #fcf3d9; }
+  header #header_team_nav li a { color: #586e75; }
+  header #header_team_nav li a:hover { background: #fdf6e3; color: #586e75; }
+  header #header_team_nav li a .team_icon.ts_icon_plus { background: #fbeecb; color: #2aa198; }
+  header #header_team_nav #add_team_option { border-top: 1px solid #fbeecb; }
+  html.no_touch header #header_team_nav li a { color: #586e75; }
+  html.no_touch header #header_team_nav li a:hover { background: #fdf6e3; color: #586e75; }
+  html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #dc322f; }
+  html.no_touch header .header_btns a:hover { color: #dc322f; }
+  html.no_touch header .header_btns a:hover .label { color: #2aa198; }
+  nav#site_nav h3, #header_team_name, header #header_team_name a { color: #268bd2; }
+  nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #dc322f; }
+  #home_footer a { color: #dc322f; }
+  .admin_pref:not(:first-of-type) { border-top-color: #fdf6e3; }
+  .admin_pref.locked { background-color: rgba(220, 50, 47, 0.2); }
+  .admin_pref .admin_pref_locked_label { color: #2aa198; }
+  .tooltip-inner { background-color: #fffefb; color: #586e75; }
+  .tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #fffefb; }
+  .tooltip.right .tooltip-arrow { border-right-color: #fffefb; }
+  .tooltip.left .tooltip-arrow { border-left-color: #fffefb; }
+  .tooltip.bottom .tooltip-arrow { border-bottom-color: #fffefb; }
+  .api #header_logo img { display: none; }
+  body.api header .header_links a { color: #586e75; }
+  body.api header .header_links a.active { background: #fef9ed; }
+  body.api .reverse_header { background-color: #fbeecb; color: #586e75; }
+  body.api pre { overflow-x: auto; }
+  body.api pre code { color: #586e75; }
+  body.api #page_contents .card { background: #fcf3d9; }
+  body.api .scopes_to_methods code { color: #586e75; }
+  body.api .scopes_to_methods .selected code { color: #dc322f; }
+  body.api .scopes_to_methods li { color: #586e75; }
+  body.api .scopes_to_methods .selected li { color: #586e75; }
+  body.api .section_title { border-bottom: 2px solid #fdf6e3; }
+  body.api .example { border: 1px solid #fbeecb; }
+  body.api .example h5 { background-color: #fbeecb; color: #586e75; }
+  body.api .alert { background: #fef9ed; }
+  body.api .hljs { background-image: none; }
+  body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+  body.api .hljs-number { color: #a5d6a7; }
+  body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+  body.api .hljs-variable { color: #9fa8da; }
+  body.api .hljs-template-variable { color: #c5e1a5; }
+  body.api .hljs-comment { color: #ffcc80; }
+  body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+  body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+  body.api .hljs-meta { color: #eee; }
+  body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+  body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+  body.api .hljs-tag { color: #a5d6a7; }
+  body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+  body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+  body.api .hljs-quote { color: #b0bec5; }
+  body.api .hljs-link, body.api .hljs-regexp { color: #268bd2; }
+  body.api span.btn { background-color: #fdf6e3; }
+  body.api span.deprecation, body.api span.warning { background-color: #dc322f; border-color: #dc322f; }
+  nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #api_nav .footer_nav a { color: #268bd2; }
+  #api_nav .footer_nav a:hover { color: #dc322f; }
+  #api_nav .footer_nav .footer_signature { color: #dc322f; }
+  .api_articles .api_articles_section { border-bottom-color: #fdf6e3; }
+  .api_articles .article_tag_count { color: #2aa198; }
+  .api.feature_related_content #api_related_content h2 { color: #586e75; }
+  .api.feature_related_content #api_related_content .article_link_title_wrapper { color: #268bd2; }
+  .tab_menu { background-color: #fcf3d9; }
+  .tab_menu.grey { background-color: #fcf3d9; }
+  .tab_menu .tab { color: #586e75; }
+  .tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(220, 50, 47, 0.4); }
+  .tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #dc322f; color: #586e75; }
+  .tab_menu .tab:disabled { color: #2aa198; }
+  .page_faq h3, .page_scim h3 { background-color: #fdf6e3; }
+  .application_config aside { color: #2aa198; }
+  .page_apps_directory_home { background-color: #fdf6e3 !important; }
+  .page_apps_directory_home .nav_title { color: #586e75 !important; }
+  .page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #2aa198; }
+  .page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #fffefb; }
+  .splash_container__background { background-color: #fcf3d9; }
+  .splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+  .splash_interactive__button { border-color: #fef9ed; }
+  .splash_interactive__button--active { box-shadow: 0 0 10px 1px #fffefb; }
+  .splash_interactive__window { background-color: #fdf6e3; border-color: #fef9ed; }
+  .splash_interactive__window:hover .splash_interactive__window_headline { color: #586e75; }
+  .splash_interactive__window::after { background: linear-gradient(to bottom, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+  .splash_interactive__window_response { background-color: #fff; }
+  a.splash_interactive__window_link { color: #586e75; }
+  .splash_interactive__window_message_content_text--drive { color: #2aa198; }
+  .search_input.apps_search_input { border-color: #fffefb; }
+  .menu_launcher, .menu_launcher_large { background-color: #fef9ed; border-color: #fdf6e3 !important; color: #586e75; }
+  .menu_launcher_large { border-color: #fdf6e3; }
+  .menu.avatar_menu ul li:hover ts-icon { background: #fef9ed; color: #586e75; }
+  .menu.avatar_menu ul li a { color: #586e75; }
+  .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #fef9ed; color: #2aa198; }
+  .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #586e75; }
+  #page .media_list { background-color: #fcf3d9; border: 1px solid #fef9ed; }
+  #page .media_list > li + li::before { border-top-color: #fef9ed; }
+  #page .media_list > li.interactive a { color: #586e75; }
+  #page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #fef9ed; border-color: #fffefb; }
+  #page .media_list > li .media_list_text { color: #586e75; }
+  #page .media_list.media_list_with_arrows a::before { color: #2aa198; }
+  #page .media_list_title { color: #586e75; }
+  #page .media_list_subtitle { color: #2aa198; }
+  #page .sidebar_menu_list_item { color: #586e75; }
+  #page .sidebar_menu_list_item.is_active { background-color: #fdf6e3; border-color: #fdf6e3; color: #586e75; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #page .sidebar_menu_list_item.is_active a { color: #586e75; }
+  #page .sidebar_menu_list_item:not(.is_active):hover { background-color: #fdf6e3; border-color: #fdf6e3; }
+  #page .sidebar_menu_list_item a { color: #586e75; }
+  #page ul.breadcrumbs li { color: #2aa198; }
+  #page ul.breadcrumbs li:not(:first-child)::before { color: #2aa198; }
+  #page ul.navigation_list li a { color: #586e75; }
+  #page ul.navigation_list li a:hover { background-color: #fef9ed; }
+  #page ul.navigation_list li a::after { color: #586e75; }
+  #page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+  #page .tag { background-color: #fbeecb; border: 1px solid #fcf3d9; }
+  #page .tag:hover { background-color: #fef9ed !important; }
+  #page .app_desc_btn { background-color: #fef9ed; color: #586e75; }
+  #page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(253, 246, 227, 0) 0, #fdf6e3 100%); }
+  #page .service_panel { background-color: #fcf3d9; }
+  #page .service_card { background-color: #fdf6e3; border: 1px solid #fdf6e3; }
+  .app_card, .large_app_card { background-color: #fdf6e3; border: 1px solid #fcf3d9; }
+  nav.top.persistent ul a { color: #586e75; }
+  nav.top.apps_nav { background: transparent; }
+  nav.top.apps_nav.persistent .nav_title { border-color: #fffefb; }
+  nav.top.apps_nav.clear_nav .nav_title a { color: #586e75; }
+  nav.top.apps_nav .nav_title a { color: #586e75; }
+  nav.top.apps_nav ul a.active { color: #dc322f; }
+  .plastic_typeahead { background: #fcf3d9; border: 1px solid #fcf3d9; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+  .plastic_typeahead_item { color: #586e75; }
+  .plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #fef9ed; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #fdf6e3; border-top-color: #fcf3d9; color: #586e75; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #2aa198; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #fbeecb; border-color: #fef9ed; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #fef9ed; }
+  a.plastic_typeahead_item { color: #586e75; }
+  .apps_typeahead_item_media { background: #fbeecb; }
+  .search_input_container .search_input:focus ~ .icon_search_input { color: #586e75; }
+  .icon_search_input { color: #2aa198; }
+  .quote_block { color: #586e75; }
+  .quote_block::before { background-color: #fef9ed; }
+  .well { background: #fbeecb; border-color: #fbebc2; color: #586e75; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #2aa198; }
+  .c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #fef9ed; }
+  .c-tabs__tab { color: #2aa198; }
+  .c-tabs__tab:hover { color: #586e75; }
+  .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #fffefb; color: #586e75; }
+  .c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #fef9ed; }
+  a.c-tabs__tab--plastic { color: #2aa198; }
+  a.c-tabs__tab--plastic:hover { color: #586e75; }
+  a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #fffefb; color: #586e75; }
+  .p-detail_scope { box-shadow: inset 0 1px 0 0 #fef9ed; }
+  .p-detail_scope:last-child { border-bottom-color: #fef9ed; }
+  .p-detail_dangerous_scope { border-left-color: #dc322f; border-right-color: #fef9ed; }
+  .p-detail_arrow_icon { color: #2aa198; }
+  .p-detail_arrow_icon:hover { color: #586e75; }
+  .p-detail_permissions { background: #fcf3d9; border-color: #fef9ed; }
+  table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #fef9ed; }
+  .section_rollup { border-bottom-color: #fdf6e3; }
+  .section_rollup:first-of-type { border-top-color: #fdf6e3; }
+  .section_rollup:hover:not(.is_active) { background: rgba(253, 246, 227, 0.5); color: #586e75; }
+  .is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #859900; color: #fbeecb; }
+  .developer_apps_functionality_link:hover { border-color: #fef9ed; box-shadow: 0 0 6px 0 rgba(255, 254, 251, 0.25); }
+  .developer_apps_functionality_link::before { background-color: #fef9ed; }
+  .developer_apps_functionality_link_enabled::before { background-color: #859900; }
+  .legal-hero { background-color: #fdf6e3; }
+  .legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #fdf6e3; }
+  .legal-hero .o-hero__header__headline--larger { color: #586e75; }
+  .legal-main { background-color: #fcf3d9; }
+  .legal-main.v--no-switch { background-color: #fcf3d9; border-bottom-color: #fef9ed; border-top-color: #fef9ed; }
+  .legal-main p { color: #586e75; }
+  .legal-main a { border-bottom-color: #fef9ed; }
+  @media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #586e75; }
+    .legal-main .c-nav--sidebar__listitem a.is-selected { color: #2aa198; } }
+  .legal-main .t-contains-subtle-links a:not(.c-button) { color: #586e75; }
+  .legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #2aa198; }
+  @media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #fcf3d9; } }
+  .t-no-header .legal-hero.o-hero.v--short { background-color: #fcf3d9; }
+  .c-oauth_scope_info__spacer_icon { color: #dc322f; }
+  .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #fef9ed; }
+  .c-oauth_scope_info__dangerous_scopes { border-left-color: #dc322f; border-right-color: #fef9ed; border-top-color: #fef9ed; }
+  .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #fef9ed; }
+  a.p-oauth_nav__anchor { color: #2aa198; }
+  .p-oauth_nav__team-switcher .menu_launcher { border-color: #fcf3d9; }
+  .p-oauth_nav__team-switcher .menu_launcher:hover { border: #fef9ed; }
+  .p-oauth_page, .p-oauth_page--error { background: #fdf6e3; }
+  .p-oauth_page__title { color: #586e75; }
+  .p-oauth_page_single_channel_picker { border-bottom-color: #fcf3d9; }
+  ts-rocket { color: #586e75; }
+  ts-rocket a { color: #268bd2; }
+  ts-rocket a caret::before { background-color: #fcf3d9; border-color: #fcf3d9; }
+  ts-rocket hr { border-color: #fcf3d9; }
+  ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #fbeecb; }
+  ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #fbeecb; }
+  ts-rocket .cl.text { background-color: #fbeecb; border-bottom: 1px solid #fcf3d9; }
+  ts-rocket .cl.text .checkbox.checked + li { color: #2aa198; }
+  ts-rocket > div > .checklist { background-color: #fbeecb; border-bottom: 1px solid #fcf3d9; }
+  ts-rocket > div > .checklist .checkbox.checked + li { color: #2aa198; }
+  ts-rocket > div > .checklist li::before { background: #fcf3d9; }
+  ts-rocket > div > .checklist li.checked { color: #2aa198; }
+  ts-rocket .unfurl .unfurl-container { background-color: #fbeecb; }
+  ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(220, 50, 47, 0.1); }
+  ts-rocket .unfurl .attachment_bar { background-color: #fcf3d9 !important; }
+  ts-rocket .unfurl .unfurl-remove::before { color: #2aa198; }
+  ts-rocket .unfurl .unfurl-remove:hover::before { color: #586e75; }
+  ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(255, 254, 251, 0.5); }
+  ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(255, 254, 251, 0.5) !important; }
+  ts-rocket caret::before { background-color: #fcf3d9; border: 1px solid #fcf3d9; }
+  ts-rocket carriage { background-color: rgba(255, 254, 251, 0.5); }
+  ts-rocket selection { background-color: rgba(255, 254, 251, 0.5); }
+  ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(255, 254, 251, 0.5); }
+  ts-rocket ime { background-color: rgba(255, 254, 251, 0.5); }
+  ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(255, 254, 251, 0.5); }
+  .focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #fbeecb; }
+  nav { background: #fcf3d9; }
+  nav .space { background-color: #fcf3d9; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+  nav .space::after { border-left: 1px solid #fef9ed; }
+  nav .comments { background-color: #fcf3d9; }
+  nav .space_buttons .btn_outline { background-color: #fdf6e3; }
+  nav .space_buttons .btn_outline::after { border-color: #fef9ed; }
+  nav .space_btn_star { background: none; border: 0; }
+  nav .space_btn_star:hover { background: none !important; }
+  nav .space_btn_edit { background: #fef9ed; }
+  nav .space_btn_edit.editing { background: #fffefb; }
+  nav .star_info { color: #2aa198; }
+  nav #space_status { border-left: 1px solid #fef9ed; color: #2aa198; }
+  nav #space_status.slightly_concerned { color: #dc322f; }
+  nav #edit_status { color: #2aa198; }
+  nav .comments_open.unread span.notif { background-color: #dc322f; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+  nav .comments_close { color: #2aa198; }
+  nav .comments_close:hover::before { color: #268bd2 !important; }
+  ts-space header { background: transparent; }
+  ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #586e75; }
+  ts-space header .owner_detail .inline-edit { background: none; }
+  ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #586e75; }
+  ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #586e75; }
+  ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #2aa198; }
+  ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #2aa198; }
+  ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(255, 254, 251, 0.5); }
+  ts-space header .owner_detail small { color: #2aa198; }
+  ts-space header .divider { border-top: 1px solid #fef9ed; }
+  ts-space a.feedback { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+  ts-space a.feedback:hover { background-color: #fcf3d9; color: #586e75; }
+  comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+  #space_alert { background-color: #fbeecb; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+  #space_alert.error { background-color: #dc322f; }
+  #space_alert span#space_alert_text { color: #586e75; }
+  #space_alert a { color: #268bd2; }
+  #space_alert button#space_alert_close::before { color: #2aa198; }
+  #space_alert button#space_alert_close:hover::before { color: #2aa198; }
+  #space_alert .btn_outline.btn_transparent { background-color: #fdf6e3 !important; color: #586e75 !important; }
+  #space_alert .btn_outline.btn_transparent::after { border-color: #fef9ed; }
+  #space_find_bar { background-color: #fcf3d9; border-bottom: 1px solid rgba(255, 254, 251, 0.1); border-left: 1px solid rgba(255, 254, 251, 0.07); border-right: 1px solid rgba(255, 254, 251, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #space_find_bar #space_find_info.no_matches { color: #dc322f; }
+  #space_find_bar #space_find_next .ts_icon { background-color: #fef9ed; }
+  #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #586e75; }
+  #space_find_bar #space_find_next:hover .ts_icon { background-color: #fffefb; }
+  #space_find_bar #space_find_close::before { color: #2aa198; }
+  #space_find_bar #space_find_close:hover::before { color: #2aa198; }
+  #connected_members .connected_members_count { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+  #connected_members .toggle_more_members_popover { background: #fdf6e3; color: #2aa198; }
+  #connected_members_overflow_popover { border-bottom: 1px solid #fcf3d9; border-left: 1px solid rgba(251, 238, 203, 0.11); border-right: 1px solid rgba(251, 238, 203, 0.11); border-top: 1px solid rgba(251, 238, 203, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .arrow::after { background-color: #fcf3d9; }
+  #connected_members_overflow_popover .arrow_shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .monkey_scroll_wrapper { background: #fcf3d9; }
+  #connection_status #connection_label { color: #586e75; text-shadow: -1px -1px 0 #fbeecb, -1px 1px 0 #fbeecb, 1px 1px 0 #fbeecb, 1px -1px 0 #fbeecb; }
+  #shortcuts_spaces_dialog { background-color: rgba(251, 238, 203, 0.8); text-shadow: 0 1px 1px rgba(252, 243, 217, 0.7); }
+  #shortcuts_spaces_dialog .modal-body { color: #586e75; }
+  #shortcuts_spaces_dialog .col .keyboard { background-color: #fffefb; border-bottom: 2px solid #fdf6e3; box-shadow: 0 1px 2px rgba(251, 238, 203, 0.5); color: #586e75; }
+  #shortcuts_spaces_dialog .close:hover { background-color: #fffefb; }
+  #shortcuts_spaces_dialog .close .ts_icon::before { color: #2aa198 !important; }
+  .textstyle_menu .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fcf3d9; }
+  .textstyle_menu .arrow::after { background-color: #fcf3d9; }
+  .textstyle_menu .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fcf3d9, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .arrow-shadow::after { background-color: #fcf3d9; }
+  .textstyle_menu.link .arrow::after { background-color: #fcf3d9; }
+  .textstyle_menu.link .content { background-color: #fcf3d9; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .content input[type=text] { background-color: #fef9ed; }
+  .textstyle_menu.link .content > a.link { color: #268bd2; }
+  .textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #2aa198; }
+  .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #fcf3d9; }
+  .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #fef9ed; }
+  .textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #fef9ed; border: 1px solid #fffefb; }
+  .textstyle_menu.style a.deformat::before { border-left: 1px solid #fef9ed; }
+  .textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #2aa198; }
+  .para_menu .insert .tip { color: #2aa198; }
+  .para_menu .insert .tooltip .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed; }
+  .para_menu .insert .tooltip .arrow::after { background-color: #fcf3d9; }
+  .para_menu .insert .tooltip .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .arrow-shadow::after { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed; }
+  .para_menu .format .options .arrow::after { background-color: #fcf3d9; }
+  .para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #fef9ed; }
+  .para_menu .format .options .content { background-color: #fcf3d9; box-shadow: 0 0 0 1px #fef9ed, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .content ul:first-child { border-bottom: 1px solid #fcf3d9; }
+  .para_menu .format .options.show .tooltip > div { background-color: #fcf3d9; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #586e75; }
+  .para_menu .format .options.show .tooltip span { background-color: #fef9ed; }
+  .para_menu .options a:hover { border: 1px solid #fef9ed; }
+  .para_menu .options a.active { background-color: #fdf6e3; border: 1px solid #fcf3d9; }
+  .para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+  .para_menu .options a span { filter: grayscale(2) brightness(5); }
+  .para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+  .para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); } }

--- a/scss/themes/_solarized-dark.scss
+++ b/scss/themes/_solarized-dark.scss
@@ -1,0 +1,41 @@
+// Solarized color palette
+// Taken from ethanschoonover.com/solarized
+$base03: #002b36;
+$base02: #073642;
+$base01: #586e75;
+$base00: #657b83;
+$base0: #839496;
+$base1: #93a1a1;
+$base2: #eee8d5;
+$base3: #fdf6e3;
+$yellow: #b58900;
+$orange: #cb4b16;
+$red: #dc322f;
+$magenta: #d33682;
+$violet: #6c71c4;
+$blue: #268bd2;
+$cyan: #2aa198;
+$green: #859900;
+
+// Theme Colors
+$color-base: $base03;
+$color-highlight: $cyan;
+
+$color-red: $red;
+$color-green: $green;
+$color-yellow: $yellow;
+
+$black: $base02;
+$white: $base2;
+
+$color-shade-darkest: darken($color-base, 5%);
+$color-shade-dark: darken($color-base, 2%);
+$color-shade-mid: $color-base;
+$color-shade-light: lighten($color-base, 2%);
+$color-shade-lightest: lighten($color-base, 5%);
+
+// Font Colors
+$base-font-color: lighten($base1, 5%);
+
+$base-link-color: $blue;
+$base-link-color-active: $red;

--- a/scss/themes/_solarized-light.scss
+++ b/scss/themes/_solarized-light.scss
@@ -1,0 +1,41 @@
+// Solarized color palette
+// Taken from ethanschoonover.com/solarized
+$base03: #002b36;
+$base02: #073642;
+$base01: #586e75;
+$base00: #657b83;
+$base0: #839496;
+$base1: #93a1a1;
+$base2: #eee8d5;
+$base3: #fdf6e3;
+$yellow: #b58900;
+$orange: #cb4b16;
+$red: #dc322f;
+$magenta: #d33682;
+$violet: #6c71c4;
+$blue: #268bd2;
+$cyan: #2aa198;
+$green: #859900;
+
+// Theme Colors
+$color-base: $base3;
+$color-highlight: $cyan;
+
+$color-red: $red;
+$color-green: $green;
+$color-yellow: $yellow;
+
+$black: $base02;
+$white: $base2;
+
+$color-shade-darkest: darken($color-base, 5%);
+$color-shade-dark: darken($color-base, 2%);
+$color-shade-mid: $color-base;
+$color-shade-light: lighten($color-base, 2%);
+$color-shade-lightest: lighten($color-base, 5%);
+
+// Font Colors
+$base-font-color: $base01;
+
+$base-link-color: $blue;
+$base-link-color-active: $red;

--- a/scss/themes/build-variants/solarized-dark--main.scss
+++ b/scss/themes/build-variants/solarized-dark--main.scss
@@ -1,0 +1,3 @@
+@import "../solarized-dark";
+
+@import "../../main";

--- a/scss/themes/build-variants/solarized-dark--styles.scss
+++ b/scss/themes/build-variants/solarized-dark--styles.scss
@@ -1,0 +1,3 @@
+@import "../solarized-dark";
+
+@import "../../styles";

--- a/scss/themes/build-variants/solarized-light--main.scss
+++ b/scss/themes/build-variants/solarized-light--main.scss
@@ -1,0 +1,3 @@
+@import "../solarized-light";
+
+@import "../../main";

--- a/scss/themes/build-variants/solarized-light--styles.scss
+++ b/scss/themes/build-variants/solarized-light--styles.scss
@@ -1,0 +1,3 @@
+@import "../solarized-light";
+
+@import "../../styles";


### PR DESCRIPTION
Adding solarized dark and light themes.
I have tested them both on slack.com and on the Slack macos desktop app and they look fine to me, but open to any suggestions to make them better.