### PR TITLE
Add gruvbox-dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ This is based on Slack's aubergine/maroon style. It's the original theme.
 ### Variants
 
 * **Arc ([source](scss/themes/_arc-dark.scss) - [build](css/variants/arc-dark.css))** _by [@Lemmmy](https://github.com/Lemmmy)_
+* **Gruvbox Dark ([source](scss/themes/_gruvbox-dark.scss) - [build](css/variants/gruvbox-dark.css))** _by [@lvarado](https://github.com/lvarado)_
 * **Midnight Blue ([source](scss/themes/_midnight-blue.scss) - [build](css/variants/midnight-blue.css))** _by [@matt-h](https://github.com/matt-h)_
-* **Tomorrow Dark (base16) ([repository](https://github.com/danarnold/slack-night-mode))** _by [@danarnold](https://github.com/danarnold)_
 * **Solarized Dark ([source](scss/themes/_solarized-dark.scss) - [build](css/variants/solarized-dark.css))** _by [@glostis](https://github.com/glostis)_
 * **Solarized Light ([source](scss/themes/_solarized-light.scss) - [build](css/variants/solarized-light.css))** _by [@glostis](https://github.com/glostis)_
+* **Tomorrow Dark (base16) ([repository](https://github.com/danarnold/slack-night-mode))** _by [@danarnold](https://github.com/danarnold)_
 
 ### Extensions
 

--- a/css/raw/variants/gruvbox-dark.css
+++ b/css/raw/variants/gruvbox-dark.css
@@ -1,0 +1,4194 @@
+body { background: #1d2021; color: #f9f5d7; }
+
+a { color: #689d6a; }
+
+a:link, a:visited { color: #689d6a; }
+
+a:hover, a:active, a:focus { color: #cc241d; }
+
+hr { border-bottom: 1px solid #282828; border-top: 1px solid #1d2021; }
+
+h1, h2, h3, h4 { color: #f9f5d7; }
+
+h1 a { color: #f9f5d7; }
+
+h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
+
+.bordered { border: 1px solid #282828; }
+
+.top_border { border-top: 1px solid #282828; }
+
+.bottom_border { border-bottom: 1px solid #282828; }
+
+.left_border { border-left: 1px solid #282828; }
+
+.right_border { border-right: 1px solid #282828; }
+
+.bullet { color: #d79921; }
+
+.alert, .c-alert, .c-alert--boxed { background-color: #282828; border-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.alert h4, .c-alert h4, .c-alert--boxed h4 { color: #f9f5d7; }
+
+.alert-info { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+
+.alert-info h4 { color: #f9f5d7; }
+
+::-webkit-scrollbar-track { background: #282828 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #282828 !important; }
+
+::-webkit-scrollbar-thumb { background: #1d2021 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
+
+::-webkit-scrollbar-corner { background: #1d2021 !important; }
+
+.supports_custom_scrollbar #messages_container::after { background: none !important; }
+
+.monkey_scroll_bar { background: #282828; }
+
+.monkey_scroll_handle_inner { background: #1d2021; border: 1px solid #ebdbb2; }
+
+.monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+
+#client-ui .monkey_scroll_bar { background: #282828; }
+
+#client-ui .monkey_scroll_handle_inner { background: #1d2021; border: 3px solid #1d2021; }
+
+.c-scrollbar--monkey .c-scrollbar__track { background: #282828; }
+
+.c-scrollbar--monkey .c-scrollbar__bar { background: #1d2021; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
+
+.client_channels_list_container { background-color: #282828; border-right-color: #1d2021; }
+
+#col_channels { color: #f9f5d7; }
+
+.p-channel_sidebar { background-color: #282828; color: #f9f5d7; }
+
+.p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(249, 245, 215, 0.8) !important; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #f9f5d7; }
+
+.p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #1d2021 !important; }
+
+.p-channel_sidebar__header { color: #f9f5d7 !important; }
+
+.p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #f9f5d7; }
+
+.p-channel_sidebar__channel--im .c-presence--away { color: #d79921; }
+
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #1d2021 !important; }
+
+.p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #1d2021 !important; }
+
+.p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #f9f5d7; }
+
+.p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #f9f5d7; }
+
+.p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #cc241d; }
+
+.p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #1d2021; }
+
+.p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #fdfcf2 !important; }
+
+.p-channel_sidebar__close_container:hover { background: #282828; }
+
+.p-channel_sidebar__jumper { background: transparent !important; }
+
+.channels_list_holder h2 { color: #f9f5d7 !important; }
+
+.channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #f9f5d7; opacity: 0.8; }
+
+.channels_list_holder ul { color: #f9f5d7 !important; }
+
+.channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #282828; color: rgba(249, 245, 215, 0.8) !important; }
+
+.channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #1d2021 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+
+.channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #1d2021; }
+
+.channels_list_holder ul li.mention a { color: #f9f5d7; }
+
+.channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #fdfcf2 !important; }
+
+.channels_list_holder ul li.unread .prefix { color: #f9f5d7 !important; opacity: 1; }
+
+.channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #689d6a !important; }
+
+.channels_list_holder .unread_highlights { background: #cc241d; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.channels_list_holder .unread_msgs { background: #1d2021; color: #f9f5d7; }
+
+#channel_list_invites_link { border-bottom: 1px dotted #689d6a; color: #689d6a !important; font-size: 0.9rem; }
+
+#channel_list_invites_link:hover { border-bottom: 1px solid #689d6a; }
+
+#quick_switcher_btn { background: #282828; border-top: 2px solid #282828; }
+
+#quick_switcher_btn > i { color: #d79921; }
+
+#quick_switcher_btn:active, #quick_switcher_btn:hover { background: #1d2021; border-color: #1d2021; }
+
+#quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #689d6a; }
+
+#quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #689d6a; }
+
+#quick_switcher_label { color: #d79921; }
+
+.p-channel_insights__channel .channel_link { color: #689d6a; }
+
+.p-channel_insights__date_heading::before { background-color: #282828; }
+
+.p-channel_insights__date_heading span { background-color: #1d2021; color: #d79921; }
+
+.p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #282828 90%); }
+
+.p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #282828; }
+
+.c-dialog__content { border-radius: 0.6rem; }
+
+.c-dialog__header, .c-dialog__body, .c-dialog__footer { background: #282828; }
+
+.c-dialog__title { color: #f9f5d7; }
+
+.c-dialog .p-custom_status_input__duration_picker_select { padding-left: 11px; }
+
+.c-dialog .p-custom_status_input__duration_picker_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
+
+.loading #loading-zone { background: #1d2021; }
+
+#loading_welcome { background-image: none; }
+
+#loading_message p { color: #f9f5d7; }
+
+#loading_message #loading_message_attribution { color: #d79921; }
+
+#loading_team_menu_bg, #loading_user_menu_bg { background: #1d2021; border: none; }
+
+.infinite_spinner_bg, .infinite_spinner_blue { stroke: #f9f5d7; }
+
+body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #282828; }
+
+.p-degraded_list__loading { background-color: #1d2021; color: #f9f5d7; }
+
+input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(40, 40, 40, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+
+input[type=file]:focus { outline: #f9f5d7 dotted thin; }
+
+input[type=radio]:focus, input[type=checkbox]:focus { outline: #f9f5d7 dotted thin; }
+
+select { background: #1d2021; }
+
+select, textarea { border: 1px solid #282828; color: #f9f5d7; }
+
+select:active, select:focus, textarea:active, textarea:focus { border-color: #282828; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
+
+input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #282828 !important; }
+
+.no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #282828; }
+
+.no_touch label.select:hover select { border-color: #282828; }
+
+.no_touch label.select:not(.disabled):hover::after { color: #282828; }
+
+label.disabled { color: #f9f5d7; }
+
+legend { border-bottom: 1px solid #ebdbb2; }
+
+legend small { color: #d79921; }
+
+.uneditable-input, .uneditable-textarea { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+.uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+
+textarea { background-color: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+
+textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+
+::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+[data-placeholder]:empty::before { color: #f9f5d7 !important; }
+
+input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+input::-moz-placeholder, textarea::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+input::placeholder, textarea::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #f9f5d7 !important; }
+
+input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #1d2021 !important; }
+
+.form-actions { background-color: #282828; border-top: 1px solid #282828; }
+
+.help-block, .help-inline { color: #d79921; }
+
+.input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #1d2021; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.btn { background-color: #1d2021; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #1d2021; color: #f9f5d7; }
+
+.btn.btn_border { border: 2px solid #282828; }
+
+.btn.disabled, .btn:disabled { background-color: #282828 !important; }
+
+.btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #282828 !important; }
+
+.btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #cc241d !important; color: #f9f5d7 !important; }
+
+.btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #1d2021 !important; border-color: #cc241d !important; color: #cc241d !important; }
+
+.btn.btn_outline.disabled { background: #282828 !important; color: #689d6a !important; }
+
+.btn.btn_outline.disabled:hover { background: #282828 !important; color: #689d6a !important; }
+
+.btn.btn_attachment { border-color: #1d2021; }
+
+.btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #282828; border-color: #ebdbb2; }
+
+.btn.btn_attachment.btn_danger { border-color: #cc241d; }
+
+.btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e34039; }
+
+.btn.btn_attachment.btn_primary { border-color: #ebdbb2; }
+
+.btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: #f6eeda; }
+
+.btn_basic:focus, .btn_basic:hover { color: #f9f5d7; }
+
+.btn_outline { background: #1d2021; color: #689d6a !important; }
+
+.btn_outline::after { border: 1px solid #282828; }
+
+.btn_outline.btn_transparent { color: rgba(29, 32, 33, 0.9) !important; }
+
+.btn_outline.btn_transparent::after { border: 1px solid rgba(29, 32, 33, 0.5); }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(29, 32, 33, 0.9) !important; color: #cc241d !important; }
+
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(29, 32, 33, 0.8) !important; }
+
+.btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #1d2021; color: #cc241d !important; }
+
+.btn_outline:active { color: #cc241d; }
+
+.btn_outline.active { color: #cc241d !important; }
+
+.btn_link { color: #689d6a; }
+
+.btn_link:hover, .btn_link:focus { color: #cc241d; }
+
+.btn-group.open .btn.dropdown-toggle { background-color: #1d2021; }
+
+.btn-group.open .btn-primary.dropdown-toggle { background-color: #282828; }
+
+.btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+
+.btn_info, .btn.btn_success { background-color: #1d2021 !important; }
+
+.btn_warning, .btn_danger { background-color: #cc241d !important; }
+
+.btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #f9f5d7; border-top-color: #f9f5d7; }
+
+.input_note { color: #f9f5d7; }
+
+.c-enhanced_text_input { background-color: #1d2021; border-color: #282828; color: #d79921; }
+
+.c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #1d2021; }
+
+.c-filter_input { background: #1d2021; }
+
+.p-share_dialog_message_input { color: #f9f5d7; }
+
+.c-texty_input .ql-placeholder { color: #f9f5d7; }
+
+.lazy_filter_select.disabled { background: #282828; }
+
+.lazy_filter_select.disabled input.lfs_input { background: #ebdbb2; }
+
+.lazy_filter_select .lfs_input_container { background-color: #1d2021; border-color: #282828; }
+
+.lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #282828; }
+
+.lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(29, 32, 33, 0.15); }
+
+.lazy_filter_select .lfs_list_container { background: #1d2021; border-color: #282828; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+
+.lazy_filter_select .lfs_list .lfs_item.selected { color: #f9f5d7; }
+
+.lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #f9f5d7 !important; }
+
+.lazy_filter_select .lfs_list .lfs_item.disabled { color: #d79921; }
+
+.lazy_filter_select .lfs_list .lfs_item.active { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+
+.lazy_filter_select .lfs_token { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+
+.lazy_filter_select .lfs_token::after { color: #f9f5d7; }
+
+.lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #f9f5d7; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #f9f5d7 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #d79921 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item { color: #d79921 !important; }
+
+#select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #d79921 !important; }
+
+#message_edit_form .emo_menu { color: rgba(249, 245, 215, 0.3); }
+
+#message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #ebdbb2; }
+
+#message_edit_form.focus .emo_menu { color: rgba(249, 245, 215, 0.6); }
+
+#message_edit_form.focus #primary_file_button:not(:hover) { border-color: #282828; }
+
+#message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #282828 !important; }
+
+#message_edit_form.offline #primary_file_button { border-color: #282828; color: #d79921; }
+
+#msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+
+#msg_form #msg_input { background: padding-box #1d2021; border-color: #282828; border-left: 0; color: #f9f5d7; }
+
+#msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #f9f5d7; }
+
+#msg_form .msg_mentions_button { color: #d79921; }
+
+#msg_form .msg_mentions_button:hover { color: #f9f5d7; }
+
+#msg_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+#msg_input::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+
+#msg_input::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+#msg_input::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+
+#msg_input[data-placeholder]:empty::before { color: #f9f5d7 !important; }
+
+#msg_input:focus, #msg_input.focus { border-color: #282828; }
+
+#msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+
+#msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+
+#msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #282828; }
+
+#msg_input.offline:not(.pretend-to-be-online) { background-color: #282828 !important; color: #d79921; }
+
+#msg_input.disabled, #msg_input.ql-disabled { background-color: #282828; border-color: #282828; color: #d79921; }
+
+#msg_input_message { background-color: #282828; color: #f9f5d7; }
+
+#primary_file_button { background: padding-box #1d2021; border-color: #282828; color: #d79921; }
+
+#primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #282828; border-color: #282828; color: #f9f5d7; }
+
+#footer, #footer.footer_msg_input { background: #1d2021; box-shadow: inset 1px 0 0 0 #1d2021; }
+
+#footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #282828 !important; border-color: #282828 !important; }
+
+#footer_archives_table { color: #d79921; }
+
+#typing_text { color: #d79921; filter: none; }
+
+#notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+
+#special_formatting_text { color: #d79921; }
+
+#message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.inline_message_input_container .ql-container { border-color: #1d2021; color: #f9f5d7; }
+
+.inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #ebdbb2; }
+
+.c-message--editing { background: #282828; border-color: #282828; color: #f9f5d7; }
+
+.c-message__editor__input, .c-message__editor__input--legacy { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.c-message__editor__input.focus, .c-message__editor__input--legacy.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-message__editor__warning { color: #cc241d; }
+
+.c-message .c-button { border-color: #282828; }
+
+.c-message .c-button--outline { background-color: #282828; color: #689d6a; }
+
+.c-message .c-button--outline:hover { color: #cc241d; }
+
+.c-message .c-button--primary { background-color: #1d2021; color: #f9f5d7; }
+
+#message_edit_container .message_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+#message_edit_container .message_input.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.ql-editor::-webkit-scrollbar-thumb { background-color: rgba(29, 32, 33, 0.5); color: #1d2021; }
+
+.ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(29, 32, 33, 0.8); }
+
+.ql-placeholder, .texty_legacy .ql-placeholder { color: #f9f5d7; filter: none; }
+
+.ql-container.texty_single_line_input { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+
+.ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+
+.c-input_select { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
+
+.c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.c-input_select_options_list__option { color: #f9f5d7; }
+
+.c-label__text { color: #f9f5d7; }
+
+.c-date_picker__dropdown { background-color: #282828; }
+
+.c-calendar_view_header__stepper_btn:disabled, .c-calendar_view_header__title_btn:disabled { color: #d79921; }
+
+.c-calendar_view_header__stepper_btn, .c-calendar_view_header__title_btn { color: #f9f5d7; }
+
+.c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #1d2021; }
+
+.c-date_picker_calendar__date--disabled, .c-date_picker_calendar__date--disabled:hover { background-color: #282828; }
+
+.c-mini_calendar__month_button:disabled, .c-mini_calendar__month_button:disabled:hover { background-color: #282828; }
+
+.c-calendar_month__day_of_week_heading { color: #f9f5d7; }
+
+.menu { background: #282828; border: 1px solid #1d2021; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #f9f5d7; }
+
+.menu .menu_content { background: #282828 !important; }
+
+.menu .menu_filter_container { background: #1d2021; }
+
+.menu .menu_filter_container input.menu_filter { border: 1px solid #282828; }
+
+.menu .menu_filter_container input.menu_filter:focus { border-color: #1d2021; }
+
+.menu .menu_filter_container .icon_search { color: #d79921; }
+
+.menu .menu_filter_container .icon_close { color: #d79921 !important; }
+
+.menu #menu_header .menu_simple_header { background: #282828; border-color: #282828; color: #f9f5d7; }
+
+.menu #menu_header .menu_simple_header a { color: #689d6a; }
+
+.menu #menu_header .menu_simple_header a:hover { color: #cc241d; }
+
+.menu #menu_header .menu_close { color: #f9f5d7; }
+
+.menu .section_header .header_label { background-color: #282828; color: #d79921; }
+
+.menu .section_header > div.header_label_container { color: #d79921; }
+
+.menu ul li a { background: #282828; border-bottom: 0; color: #f9f5d7; }
+
+.menu ul li a.delete_link { color: #cc241d; }
+
+.menu ul li a:not(.inline_menu_link) { color: #f9f5d7; }
+
+.menu ul li.highlighted a { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #f9f5d7; }
+
+.menu ul li.highlighted a.delete_link { color: #cc241d; }
+
+.menu ul li.disabled a { color: #d79921; }
+
+.menu ul li i { color: #d79921; }
+
+.menu ul li.divider { border-bottom-color: #1d2021; }
+
+.menu ul li .menu_item_details { color: #d79921; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
+
+.menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #cc241d; }
+
+.menu input { background: #282828; border: 1px solid #1d2021; }
+
+.menu textarea { background: #282828; border: 1px solid #1d2021; }
+
+.menu #menu_footer .menu_footer { background: #282828; border-top: 1px solid #282828; }
+
+.menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #282828; }
+
+.menu #menu_list_container #menu_list .menu_list_item a { color: #f9f5d7; }
+
+.menu #menu_list_container #menu_list .menu_list_item.active a { background: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.c-menu { background-color: #282828; }
+
+.c-menu_item__label { color: #fff; }
+
+.c-menu_item__header { color: #d79921; }
+
+#autocomplete_menu { color: #f9f5d7; }
+
+#autocomplete_menu header { background-color: #1d2021; }
+
+#autocomplete_menu header .header_label { color: #d79921; }
+
+#autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #282828; }
+
+#autocomplete_menu h2 { color: #f9f5d7; }
+
+#autocomplete_menu .no_results { color: #f9f5d7; }
+
+#autocomplete_menu .keyword_match .modifier { color: #d79921; }
+
+#autocomplete_menu .boxed { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu .pickmeup { border-bottom: 1px solid #282828; }
+
+#autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #1d2021; }
+
+#autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #282828; }
+
+#autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+
+#autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #d79921; }
+
+#autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #689d6a; }
+
+#autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #cc241d; }
+
+#autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #d79921; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #d79921; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #d79921; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #689d6a; }
+
+#autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #cc241d; }
+
+#autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #d79921; }
+
+#autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #282828; }
+
+#autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #f9f5d7; }
+
+#autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #282828; color: #f9f5d7; }
+
+#autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #d79921; }
+
+#autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+
+#autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(29, 32, 33, 0.25); border: #ebdbb2; }
+
+#autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
+
+.search_light_grey { color: #f9f5d7 !important; }
+
+.highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+
+.highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+
+.highlighter_underlay .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
+
+.highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #1d2021; }
+
+.highlighter_underlay .ghost_text { color: #f9f5d7; }
+
+.pickmeup { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+
+.pickmeup .pmu-instance .pmu-button { color: #f9f5d7; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #282828 !important; }
+
+.pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #ebdbb2; color: #f9f5d7 !important; }
+
+.pickmeup .pmu-instance .pmu-today-border { border: 2px solid #1d2021 !important; color: #ebdbb2 !important; }
+
+.pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #1d2021; color: #f9f5d7; }
+
+.pickmeup .pmu-instance .pmu-not-in-month { background: #1d2021; color: #d79921; }
+
+.pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #1d2021; }
+
+.pickmeup .pmu-instance .pmu-disabled { background: #1d2021; color: #d79921; }
+
+.pickmeup .pmu-instance .pmu-disabled:hover { background: #1d2021; color: #d79921; }
+
+.pickmeup .pmu-instance .pmu-selected { background: #1d2021; color: #f9f5d7; }
+
+.pickmeup .pmu-instance nav { color: #689d6a; }
+
+.pickmeup .pmu-instance nav :first-child :hover { color: #cc241d; }
+
+.pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #282828; }
+
+.pickmeup .pmu-instance .pmu-day-of-week { color: #f9f5d7; }
+
+.pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #282828; }
+
+.pickmeup .pmu-instance .pmu-days * { border: 1px solid #282828; }
+
+.p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #1d2021; color: #ebdbb2; }
+
+#menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #1d2021; }
+
+#menu.date_picker li.date_picker_item a { color: #f9f5d7; }
+
+#menu.date_picker li.date_picker_item a:hover { color: #f9f5d7; }
+
+#menu.date_picker li.date_picker_item.highlighted a { color: #d79921; }
+
+#file_member_filter { background: #282828; }
+
+#client-ui .member_filter { border: 1px solid #1d2021; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #1d2021; }
+
+#client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #f9f5d7; }
+
+#client-ui #team_list_container #team_filter .member_filter { background-color: #1d2021; border-left: 1px solid #282828; }
+
+#client-ui #file_member_filter { border-color: #1d2021; }
+
+#client-ui #file_member_filter .member_filter { border-color: #1d2021; }
+
+#client-ui .team_tabs_container { border-bottom: 1px solid #282828; }
+
+#team_filter .icon_search { color: #d79921; }
+
+#team_filter a.icon_close { color: #689d6a; }
+
+#team_filter a.icon_close:hover { color: #cc241d; }
+
+.filter_header { background-color: #1d2021; }
+
+.popover_menu { background-color: #1d2021; border-top: 1px solid #1d2021; }
+
+.popover_menu .arrow::after { background-color: #282828; }
+
+.popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #1d2021, 0 0 3px rgba(0, 0, 0, 0.08); }
+
+.popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #1d2021 !important; }
+
+.popover_menu .content { background-color: #1d2021; }
+
+.tab_complete_ui { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+
+.tab_complete_ui .tab_complete_ui_header { background: padding-box #282828; border-bottom: 1px solid #282828; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui ul.type_emoji li { color: #f9f5d7; }
+
+.tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #f9f5d7; }
+
+.tab_complete_ui ul.type_members .unify_broadcast { color: #f9f5d7; }
+
+.tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #d79921; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #f9f5d7 !important; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #282828; }
+
+.tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #d79921; }
+
+.tab_complete_ui ul.type_cmds .cmdname { color: #f9f5d7; }
+
+.tab_complete_ui ul.type_cmds .cmddesc { color: #d79921; }
+
+.tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #282828; }
+
+.tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #1d2021; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #f9f5d7 !important; }
+
+.tab_complete_ui .not_in_channel { color: #d79921; }
+
+#team_menu { background: #282828; border-bottom: 2px solid #282828; color: #f9f5d7; }
+
+#team_menu.active, #team_menu:hover { background: #282828 !important; border-bottom-color: #282828 !important; }
+
+#team_menu.active i, #team_menu:hover i { color: #f9f5d7; }
+
+#team_menu i { color: #d79921; }
+
+#team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+#team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #f9f5d7 !important; }
+
+#team_menu_user { color: #d79921; }
+
+#team_menu_user_name, #team_menu_user_details { color: #f9f5d7 !important; opacity: 0.75; }
+
+.slack_menu_section::before { border-top-color: #1d2021; }
+
+.slack_menu_header_secondary { color: #d79921; }
+
+.slack_menu_download { background-color: #282828; }
+
+.slack_menu_download ts-icon { color: #d79921; }
+
+#menu_items_scroller::-webkit-scrollbar-track { background: #1d2021 !important; }
+
+#limit_meter:hover #limit_meter_message_body { color: #f9f5d7; }
+
+#limit_meter_message_body { color: #d79921; }
+
+.channel_header { background: #1d2021; box-shadow: inset 1px 0 0 0 #1d2021; }
+
+.channel_header .blue_on_hover:hover { color: #f9f5d7; }
+
+#client_body:not(.onboarding)::before { background: #1d2021; border-bottom: 1px solid #282828; box-shadow: inset 1px 0 0 0 #1d2021; }
+
+#client_body:not(.onboarding):not(.feature_global_nav_layout)::before { background: #1d2021; border-bottom: 1px solid #282828; box-shadow: inset 1px 0 0 0 #1d2021; }
+
+.messages_header { color: #f9f5d7; }
+
+.channel_title .channel_name_container .channel_name { color: #f9f5d7; }
+
+.channel_title .channel_name_container .channel_name.muted { color: #d79921; }
+
+.channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #d79921; }
+
+.channel_title .channel_name_container .muted_icon { color: #d79921; }
+
+.channel_title .channel_name_container .muted_icon:hover { color: #cc241d; }
+
+#im_title.away { color: #d79921; }
+
+.channel_header_info button { color: #689d6a; }
+
+.channel_header_icon { color: #f9f5d7; }
+
+.channel_calls_button .call_icon.call_window_offline { color: #d79921; }
+
+.channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #f9f5d7; }
+
+#flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #f9f5d7; }
+
+#flex_menu_toggle .flex_menu_download_circle { background: #1d2021; }
+
+#flex_menu_toggle .flex_menu_download_circle canvas { background: #1d2021; }
+
+#flex_menu_toggle.unread #help_icon_circle_count { background-color: #cc241d; color: #fff; }
+
+#flex_menu_toggle.open #help_icon_circle_count { background-color: #282828; color: #f9f5d7; }
+
+#canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #282828; color: #f9f5d7; }
+
+#canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #1d2021; color: #f9f5d7; }
+
+#recent_mentions_toggle:hover { color: #cc241d; }
+
+#rxn_toast_div { background: #282828; border: 1px solid #1d2021; }
+
+.presence { color: #d79921; }
+
+#edit_topic_inner:not(.unable_to_post)::before { background: #1d2021; border-color: #282828; }
+
+#edit_topic_trigger { color: #689d6a; }
+
+.c-message_list__day_divider__label { color: #d79921; }
+
+.c-message_list__day_divider__label__pill { background: #1d2021; position: relative; }
+
+.c-message_list__day_divider__line { border-top-color: #282828; }
+
+.day_divider, .mention_day_container_div .day_divider { background: #1d2021; color: #d79921; }
+
+.day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #282828; }
+
+.day_divider .day_divider_label { background: #1d2021; }
+
+.day_container .day_msgs { border-top: 1px solid #282828; }
+
+.day_container.unread_day_container .day_msgs { border-color: #ebdbb2; }
+
+.day_container .day_divider { background: none; color: #d79921; }
+
+.day_container .day_divider .day_divider_label { background: #1d2021; }
+
+.search_form { border-color: #1d2021; }
+
+.search_form .search_input { background: transparent; }
+
+.search_form:hover { border-color: #ebdbb2; }
+
+.search_focused .search_form { border-color: #ebdbb2; }
+
+.search_clear_icon .ts_icon_times_circle { color: #d79921; }
+
+#search_spinner { color: #f9f5d7; }
+
+#search_container .search_input { background: transparent; }
+
+#search_container .icon_search { color: #d79921; }
+
+#search_container .icon_close { color: #689d6a; }
+
+#team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #d79921; }
+
+#team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #689d6a; }
+
+#team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #cc241d; }
+
+.c-search { background: transparent; }
+
+.c-search_message__body { color: #f9f5d7; }
+
+.p-search_filter__more_link { color: #f9f5d7; }
+
+.p-search_filter__title_text { background: #282828; color: #f9f5d7; }
+
+.p-search_filter__datepicker_trigger { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+.p-search_filter__datepicker_trigger:hover { color: #d79921; }
+
+.c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+.c-search_autocomplete footer { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+.c-search_autocomplete__suggestion_item { color: #f9f5d7; }
+
+.c-search_autocomplete__suggestion_item--selected { background-color: #282828; }
+
+.c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #f9f5d7; }
+
+.c-search__input_and_close { border-bottom-color: #282828; }
+
+.c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #f9f5d7; }
+
+#msgs_overlay_div { background: #1d2021; }
+
+#col_messages { box-shadow: inset 1px 0 0 0 #1d2021; }
+
+.c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #d79921 !important; }
+
+.c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #d79921; }
+
+.c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #d79921; }
+
+.c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(40, 40, 40, 0.1); }
+
+.c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #d79921; }
+
+.c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #d79921; }
+
+.c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(40, 40, 40, 0.1); }
+
+.c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(40, 40, 40, 0.2); }
+
+.c-message--custom_response { background: rgba(40, 40, 40, 0.15); }
+
+.c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(40, 40, 40, 0.1); }
+
+.c-message--pinned .c-message__label__icon { color: #cc241d; }
+
+.c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #f9f5d7; }
+
+.c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #d79921; }
+
+.c-message--sli_highlight_negative .c-message__label { background: rgba(40, 40, 40, 0.1); }
+
+.c-message--resend .c-message__body { color: #d79921; }
+
+.c-message--deleting { background: rgba(204, 36, 29, 0.6); }
+
+.c-message--standalone { border-color: rgba(29, 32, 33, 0.1); }
+
+.c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+
+.c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #d79921; }
+
+.c-message__sender { color: #f9f5d7; }
+
+.c-message__sender a { color: #f9f5d7; }
+
+.c-message__sender .c-emoji__text_mode_icon { color: #d79921; }
+
+.c-message__body { color: #f9f5d7; }
+
+.c-message__body--unknown { background: rgba(29, 32, 33, 0.1); }
+
+.c-message__body--automated { color: #d79921; }
+
+.c-message__body--tombstone { color: #d79921; }
+
+.c-message__label { color: #d79921; }
+
+.c-message__label__highlight_title { color: #f9f5d7; }
+
+.c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #d79921; }
+
+.c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #f9f5d7; }
+
+.c-message__resend_controls { color: #d79921; }
+
+.c-message__resend_column { background-color: rgba(29, 32, 33, 0.1); }
+
+.c-message__resend, .c-message__cancel { color: #f9f5d7; }
+
+.c-message__edited_label { color: #d79921; }
+
+.c-message__tombstone_icon { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+
+.c-message__bot_label { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+
+.c-message__comment:before { color: #d79921; }
+
+.c-message__call_attachment { background: #1d2021; border-color: rgba(29, 32, 33, 0.1); }
+
+.c-message__call_icon { color: #f9f5d7; }
+
+.c-message__call--ended .c-message__call_icon { color: #d79921; }
+
+.c-message__call_info { color: #f9f5d7; }
+
+.c-message__call_name--linked { color: #f9f5d7; }
+
+.c-message__call_name + .c-message__call_description::before { color: #d79921; }
+
+.c-message__call_sub { color: #d79921; }
+
+.c-message_actions__container { background: #1d2021; border-color: #282828; }
+
+.c-message_actions__container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+.c-message_actions__button { border-right-color: #282828; color: #689d6a; }
+
+.c-message_actions__button:hover { color: #f9f5d7; }
+
+.c-message_actions__button:active { background: #282828; }
+
+.c-message_group { background-color: #1d2021; border-color: #282828; }
+
+.c-message_group:hover .c-message_group__header { color: #d79921; }
+
+.c-message_group__header { color: #f9f5d7; }
+
+.c-message_group__divider_text { background-color: #1d2021; color: #f9f5d7; }
+
+.c-message_list__unread_divider__separator { border-color: #1d2021; }
+
+.c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #1d2021; }
+
+.c-message_list__spinner { color: #d79921; }
+
+.c-message_list .c-scrollbar__bar { background: #282828; }
+
+.c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(235, 219, 178, 0.8); }
+
+ts-message { color: #f9f5d7; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(40, 40, 40, 0.1); box-shadow: inset 1px 0 0 0 #1d2021; }
+
+ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(40, 40, 40, 0.2); }
+
+ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #d79921; }
+
+ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #d79921 !important; }
+
+ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #d79921 !important; }
+
+ts-message.is_pinned { background: rgba(40, 40, 40, 0.15); }
+
+ts-message .timestamp { color: #689d6a; }
+
+ts-message .temp_msg_controls { color: #d79921; }
+
+ts-message .edited { color: rgba(215, 153, 33, 0.8); }
+
+ts-message:hover .edited { color: #d79921; }
+
+ts-message .only_visible_to_user { color: #d79921; }
+
+ts-message.ephemeral { color: #f9f5d7; }
+
+ts-message .bot_label { background: #282828; color: #d79921; }
+
+ts-message .in_reply_to { background: #282828; color: #d79921; }
+
+ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #282828; }
+
+ts-message.unprocessed { color: rgba(249, 245, 215, 0.75); }
+
+ts-message.highlight { background: rgba(204, 36, 29, 0.4); }
+
+ts-message.highlight:hover { background: rgba(204, 36, 29, 0.4); }
+
+ts-message .is_highlights_holder { color: #d79921; }
+
+ts-message .is_highlights_holder ts-icon { color: #d79921; }
+
+ts-message .is_highlights_holder .highlights_feedback_link { color: #d79921; }
+
+ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #f9f5d7; }
+
+ts-message .recap_highlight { background: rgba(204, 36, 29, 0.4); }
+
+ts-message .recap_highlight a { color: #f9f5d7; }
+
+ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(204, 36, 29, 0.75); }
+
+ts-message.automated .message_body { color: rgba(249, 245, 215, 0.8); }
+
+ts-message .action_hover_container { border: 1px solid #282828; }
+
+ts-message .action_hover_container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #1d2021; }
+
+ts-message .action_hover_container .btn_msg_action { background: #1d2021; border-right: 1px solid #282828; color: #689d6a; }
+
+ts-message .action_hover_container .btn_msg_action:hover { color: #f9f5d7; }
+
+ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #282828; color: #f9f5d7; }
+
+ts-message.selected { background: #1d2021; }
+
+ts-message.selected:not(.delete_mode) { background: #1d2021; }
+
+ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+
+ts-message .meta { color: #d79921; }
+
+ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #689d6a !important; }
+
+ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #d79921 !important; }
+
+ts-message .pinned_item_message_header { color: #d79921; }
+
+ts-message .mention { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+
+ts-message .internal_member_link { background: #1d2021 !important; border: 0; color: #689d6a !important; }
+
+ts-message .internal_member_link:hover { color: #cc241d !important; }
+
+ts-message.show_recap:not(.is_pinned) { background: rgba(40, 40, 40, 0.15); }
+
+ts-message.show_recap:not(.is_pinned):hover { background: rgba(40, 40, 40, 0.15); }
+
+.ephemeral.message .message_content { color: #f9f5d7; }
+
+ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !important; }
+
+.selecting_messages ts-message:hover { background: #282828; }
+
+.selecting_messages ts-message.multi_delete_mode:hover { background: rgba(204, 36, 29, 0.75); }
+
+#convo_container { background-color: #1d2021; }
+
+#convo_container #message_edit_container { border-bottom: 1px solid #1d2021; border-top: 1px solid #1d2021; }
+
+#convo_container ts-conversation::after { background: rgba(40, 40, 40, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(40, 40, 40, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(40, 40, 40, 0.08) 100%); }
+
+#convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(40, 40, 40, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(40, 40, 40, 0.08) 0, transparent 100%); }
+
+#convo_container ts-conversation ts-message.selected { background: #1d2021; }
+
+#convo_container ts-conversation ts-relatives::after { background: #1d2021; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #1d2021; color: #d79921; }
+
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #f9f5d7; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #1d2021; }
+
+#convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #292d2f; }
+
+#msgs_div .unread_divider hr { border-top: 1px solid #1d2021; }
+
+#msgs_div .unread_divider .divider_label { background: #1d2021; color: #1d2021; }
+
+#msgs_div .unread_divider.no_unreads hr { border-top-color: #282828; }
+
+#msgs_div .unread_divider.no_unreads .divider_label { color: #d79921; }
+
+.channel_archive_messages.card .col:first-child { border-right: 1px solid #1d2021; }
+
+.star { color: #d79921; }
+
+.star_item { border-bottom: 1px solid #282828; }
+
+.star_item .star_meta { color: #d79921; }
+
+.bot_message .message_sender { color: #f9f5d7; }
+
+.bot_message .message_sender a { color: #f9f5d7; }
+
+.color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #f9f5d7; }
+
+#msgs_scroller_div #end_display_div #end_display_status { color: #d79921; }
+
+#msgs_scroller_div #end_display_div #end_display_meta { color: #d79921; }
+
+#msgs_scroller_div #end_display_div #end_display_meta h1 { color: #f9f5d7; }
+
+#msgs_scroller_div #end_display_div p { color: #f9f5d7; }
+
+.member_mentions_options { background-color: #282828; border-top: 1px solid #282828; }
+
+.dm_badge .dm_badge_meta { color: #f9f5d7; }
+
+.dm_badge a { color: #689d6a; }
+
+.dm_badge a.member_preview_link { color: #689d6a; }
+
+.dm_badge .dm_badge:hover a { color: #689d6a; }
+
+.dm_badge .hint { color: #d79921; }
+
+#toggle-subscription-status .subscription_desc { color: #d79921; }
+
+.bot_label { background: #282828; color: #d79921; }
+
+@keyframes to-grey { 0% { color: inherit; }
+  100% { color: #d79921; } }
+
+@keyframes fade-background-highlight { 0% { background: #1d2021; }
+  100% { background: transparent; } }
+
+@keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #1d2021, 0 0 0 0.5px #ebdbb2; }
+  100% { box-shadow: 0 0 4px 0 #1d2021, 0 0 0 0 #ebdbb2; } }
+
+.c-message_attachment { color: #f9f5d7; }
+
+.c-message_attachment__border { background-color: #1d2021; }
+
+.c-message_attachment__delete { color: #689d6a; }
+
+.c-message_attachment__delete:hover { color: #cc241d; }
+
+.c-message_attachment__pretext { color: #f9f5d7; }
+
+.c-message_attachment__part + .c-message_attachment__part::before { color: #1d2021; }
+
+.c-message_attachment__author .c-message_attachment__autor--distinct { color: #689d6a; }
+
+.c-message_attachment__author_link + .c-message_attachment__author_link { color: #689d6a; }
+
+.c-message_attachment__title_link span { color: #f9f5d7; }
+
+.c-message_attachment__text_expander { color: #689d6a; }
+
+.c-message_attachment__footer { color: #689d6a; }
+
+.c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(40, 40, 40, 0.1) inset; }
+
+.c-message_attachment__video_html { background-color: rgba(29, 32, 33, 0.4); }
+
+.c-message_attachment__video_buttons { background: rgba(40, 40, 40, 0.4); }
+
+.c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #f9f5d7; }
+
+.c-message_attachment__video_play, .c-message_attachment__video_link { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+
+.c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #f9f5d7; }
+
+.c-message_attachment__media_trigger .c-expandable_trigger { color: #689d6a; }
+
+.c-message_attachment__media_trigger--too_large { color: #689d6a; }
+
+.c-message_attachment__select { border-color: #282828; }
+
+.c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #1d2021; }
+
+.c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #1d2021; border-color: #282828; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #d79921; }
+
+.c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #1d2021; }
+
+.c-message__reply_bar_description { color: #d79921; }
+
+.c-message__file_meta { color: #d79921; }
+
+.c-message__image_container { background: rgba(40, 40, 40, 0.1); }
+
+.c-message__image_wrapper:after { border-color: transparent; }
+
+.c-message_kit__file__meta { color: #f9f5d7; }
+
+.attachment_group.has_container { background: #1d2021; border: 1px solid #282828; }
+
+.attachment_group.has_container .inline_attachment::after { background-color: #282828; }
+
+.attachment_group.has_container.has_link:hover { border-bottom-color: #282828; border-left-color: #282828; border-right-color: #282828; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.attachment_group .media_caret { color: #d79921; }
+
+.attachment_group .attachment_source span { color: #d79921 !important; }
+
+.attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #d79921; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #d79921; }
+
+.attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #282828; }
+
+.attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #d79921; }
+
+.attachment_group .attachment_title a { color: #f9f5d7; }
+
+.attachment_group .attachment_footer_text + .attachment_ts::before { color: #d79921; }
+
+.attachment_group .delete_attachment_link ts-icon::before { color: #689d6a; }
+
+.attachment_group .delete_attachment_link:hover ts-icon::before { color: #cc241d; }
+
+.attachment_still_pending ts-inline-saver { color: #d79921; }
+
+.msg_inline_attachment_column.column_border { background-color: #1d2021; }
+
+.msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #282828; }
+
+.msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #689d6a; }
+
+.msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #cc241d; }
+
+.msg_inline_img { background: #1d2021; }
+
+.msg_inline_room_preview_collapser { color: #d79921; }
+
+.msg_inline_room_preview_collapser:hover { color: #d79921; }
+
+.inline_attachment span.attachment_author_name { color: #689d6a; }
+
+.inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #689d6a; }
+
+.inline_attachment a span:active, .inline_attachment a span:hover { color: #cc241d !important; }
+
+.inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #689d6a; }
+
+.inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #689d6a; }
+
+.inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #cc241d !important; }
+
+.inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #cc241d !important; }
+
+.inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #282828; }
+
+.meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #689d6a !important; }
+
+.meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #689d6a !important; }
+
+.meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #cc241d !important; }
+
+.meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #cc241d !important; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #f9f5d7; }
+
+.meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #d79921; }
+
+.meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #cc241d !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #cc241d !important; }
+
+.meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #cc241d !important; }
+
+.meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #689d6a !important; }
+
+.delete_attachment_link { color: #689d6a; }
+
+.delete_attachment_link:hover { color: #cc241d; }
+
+.file_container, .c-file_container { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+.file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #282828; border-left-color: #282828; border-right-color: #282828; }
+
+.file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: -moz-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: -o-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+
+.file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #1d2021; box-shadow: 0 0 0 3px #1d2021; color: #f9f5d7; }
+
+.file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #282828; }
+
+.file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #282828; color: #f9f5d7; }
+
+.file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #d79921; }
+
+.file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #282828; }
+
+.file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #282828; color: #f9f5d7 !important; }
+
+.file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #282828; }
+
+.file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(235, 219, 178, 0.9); color: #f9f5d7 !important; }
+
+.file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #282828; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #282828; }
+
+.file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #282828; }
+
+.file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #1d2021; }
+
+.file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(235, 219, 178, 0.9); }
+
+.file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #282828; }
+
+.file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(235, 219, 178, 0.9); border: 1px solid rgba(40, 40, 40, 0.1); }
+
+.file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(29, 32, 33, 0.8), rgba(29, 32, 33, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
+
+.file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(29, 32, 33, 0.8); color: #f9f5d7; }
+
+.file_container .c-file__title, .c-file_container .c-file__title { color: #f9f5d7; }
+
+.c-file_container--has_thumb .c-file__actions::before { background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), #282828 20px); }
+
+.message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #1d2021; color: #f9f5d7; }
+
+.msg_inline_video_buttons_div { background-color: rgba(29, 32, 33, 0.4); }
+
+.msg_inline_video_buttons_div a { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+
+.msg_inline_video_buttons_div a:visited { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+
+.post_body ul.checklist { background-color: #282828; }
+
+.post_body ul.checklist li::before { background: #282828; }
+
+.post_body ul.checklist li.checked { color: #d79921; }
+
+.post_body ul.list.checklist li { border-bottom: 1px solid #1d2021; }
+
+.post_body ul.list.checklist li.checked { color: #d79921; }
+
+.post_body .message { background-color: #f9f5d7; }
+
+.post_body code, .post_body pre { background: #282828; }
+
+ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #d79921; }
+
+ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
+
+.inline_color_block { border-color: #1d2021; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #1d2021; }
+
+.p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #1d2021; border-bottom: 1px solid #1d2021; }
+
+.p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #1d2021; }
+
+.p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #f9f5d7; }
+
+.p-message_pane__limited_history_foreword { background: #282828; background-image: none; color: #f9f5d7; }
+
+.p-message_pane__unread_banner__banner { background: #1d2021; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner { color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.messages_banner a { color: #f9f5d7; }
+
+.messages_banner a:hover { color: #f9f5d7; }
+
+#connection_div { background: #cc241d; }
+
+#archives_return { background: padding-box #ebdbb2; color: #f9f5d7; }
+
+#archives_return.warning { background: #cc241d; }
+
+#archives_return a { color: #f9f5d7; }
+
+#archives_return a:hover { color: rgba(249, 245, 215, 0.8); }
+
+#messages_unread_status { background: #1d2021; }
+
+#messages_unread_status:hover { background: #ebdbb2; }
+
+#messages_unread_status:hover .clear_unread_messages { background: #ebdbb2; }
+
+#messages_unread_status:hover .clear_unread_messages:hover { background: #1d2021; }
+
+#messages_unread_status.quiet { background: #ebdbb2; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#messages_unread_status.quiet a { color: #f9f5d7; }
+
+.clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+
+#messages_container.has_top_messages_banner::before { background: none; }
+
+.end_div_msg_lim { background-color: #282828; background-image: none; }
+
+#archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #f9f5d7; }
+
+#archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(249, 245, 215, 0.8); }
+
+code { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+code a.app_preview_link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+
+.file_list_item.snippet .snippet_preview { background: #282828; }
+
+.snippet_preview, .snippet_body { background: #282828; }
+
+.snippet_preview pre, .snippet_body pre { color: #f9f5d7 !important; }
+
+.file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #282828; border-right: 1px solid #282828; color: #d79921; }
+
+.c-snippet .c-file_container { background-color: #1d2021; }
+
+.c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+
+.CodeMirror { background: #282828; border: 1px solid #282828; color: #f9f5d7 !important; }
+
+.CodeMirror pre { background: transparent !important; }
+
+.CodeMirror div.CodeMirror-cursor { border-left: 1px solid #f9f5d7; }
+
+.CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #f9f5d7; }
+
+.CodeMirror .CodeMirror-gutters { background-color: #282828; border-right: 1px solid #1d2021; }
+
+.CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #282828; }
+
+.CodeMirror-linenumber { color: #d79921 !important; }
+
+.CodeMirror-guttermarker { color: #d79921; }
+
+.CodeMirror-guttermarker-subtle { color: #d79921; }
+
+.CodeMirror-ruler { border-left: 1px solid #ebdbb2; }
+
+.cm-s-default .cm-keyword { color: #ce93d8; }
+
+.cm-s-default .cm-atom { color: #9fa8da; }
+
+.cm-s-default .cm-number { color: #a5d6a7; }
+
+.cm-s-default .cm-def { color: #536dfe; }
+
+.cm-s-default .cm-variable-2 { color: #9fa8da; }
+
+.cm-s-default .cm-variable-3 { color: #c5e1a5; }
+
+.cm-s-default .cm-comment { color: #ffcc80; }
+
+.cm-s-default .cm-string { color: #ef9a9a; }
+
+.cm-s-default .cm-string-2 { color: #ffab91; }
+
+.cm-s-default .cm-meta { color: #eee; }
+
+.cm-s-default .cm-qualifier { color: #eee; }
+
+.cm-s-default .cm-builtin { color: #b39ddb; }
+
+.cm-s-default .cm-bracket { color: #e6ee9c; }
+
+.cm-s-default .cm-tag { color: #a5d6a7; }
+
+.cm-s-default .cm-attribute { color: #40c4ff; }
+
+.cm-s-default .cm-header { color: #80cbc4; }
+
+.cm-s-default .cm-quote { color: #b0bec5; }
+
+.cm-s-default .cm-hr { color: #282828; }
+
+.cm-s-default .cm-link { color: #689d6a; }
+
+.cm-negative { color: #cc241d; }
+
+.cm-positive { color: #98971a; }
+
+.cm-invalidchar, .cm-s-default .cm-error { color: #cc241d; }
+
+div.CodeMirror span.CodeMirror-matchingbracket { color: #98971a; }
+
+div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #cc241d; }
+
+.CodeMirror-matchingtag { background: #282828; }
+
+.CodeMirror-activeline-background { background: #ebdbb2; }
+
+.CodeMirror-selected { background: #ebdbb2; }
+
+.CodeMirror-focused .CodeMirror-selected { background: #ebdbb2; }
+
+.cm-searching { background: #ebdbb2; }
+
+.sssh-keyword { color: #ce93d8; }
+
+.sssh-atom { color: #9fa8da; }
+
+.sssh-number { color: #a5d6a7; }
+
+.sssh-def { color: #536dfe; }
+
+.sssh-variable { color: #9fa8da; }
+
+.sssh-variable-2 { color: #c5e1a5; }
+
+.sssh-variable-3 { color: #c1a5e1; }
+
+.sssh-operator { color: #f9f5d7; }
+
+.sssh-property { color: #f9f5d7; }
+
+.sssh-comment { color: #ffcc80; }
+
+.sssh-string { color: #ef9a9a; }
+
+.sssh-string-2 { color: #ffab91; }
+
+.sssh-meta { color: #eee; }
+
+.sssh-error { color: #cc241d; }
+
+.sssh-qualifier { color: #eee; }
+
+.sssh-builtin { color: #b39ddb; }
+
+.sssh-bracket { color: #e6ee9c; }
+
+.sssh-tag { color: #a5d6a7; }
+
+.sssh-attribute { color: #40c4ff; }
+
+.sssh-header { color: #80cbc4; }
+
+.sssh-quote { color: #b0bec5; }
+
+.sssh-hr { color: #282828; }
+
+.sssh-link { color: #689d6a; }
+
+.c-message--dense .c-timestamp__label { color: #689d6a; }
+
+.c-message--dense .c-message__content_header .c-custom_status { border-color: #282828; }
+
+.dense_theme ts-message { color: #f9f5d7; }
+
+.dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #689d6a; }
+
+.dense_theme ts-message .message_content .message_current_status { border-color: #282828; }
+
+.c-message--light .c-message__sender .c-message__sender_link { color: #f9f5d7; }
+
+.light_theme ts-message { color: #f9f5d7; }
+
+.light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #f9f5d7 !important; }
+
+.light_theme ts-message .comment::before { color: #d79921; }
+
+.channel_overlay { border-color: #282828; color: #d79921; }
+
+.channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #f9f5d7; }
+
+.channel_overlay.channel_overlay_redesign li { color: #d79921; }
+
+.channel_overlay_title_wrap { border-color: #282828; }
+
+.channel_overlay_title_shared { color: #f9f5d7; }
+
+pre { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+pre span.mention { padding: 2px 0 !important; }
+
+#page pre, body > pre { background: #282828; color: #f9f5d7 !important; }
+
+body > pre { background: #ebdbb2; }
+
+.special_formatting_quote .quote_bar { background-color: #1d2021; }
+
+#threads_msgs_scroller_div { background: #1d2021; }
+
+#threads_msgs_scroller_div:not(.loading)::before { background: #1d2021; }
+
+#threads_msgs_scroller_div.loading::before { color: #d79921; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #282828; }
+
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #1d2021; color: #f9f5d7; }
+
+#threads_msgs_scroller_div.loading { background: none; }
+
+#threads_msgs_scroller_div.loading::before { color: #f9f5d7; }
+
+#threads_view_banner.messages_banner { background: #282828; }
+
+#threads_view_banner.messages_banner:hover { background: #1d2021; }
+
+#threads_view_banner.messages_banner:hover .clear_unread_messages { background: #1d2021; }
+
+#threads_msgs.new_banner_is_showing::before { background: #1d2021; }
+
+.p-threads_footer__input .p-message_input_field, .p-threads_footer__input--legacy .p-message_input_field { background: #282828; }
+
+.p-threads_footer__input .p-message_input_file_button, .p-threads_footer__input--legacy .p-message_input_file_button { background: #282828; }
+
+ts-thread { background: #1d2021; }
+
+ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #282828; color: #f9f5d7; }
+
+ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #282828; border-color: #282828; }
+
+ts-thread .thread_messages { background: #282828; border-color: #282828; }
+
+ts-thread ts-message.new_reply { background: #1d2021; }
+
+ts-thread ts-message.new_reply:hover { background: #282828; }
+
+ts-thread .thread_header .thread_channel_name a { color: #f9f5d7; }
+
+ts-thread .thread_header .thread_action_btns button { color: #d79921; }
+
+ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
+
+#convo_tab .thread_participants, ts-thread .thread_participants { color: #d79921; }
+
+#convo_loading_indicator { background-image: none; }
+
+.reply_input_container .inline_message_input_container .ql-container { background-color: #1d2021; border: 1px solid #282828; }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+
+.reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #f9f5d7; }
+
+.reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #d79921; }
+
+#file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #d79921; }
+
+#unread_msgs_scroller_div::after { background: transparent; }
+
+#unread_msgs_scroller_div.loading { background-image: none; }
+
+#unread_msgs_scroller_div.loading::before { color: #d79921; }
+
+#unread_msgs_div .day_divider .day_divider_line { border-top-color: #282828; }
+
+.unread_group.marked_as_read .unread_group_header { background: #1d2021; }
+
+.unread_group .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+
+.unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #f9f5d7; }
+
+.unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #d79921; }
+
+.unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #1d2021; }
+
+.unread_group.active .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+
+.collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #d79921; }
+
+.mark_as_read_checkmark { color: #d79921; }
+
+.bottom_mark_all_read { border-top-color: #282828; }
+
+.unread_group_header_name a { color: #f9f5d7; }
+
+.unread_group_footer .unread_group_new .unread_group_new_text { color: #d79921; }
+
+.unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #d79921; }
+
+.unread_empty_state_message { color: #d79921; }
+
+.unread_empty_state_undo_inner { background: #282828; color: #f9f5d7; }
+
+.unread_empty_state_undo_action { color: #f9f5d7; }
+
+.unread_empty_state_refresh { background: rgba(29, 32, 33, 0.97); }
+
+.unread_msgs_loading { background: #1d2021; background-image: none; }
+
+#col_flex { background: transparent; }
+
+#flex_contents { background: #1d2021; }
+
+#flex_contents .heading { background: #111313; border-bottom-color: #282828; color: #689d6a; }
+
+#flex_contents .heading a { color: #689d6a; }
+
+#flex_contents .heading a:hover { color: #cc241d; }
+
+#flex_contents .heading a.close_flexpane { color: #689d6a; }
+
+#flex_contents .heading .cancel_link { color: #689d6a; }
+
+#flex_contents .heading .menu_heading:hover { color: #f9f5d7; }
+
+#flex_contents .heading .menu_icon { color: #689d6a; }
+
+#flex_contents .heading .menu_icon:hover { color: #cc241d; }
+
+#flex_contents .heading_text { color: #689d6a; }
+
+#flex_contents .subheading:not(.empty) { background: #1d2021; border-top: 1px solid #282828; color: #d79921; }
+
+#flex_contents .subheading:not(.empty) p a { color: #f9f5d7; }
+
+#flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #d79921; }
+
+#flex_contents .toolbar_container { background: #1d2021; }
+
+#flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #689d6a; }
+
+#flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #282828; }
+
+#flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #689d6a; }
+
+#flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #282828; }
+
+#flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #689d6a; }
+
+#flex_contents .help { border-top: 5px solid #282828; color: #f9f5d7; }
+
+#flex_contents i.callout { color: #d79921; }
+
+.close_flexpane { color: #d79921; }
+
+.close_flexpane:focus, .close_flexpane:hover { color: #f9f5d7; }
+
+#client-ui.flex_pane_showing #col_flex { border-left-color: #282828; }
+
+.toolbar_container { background: #1d2021; border-bottom: 1px solid #282828; color: #f9f5d7; }
+
+.msg_right_link { color: #689d6a; }
+
+.message_location_label { color: #d79921; }
+
+.p-flexpane_header { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+#client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #282828; }
+
+#details_tab .heading { background: #111313; }
+
+#details_tab .heading a.close_flexpane { color: #689d6a; }
+
+#details_tab .heading a.close_flexpane:hover { color: #cc241d; }
+
+#details_tab hr { border-top-color: #282828; }
+
+#details_tab .conversation_details .member_name:hover { color: #d79921; }
+
+#details_tab .conversation_details .member_username:hover { color: #f9f5d7; }
+
+#details_tab .conversation_details .member_info_timezone { border-top-color: #1d2021; }
+
+#details_tab .channel_page_section { background: #1d2021; border-top: 1px solid #282828; }
+
+#details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #cc241d; }
+
+#details_tab .channel_page_section .section_header a { color: #689d6a; }
+
+#details_tab .channel_page_section .section_title { color: #f9f5d7; }
+
+#details_tab .channel_page_section .disclosure_triangle { color: #689d6a; }
+
+#details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(204, 36, 29, 0.25) !important; }
+
+#details_tab .created_by { color: #f9f5d7; }
+
+#details_tab .channel_page_member_tabs .icon_member_header { color: #d79921; }
+
+#details_tab .pinned_item:hover { border-color: #1d2021; }
+
+#details_tab .channel_page_action .leave_link { color: #689d6a; }
+
+#details_tab .channel_page_action .leave_link:hover { color: #cc241d; }
+
+#details_tab .channel_section_label .ts_icon_info_circle { color: #d79921; }
+
+#details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #d79921; }
+
+.channel_page_member_row { color: #f9f5d7; }
+
+.channel_page_member_row a { color: #689d6a; }
+
+.channel_page_member_row.away { color: #f9f5d7; }
+
+.channel_page_member_row.away a { color: #689d6a; }
+
+.channel_page_member_row:hover { background-color: #1d2021; border-color: #282828; }
+
+.pinned_item { color: #f9f5d7; }
+
+.pinned_item .pin_file_title { color: #689d6a; }
+
+.pinned_item .pin_member_name a { color: #689d6a !important; }
+
+.pinned_item .pin_metadata { color: #d79921; }
+
+.pinned_item .remove_pin { color: #689d6a; }
+
+.pinned_item .remove_pin:hover { color: #cc241d; }
+
+.pinned_item .pinned_message_text .pin_truncate_fade { background: #1d2021; }
+
+.pinned_item.delete_mode { border-color: #cc241d !important; }
+
+.p-channel_insights .c-member__title { color: #d79921; }
+
+.p-channel_insights_activity_bar_container:hover { background-color: rgba(40, 40, 40, 0.05); }
+
+.p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #1d2021; }
+
+.p-channel_insights__activity { border-color: #1d2021; }
+
+.p-channel_insights__activity_bar { background-color: rgba(29, 32, 33, 0.5); }
+
+.p-channel_insights__channel .channel_link { color: #f9f5d7; }
+
+.p-channel_insights__date_heading span { background-color: #1d2021; color: #f9f5d7; }
+
+.p-channel_insights__date_heading::before { background-color: #1d2021; }
+
+.p-channel_insights__drawer_title { color: #d79921; }
+
+.p-channel_insights__highlights_description { color: #d79921; }
+
+.p-channel_insights__item--user .member_preview_link, .p-channel_insights__item--user .message_sender { color: #f9f5d7 !important; }
+
+.p-channel_insights__member_count { color: #d79921; }
+
+.p-channel_insights__member_count .ts_icon_user { color: #d79921; }
+
+.p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #1d2021 90%); }
+
+.p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #1d2021; }
+
+.p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #1d2021; }
+
+.p-channel_insights__title { color: #f9f5d7; }
+
+.p-channel_insights__user_title { color: #d79921; }
+
+.p-download_item { padding: 12px 12px 4px 16px; margin: 0; }
+
+.p-download_item__container .p-download_item__name_row { color: #f9f5d7; }
+
+.p-download_item__actions { background: #1d2021; }
+
+.p-download_item__link--open, .p-download_item__link--retry, .p-download_item__link--show { color: #f9f5d7; }
+
+.p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #282828 25%, #282828); color: #f9f5d7; }
+
+#file_list_toggle_users { color: #689d6a; }
+
+#file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #cc241d; }
+
+#file_list_toggle_users.active { color: #d79921; }
+
+.file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+
+.filetype_button { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+
+.filetype_button:hover { background: #ebdbb2; }
+
+.filetype_button:hover .file_download_label { background: #1d2021; color: #f9f5d7; }
+
+.filetype_button .file_title { color: #f9f5d7; }
+
+.filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #1d2021; }
+
+a.filetype_button_web { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+
+a.filetype_button_web .filetype_icon { background-color: #1d2021; }
+
+a.file_download_link { color: #689d6a; }
+
+a.file_download_link:hover { color: #cc241d; }
+
+a:hover .file_inline_icon { color: #d79921; }
+
+a.gsheet img, a.pdf img { background: #1d2021 !important; }
+
+html.no_touch a.filetype_button_web:hover { border-color: #1d2021; }
+
+html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
+
+.file_header_detailed { color: #d79921; }
+
+.file_header_detailed .member { color: #f9f5d7 !important; }
+
+.file_inline_icon { color: #d79921; }
+
+.file_header .member { color: #d79921 !important; }
+
+.file_header .title { color: #f9f5d7; }
+
+.file_header .title a { color: #689d6a; }
+
+.file_header .title a:hover { color: #cc241d; }
+
+.flexpane_file_title .member, .flexpane_file_title .service_link { color: #689d6a !important; }
+
+.flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #689d6a; }
+
+.flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #cc241d; }
+
+.file_actions_cog { color: #689d6a !important; }
+
+.file_actions_cog:hover { color: #cc241d !important; }
+
+.file_list_item { color: #f9f5d7; }
+
+.file_list_item a { color: #689d6a; }
+
+.file_list_item a.member { color: #cc241d; }
+
+.file_list_item .bullet { color: #d79921; }
+
+.file_list_item .icon { background: #ebdbb2; border-color: #1d2021; }
+
+.file_list_item .ts_icon_comment { color: #d79921; }
+
+.file_list_item .file_comment_link:hover { color: #689d6a; }
+
+.file_list_item .file_comment_link:hover .ts_icon_comment { color: #d79921; }
+
+.file_list_item .title a { color: #689d6a; }
+
+.file_list_item .share_info .unshare_link { color: #689d6a; }
+
+.file_list_item .share_info .unshare_link:hover { color: #cc241d; }
+
+.file_list_item .actions a, .file_list_item .actions span { background-color: #282828; border: 1px solid #ebdbb2; color: #689d6a; }
+
+.file_list_item .actions a:hover { background-color: #1d2021 !important; border-color: #ebdbb2; color: #cc241d; }
+
+.file_list_item.post .preview, .file_list_item.space .preview { color: #f9f5d7; }
+
+.file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #1d2021; }
+
+.file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #689d6a; }
+
+.file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+
+.file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #282828; }
+
+.unshare_link { color: #689d6a !important; }
+
+.unshare_link i::before { color: #d79921 !important; }
+
+.unshare_link i.ts_icon_minus_circle_small:hover::before { color: #cc241d !important; }
+
+.snippet_preview pre { color: #f9f5d7; }
+
+.file_preview_wrapper .file_preview { background: #1d2021; }
+
+.file_preview_wrapper .file_preview:hover { background: #282828; }
+
+#file_preview_container .file_meta { color: #d79921; }
+
+.file_page_meta { color: #d79921; }
+
+#file_page_preview img { background: #1d2021; border: 1px solid #282828; }
+
+#file_page_preview img:hover { background: #282828; }
+
+.comment_meta { color: #d79921; }
+
+.comment .special_formatting_quote .content { color: #f9f5d7; }
+
+.comment .member { color: #f9f5d7 !important; }
+
+.comment_body { color: #f9f5d7; }
+
+.comment_actions { color: #d79921; }
+
+.comment_actions:hover { color: #f9f5d7; }
+
+.icon_quote { color: #f9f5d7; }
+
+.edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+.edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #282828; }
+
+.tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #1d2021; }
+
+.tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #282828; }
+
+.tab_container .star_item ts-message .timestamp { color: #d79921; }
+
+.tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #1d2021; border-color: #282828; }
+
+.tab_container .file_list_item .star { color: #d79921; }
+
+.tab_container .file_list_item .contents .file_comment_link { color: #689d6a; }
+
+.tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #689d6a; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #cc241d; }
+
+.tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #cc241d; }
+
+.tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #d79921; }
+
+.tab_container .file_list_item .filetype_image { background-color: #282828; }
+
+.active .tab_container .file_list_item { background-color: #1d2021; }
+
+.c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #1d2021; border-color: #282828; color: #fff; }
+
+.c-file__meta { color: #f9f5d7; }
+
+.c-file__slide--meta { background-color: #282828; }
+
+.p-file_details__name, .p-file_details__share_channel { color: #f9f5d7; }
+
+.p-file_details__meta_container .c-file__action_button { color: #fff; }
+
+.c-pillow_file_container { background-color: #282828; }
+
+.c-pillow_file_container .c-pillow_file__swap .c-pillow_file__slide { background-color: #282828; }
+
+.c-pillow_file__description, .c-pillow_file__title { color: #f9f5d7; }
+
+.p-file_list, .p-file_list__filters { background: #282828; }
+
+.p-file_list__filters { border-color: #282828; }
+
+.p-file_list__file.c-pillow_file_container, .p-file_list__file.c-pillow_file_container--full_width { background: #282828; border-color: #282828; color: #f9f5d7; }
+
+.p-file_list__file.c-pillow_file_container--full_width:hover { background: #1d2021; border-color: #1d2021; }
+
+.p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021 25%, #1d2021); color: #f9f5d7; }
+
+.p-download_item__container .p-download_item__actions { background-color: #1d2021; }
+
+.p-download_item__container .p-download_item__link__open, .p-download_item__container .p-download_item__link__retry, .p-download_item__container .p-download_item__link__show { color: #689d6a; }
+
+.p-download_item__container .p-download_item__name_row { color: #f9f5d7; }
+
+#user_groups_pane .mention { background: rgba(204, 36, 29, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+
+#user_groups_container .info_panel { background: #1d2021; border: 1px solid #1d2021; }
+
+#user_groups_container .mention { background-color: rgba(204, 36, 29, 0.25) !important; }
+
+#user_groups_header .user_groups_search .icon_search { color: #d79921; }
+
+#user_groups_header a.icon_close { color: #689d6a; }
+
+#user_groups_header a.icon_close:hover { color: #cc241d; }
+
+.user_group_item { border-bottom: 1px solid #1d2021; }
+
+.user_group_item a { color: #689d6a; }
+
+#flex_contents .user_group_item:hover { background-color: #1d2021; }
+
+#flex_contents .user_group_item:hover h4 { color: #f9f5d7; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #1d2021; }
+
+#flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #f9f5d7; }
+
+.user_group_invite_member_small .add_icon { color: #d79921; }
+
+#user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #ebdbb2; border-color: #ebdbb2; }
+
+#flex_contents .subheading:not(.empty)#mentions_options { background-color: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+
+.mention_day_container_div .day_divider::before { background: none; border-color: #282828; }
+
+#member_mentions h3 a { color: #689d6a; }
+
+a.internal_member_link { background: #282828; color: #f9f5d7; }
+
+a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+
+a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #282828; color: #f9f5d7; }
+
+.mention_rxn .mention_rxn_summary { color: #f9f5d7; }
+
+.mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #d79921; }
+
+.search_message_result { background: #1d2021 !important; border-color: #282828 !important; color: #f9f5d7 !important; }
+
+.search_message_result .search_message_result_meta { color: #d79921; }
+
+.search_message_result .search_message_result_meta a { color: #689d6a; }
+
+.search_message_result .search_message_result_meta .date_links a { color: #689d6a; }
+
+.search_message_result_text .result_msg_format a { color: #689d6a; }
+
+span.match { background: rgba(204, 36, 29, 0.25); }
+
+#search_filters .tab { background: #1d2021; color: #f9f5d7; }
+
+#search_filters .tab:hover { border-bottom: 4px solid #282828; }
+
+#search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #282828; color: #f9f5d7; }
+
+#search_file_list_toggle_users.active:hover { border: 2px solid #cc241d; color: #cc241d !important; }
+
+.no_results { color: #f9f5d7; }
+
+#search_results_team .team_results_heading { color: #f9f5d7; }
+
+#search_results_team .team_result { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+
+#search_results_team .team_result a { color: #689d6a; }
+
+#search_results_team .team_result:hover a { color: #cc241d; }
+
+#search_results_team .team_result a:hover { color: #cc241d; }
+
+#search_results_team .member_name { color: #f9f5d7 !important; }
+
+.suggestion { color: #f9f5d7; }
+
+.suggestion.active, .suggestion:hover { background: #1d2021; }
+
+#paging_in_options .search_paging { color: #d79921; }
+
+#search_results_items .search_paging { color: #f9f5d7; }
+
+.search_paging i.disabled { color: #d79921; }
+
+.search_paging a { color: #689d6a; }
+
+.search_paging a:hover { color: #cc241d; }
+
+.search_sort_prefix { color: #f9f5d7; }
+
+.search_segmented_control { border-color: #282828; color: #689d6a !important; }
+
+.search_segmented_control:hover { color: #cc241d !important; }
+
+.search_segmented_control.active { background: #282828; color: #cc241d !important; }
+
+.search_result_with_extract { background: #282828; border-color: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+
+.search_result_with_extract:hover { border-color: #ebdbb2; }
+
+.search_result_for_context::after { background: rgba(29, 32, 33, 0.1); }
+
+.extract_expand_text, .extract_expand_icons { color: #689d6a; }
+
+.search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #cc241d; }
+
+.search_module_header { color: #f9f5d7; }
+
+.search_module_footer { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+
+.search_module_footer p { color: #f9f5d7; }
+
+.search_module_footer #see_more { color: #f9f5d7; }
+
+.search_module_footer #see_more a { color: #f9f5d7; }
+
+.search_module_footer .top_results_feedback a { color: #f9f5d7; }
+
+.search_module_footer ts-icon { color: #f9f5d7; }
+
+.top_results_search_message_result { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+
+.top_results_search_message_result.duplicate { background-color: #282828; }
+
+.top_results_search_message_result .timestamp { color: #d79921; }
+
+.top_results_search_message_result .channel { color: #d79921; }
+
+.top_results_search_message_result .channel a { color: #d79921; }
+
+.top_results_search_message_result .jump { color: #f9f5d7; }
+
+.top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #1d2021 !important; }
+
+.top_results_search_message_result:first-child { border-top: 2px solid #1d2021; }
+
+.sli_expert_search { background-color: #1d2021; color: #f9f5d7; }
+
+.sli_expert_search__result { border-color: #1d2021; }
+
+.sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #f9f5d7 !important; }
+
+.sli_expert_search__fg_face::before { background-color: #1d2021; }
+
+.sli_expert_search_cta { border-color: #1d2021; }
+
+.sli_expert_search_cta:hover { border-color: #ebdbb2; }
+
+.sli_expert_search_cta__text { color: #f9f5d7; }
+
+.sli_expert_search_cta__text:hover { color: #f9f5d7; }
+
+.sli_expert_search__plus_sign_overlay { background-color: #282828; color: #d79921; }
+
+.sli_expert_search__arrow { color: #d79921; }
+
+.sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #d79921; }
+
+.sli_expert_search__partial_terms { color: #d79921; }
+
+.feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #282828; color: #f9f5d7; }
+
+.feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #d79921; }
+
+.feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #d79921; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #f9f5d7; }
+
+.feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #f9f5d7; }
+
+.feature_sli_file_search #search_results.all { background-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #d79921; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #1d2021; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #ebdbb2; }
+
+.feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #ebdbb2; }
+
+.feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #1d2021; }
+
+.feature_sli_file_search #search_results.files { background-color: #1d2021; }
+
+.feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #f9f5d7; }
+
+.feature_sli_file_search #search_results_loading { background-color: #1d2021; }
+
+.feature_sli_file_search #search_results_container #search_options { background-color: #1d2021; }
+
+.feature_sli_file_search #search_results_container .heading { background-color: #1d2021; }
+
+#client-ui .file_list_item.file_list_item--redesign { border-color: #1d2021; }
+
+#client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #d79921; }
+
+#client-ui .file_list_item.file_list_item--redesign .message_sender { color: #d79921; }
+
+.p-shortcuts_flexpane__shortcut { border-color: #282828; }
+
+.p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #282828; }
+
+.p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #f9f5d7; }
+
+.p-shortcuts_flexpane__shortcut_title { color: #d79921; }
+
+.p-shortcuts_flexpane__title { color: #f9f5d7; }
+
+.p-shortcuts_flexpane__tip { color: #d79921; }
+
+.p-shortcuts_flexpane__section_description { color: #d79921; }
+
+.p-shortcuts_flexpane__sub_heading { color: #d79921; }
+
+.c-keyboard_key { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
+
+.tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #d79921; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #689d6a; }
+
+#member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #cc241d; }
+
+#member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #689d6a; }
+
+#member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #cc241d; }
+
+#member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #689d6a !important; }
+
+#member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #ebdbb2 !important; color: #cc241d !important; }
+
+#member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #f9f5d7; }
+
+#member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #689d6a !important; }
+
+#member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #cc241d !important; }
+
+#member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #282828; color: #d79921; }
+
+#member_preview_scroller { background-color: #282828; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #282828; }
+
+#member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(249, 245, 215, 0.35) !important; }
+
+#team_tab #member_preview_scroller { background-color: #1d2021; }
+
+#team_tab #member_preview_scroller .member_details .member_name { color: #f9f5d7; }
+
+#member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #f9f5d7; }
+
+#member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #f9f5d7; }
+
+#member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #d79921; }
+
+#member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #689d6a; }
+
+#member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #cc241d; }
+
+#member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #689d6a; }
+
+#member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #282828; }
+
+#disabled_members_tab a { color: #689d6a; }
+
+#disabled_members_tab a:hover { background: #282828; color: #cc241d; }
+
+#disabled_members_tab.active a { color: #689d6a; }
+
+.team_list_item { border-top: 1px solid #1d2021; color: #689d6a; }
+
+.team_list_item .member_name { color: #f9f5d7; }
+
+#client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #f9f5d7 !important; }
+
+#client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #282828 !important; }
+
+#client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #1d2021 !important; }
+
+#client-ui .searchable_member_list .team_list_item { border-bottom-color: #282828; }
+
+#client-ui .searchable_member_list .team_list_item:hover { background: #1d2021; }
+
+.c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #f9f5d7 !important; }
+
+#convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #f9f5d7; }
+
+#convo_tab textarea.message_input { color: #f9f5d7; }
+
+#reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #282828; color: #f9f5d7; }
+
+#reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #282828; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #f9f5d7; }
+
+#reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #d79921 !important; }
+
+#reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #1d2021; color: #d79921; }
+
+#convo_container .convo_flexpane_divider { border-top-color: #282828; color: #d79921; }
+
+#convo_container .convo_flexpane_divider .reply_count { background: #1d2021; }
+
+#convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #689d6a; }
+
+#convo_tab .message_input, #convo_tab textarea#msg_text { color: #f9f5d7; }
+
+ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+
+ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+
+#whats_new_tab p { color: #f9f5d7; }
+
+#whats_new_tab .flex_heading_controls label { color: #d79921; }
+
+.c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #f9f5d7; }
+
+.c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #f9f5d7; }
+
+.c-member .external_team_badge { background-color: #1d2021; box-shadow: 0 0 0 2px #1d2021; }
+
+.c-member .external_team_badge.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #1d2021; }
+
+.c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #f9f5d7; }
+
+.c-member--small .presence { color: #d79921; }
+
+.c-member--small .team_image.icon_16 { border-color: #282828; }
+
+.c-member--small .team_image.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.c-member--dark .c-member__current-status { color: #d79921; }
+
+.c-member--dark .c-member__current-status::before { color: #d79921; }
+
+.c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #d79921; }
+
+.c-member--dark .c-member__display-name, .c-member--dark .presence { color: #f9f5d7; }
+
+.c-member--medium { color: #d79921; }
+
+.c-member--medium .presence { color: #d79921; }
+
+.c-member__secondary-name--medium { color: #f9f5d7; }
+
+.c-member--large { color: #d79921; }
+
+.c-member__display-name--large, .c-member__title--large { color: #f9f5d7; }
+
+.c-member__other-names--large { color: #d79921; }
+
+.c-usergroup--small .c-usergroup__icon { background-color: #d79921; color: #f9f5d7; }
+
+.c-usergroup__not-in-channel-context--small { color: #d79921; }
+
+.p-emoji_picker { background: #282828 !important; color: #f9f5d7 !important; }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+.p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+
+.p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+
+.p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #1d2021; }
+
+.p-emoji_picker__group_tabs { border-bottom-color: #282828; }
+
+.p-emoji_picker__group_tab { color: #689d6a; }
+
+.p-emoji_picker__group_tab:hover { background: #282828; color: #cc241d; }
+
+.p-emoji_picker__group_tab--active { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+
+.p-emoji_picker__icon_search { color: #d79921; }
+
+.p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #1d2021; border-color: #1d2021; }
+
+.p-emoji_picker__skintone_options { background: #1d2021; }
+
+.p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #d79921; }
+
+.p-emoji_picker__tip { color: #f9f5d7; }
+
+.p-emoji_picker__no_results { color: #d79921; }
+
+.p-emoji_picker__preview_text { background: #282828; color: #f9f5d7; }
+
+.p-emoji_picker__footer { background: #282828; border-top-color: #282828; }
+
+.p-emoji_picker__footer .p-emoji_picker__heading { background: #282828; }
+
+.p-emoji_picker__emoji_deluxe_label { color: #d79921; }
+
+input[type="text"].p-emoji_picker__input:focus { border-color: #1d2021; box-shadow: none; }
+
+#message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #d79921; }
+
+#message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #f9f5d7; }
+
+#message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #f9f5d7; }
+
+#message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #f9f5d7; }
+
+.current_status_emoji_picker { border-right-color: #282828; }
+
+.current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #282828; }
+
+.current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #d79921; }
+
+.rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #1d2021; }
+
+.rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #282828; }
+
+.rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #f9f5d7; }
+
+.rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(40, 40, 40, 0.08); border-color: rgba(235, 219, 178, 0.4) !important; }
+
+.rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #f9f5d7; }
+
+.rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #f9f5d7; }
+
+.rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(249, 245, 215, 0.25); }
+
+a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d79921; color: #282828; }
+
+.modal { background-color: #1d2021; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+.modal .close, .modal label { color: #f9f5d7; }
+
+.modal_input_note, .modal_input_note_full_width, .input_note_special { color: #d79921; }
+
+.modal-footer { background: padding-box #1d2021; border-top: 1px solid transparent; box-shadow: none; }
+
+.modal-header { background: padding-box #282828; border-bottom: 1px solid #282828; color: #f9f5d7; }
+
+.modal-backdrop { background-color: #1d2021; }
+
+.close { color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+#fs_modal_bg { background: #1d2021; }
+
+#fs_modal { background: #1d2021; }
+
+#fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #f9f5d7; }
+
+#fs_modal #fs_modal_sidebar a { color: #f9f5d7; }
+
+#fs_modal #fs_modal_sidebar a:hover { background: #282828; }
+
+#fs_modal #fs_modal_sidebar a.active { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#fs_modal .fs_modal_btn { color: rgba(249, 245, 215, 0.5); }
+
+#fs_modal .fs_modal_btn:hover { background: #ebdbb2; color: #f9f5d7; }
+
+#fs_modal .fs_modal_btn:active { background: #ebdbb2; color: #f9f5d7; }
+
+#fs_modal.fs_modal_header .fs_modal_btn:active { color: #f9f5d7; }
+
+#fs_modal #fs_modal_footer { background-color: #282828; }
+
+.p-apps_browser__apps_list--loading::before { background-color: #282828; }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #1d2021; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #282828; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+
+.p-apps_browser__category_header { background: #1d2021; color: #d79921; }
+
+.p-apps_browser__app { border-top-color: #1d2021; }
+
+.p-apps_browser__app--selected { background: #282828; border-color: #ebdbb2; }
+
+.p-apps_browser__app_info { color: #f9f5d7; }
+
+.p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+
+.p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #ebdbb2; color: #f9f5d7; }
+
+.p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+
+.p-apps_browser__app_description { color: #d79921; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #d79921; }
+
+#fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #f9f5d7; }
+
+#incoming_call { background-color: rgba(40, 40, 40, 0.97); color: #f9f5d7; }
+
+#fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #282828; }
+
+#fs_modal.channel_options_modal .convert_to_shared label { color: #d79921; }
+
+#fs_modal.channel_options_modal .channel_option_item { border-top-color: #282828; }
+
+#fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #f9f5d7; }
+
+#fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(40, 40, 40, 0.75); border-color: #282828; }
+
+#channel_invite_container .lfs_list_container .lfs_item { border-top-color: #282828; }
+
+#channel_invite_container .lfs_list_container .lfs_item.active { border-color: #282828; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #282828; }
+
+#channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #d79921; }
+
+#channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #1d2021; border-color: #282828; }
+
+#channel_prefs_dialog { color: #f9f5d7; }
+
+#at_channel_warning_dialog { background-color: #1d2021; }
+
+#at_channel_warning_dialog.fullsize { background-color: #1d2021; }
+
+#at_channel_warning_dialog.fullsize .modal-body { background-color: #1d2021; }
+
+.channel_prefs_modal_header { color: #f9f5d7; }
+
+.channel_prefs_body__section_header_title { color: #f9f5d7; }
+
+.channel_prefs_body__section_header_icon::before { color: #f9f5d7; }
+
+.channel_prefs_body__mute_help_text { color: #d79921; }
+
+.channel_prefs_notifications_table { border-bottom-color: #282828; color: #f9f5d7; }
+
+.channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #1d2021 !important; }
+
+.channel_prefs__muting_checkbox_label { color: #f9f5d7; }
+
+.channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #f9f5d7 !important; }
+
+.notification_prefs_icon::before { color: #f9f5d7; }
+
+.channel_modal_header { color: #f9f5d7; }
+
+#channel_browser .channel_browser_row { border-top: 1px solid #282828; color: #f9f5d7; }
+
+#channel_browser .channel_browser_row_header { color: #f9f5d7; }
+
+#channel_browser .channel_browser_creator_name { color: #d79921; }
+
+#channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #d79921; }
+
+#channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #1d2021; }
+
+#channel_browser .channel_browser_divider { background: transparent; color: #d79921; }
+
+#channel_browser .channel_browser_sort_container::after { color: #f9f5d7; }
+
+#channel_browser .channel_browser_channel_purpose { color: #f9f5d7; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #689d6a; }
+
+.channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #d79921 !important; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #282828; color: #f9f5d7; }
+
+#invite_members_container .lfs_input_container { background: #1d2021; }
+
+#notifications_not_working p.highlight_yellow_bg a { color: #f9f5d7; }
+
+.c-dialog__header { background: #282828; }
+
+.c-dialog__header .c-dialog__title, .c-dialog__header .c-dialog__close { color: #f9f5d7; }
+
+.c-dialog__header .c-dialog__close:hover { color: #689d6a; }
+
+.c-dialog__body { background: #222222; }
+
+.c-dialog__body .p-share_dialog_message_input { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+
+.c-dialog__body .p-share_dialog_message_input.focus { border-color: #1d2021; box-shadow: unset; }
+
+.c-dialog__body .p-file_upload_dialog__preview, .c-dialog__body .p-file_upload_dialog__preview_image { background-color: #282828; border-color: #282828; }
+
+.c-dialog__body input.c-input_text { border-color: #282828; }
+
+.c-dialog__body input.c-input_text .c-input_character_count { background-color: #282828; color: #f9f5d7; }
+
+.c-dialog__body input.c-input_text:focus { border-color: #1d2021; box-shadow: unset; }
+
+.c-dialog__footer { background: #222222; }
+
+.c-dialog__footer .c-button { background-color: #1d2021; color: #f9f5d7; }
+
+.c-dialog__footer .p-file_upload_dialog__footer_share_inputs { color: #f9f5d7; }
+
+#im_browser .im_browser_row { border-top: 1px solid #1d2021; }
+
+#im_browser .im_browser_row.multiparty { color: #f9f5d7; }
+
+#im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #282828; }
+
+#im_browser .im_browser_row .im_unread_cnt { background: #cc241d; color: #f9f5d7; }
+
+#im_browser .im_browser_row.disabled { color: #d79921; }
+
+#im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #1d2021 !important; }
+
+#im_browser_tokens { background: #1d2021; border: 1px solid #ebdbb2; }
+
+#im_browser_tokens.active { border-color: #ebdbb2; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
+
+#im_browser_tokens .member_token { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+
+#im_browser_tokens .member_token.ra { background: #cc241d; }
+
+.fs_modal_file_viewer_header { background-color: #282828; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+
+.fs_modal_file_viewer_header .btn { color: #f9f5d7; }
+
+.fs_modal_file_viewer_header .star { color: #d79921; }
+
+.fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #f9f5d7; }
+
+.fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #f9f5d7; }
+
+.fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #d79921; }
+
+.fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #1d2021; }
+
+.fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #d79921; }
+
+.fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #1d2021; }
+
+.fs_modal_file_viewer_content .viewer { background-color: #282828; color: #f9f5d7 !important; }
+
+.fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #1d2021; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(235, 219, 178, 0.25); color: #f9f5d7; }
+
+.fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(215, 153, 33, 0.8); }
+
+.fs_modal_file_viewer_content .aside_panel { background-color: #1d2021; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+
+.fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #282828; }
+
+.fs_modal_file_viewer_content .no_comment { background-color: #1d2021; color: #d79921; }
+
+.fs_modal_file_viewer_content .aside_close_btn { color: #f9f5d7; }
+
+.fs_modal_file_viewer_content #file_comment { color: #f9f5d7; }
+
+#file_comment_textarea.texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+
+#file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #282828; }
+
+#fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #d79921; }
+
+#fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #1d2021; }
+
+#fs_modal.help_modal .help_modal_header a { color: #f9f5d7; }
+
+#fs_modal.help_modal .help_modal_divider { color: #d79921; }
+
+#fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #282828; }
+
+#fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #d79921; }
+
+#fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #282828; border-color: #282828; }
+
+.admin_invites_account_type_option { border-bottom: 1px solid #282828; }
+
+.admin_invites_account_type_option p { color: #f9f5d7; }
+
+.admin_invites_account_type_option .option_arrow { color: #d79921; }
+
+.admin_invites_account_type_option:hover:not(.disabled) h3 { color: #f9f5d7; }
+
+.admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+
+.admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(29, 32, 33, 0.95); }
+
+.admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #d79921; }
+
+.admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #cc241d; }
+
+.admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(204, 36, 29, 0.4); }
+
+#admin_invites_channel_picker_container { border-bottom: 1px solid #282828; }
+
+#admin_invites_add_row { background: #1d2021; border: 1px solid #282828; }
+
+#admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #1d2021; }
+
+#channel_invite_tokens { background-color: #1d2021; border-color: #ebdbb2; }
+
+#channel_invite_tokens.active { border-color: #d79921; box-shadow: 0 0 7px rgba(215, 153, 33, 0.15); }
+
+#channel_invite_tokens .member_token { background: #1d2021; color: #f9f5d7; }
+
+#channel_invite_tokens .member_token.ra { background: rgba(204, 36, 29, 0.4); }
+
+#admin_invites_alert { background: #1d2021; border-color: #ebdbb2; }
+
+.channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #f9f5d7; }
+
+.channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #1d2021; color: #f9f5d7; }
+
+#shortcuts_dialog { background: rgba(29, 32, 33, 0.95); text-shadow: 0 1px 1px rgba(40, 40, 40, 0.7); }
+
+#shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #f9f5d7; }
+
+#shortcuts_dialog.modal ul ul { border-left-color: #1d2021; }
+
+#shortcuts_dialog.modal .info_block { color: #d79921; }
+
+#shortcuts_dialog.modal .close { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+
+#shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(40, 40, 40, 0.9); }
+
+#fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #d79921; }
+
+#fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #282828; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #282828; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #282828; border: 1px solid #282828; }
+
+#fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #cc241d; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+
+#fs_modal.prefs_modal legend { color: #f9f5d7; }
+
+#fs_modal.prefs_modal .global_notification_block { background: #1d2021; border-color: #282828; }
+
+#fs_modal.prefs_modal .global_notification_block.selected { background: #282828; border-color: #282828; }
+
+#fs_modal.prefs_modal .channel_overrides_row { border-top-color: #282828; }
+
+#fs_modal.prefs_modal .channel_overrides_row:hover { background: #282828; border-color: #282828; }
+
+#fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #f9f5d7; }
+
+#fs_modal.prefs_modal .notification_example.mac { background: #282828; box-shadow: 0 1px 8px 2px #282828; }
+
+#fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #282828; color: #f9f5d7; }
+
+#fs_modal.prefs_modal .badge_example { background: #cc241d; }
+
+#fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #282828; border-top-color: #282828; }
+
+#fs_modal.prefs_modal .display_real_names_block_sample { background: #1d2021; }
+
+.sidebar_menu_list_item { border: 0; color: #f9f5d7; }
+
+.sidebar_menu_list_item.is_active { background-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+.sidebar_menu_list_item:not(.is_active):hover { background-color: #282828; }
+
+.jumbomoji_pref_disabled { color: #d79921; }
+
+.jumbomoji_disabled_note { color: rgba(215, 153, 33, 0.6); }
+
+#edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #1d2021; border: 1px solid #282828; }
+
+#edit_team_profile_container .lazy_filter_select.disabled { background: #1d2021; }
+
+#edit_team_profile_container .lazy_filter_select.disabled input { background: #1d2021; }
+
+#edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #282828; }
+
+#edit_team_profile_list .row:nth-last-child(2):hover { border-color: #282828 !important; }
+
+#edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #282828; border: 1px solid #282828; }
+
+#edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #d79921; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i { color: #f9f5d7; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #d79921; }
+
+#edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #d79921; }
+
+#edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #1d2021; }
+
+#edit_team_profile_add .row:last-child { border-bottom: 1px solid #1d2021; }
+
+#edit_team_profile_add .row:not(.header_row):hover { background: #282828; border: 1px solid #282828; }
+
+#edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #f9f5d7; }
+
+#edit_team_profile_add .row:not(.header_row):hover i { border-color: #282828; color: #f9f5d7; }
+
+#edit_team_profile_add i { color: #d79921; }
+
+#edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #d79921; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #282828; }
+
+#edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #cc241d; border-color: #cc241d !important; color: #f9f5d7; }
+
+#edit_team_profile_edit .row i { border: 1px solid #282828; color: #f9f5d7; }
+
+#edit_team_profile_custom .row .col .profile_field_preview { background: #282828; border: 2px solid #282828; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #282828; }
+
+#edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #d79921; }
+
+#edit_team_profile_custom .row .col input { background: #1d2021; border: 1px solid #282828; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #d79921; }
+
+#edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #282828; }
+
+.profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #1d2021; }
+
+.profile_field_preview_protector .profile_field_preview::after { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview::before { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+
+.profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #1d2021; color: #d79921; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #282828, rgba(255, 255, 255, 0)); }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #282828; }
+
+.profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #282828 transparent transparent; }
+
+ts-jumper ts-jumper-container { background: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+
+ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #1d2021; color: #d79921; }
+
+ts-jumper input[type=text] { border: 1px solid #282828 !important; color: #f9f5d7; }
+
+ts-jumper input[type=text]:focus { border: 1px solid rgba(40, 40, 40, 0.8) !important; color: #f9f5d7; }
+
+ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #f9f5d7; }
+
+ts-jumper ol li { color: #f9f5d7; }
+
+ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #d79921; }
+
+ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #d79921; }
+
+ts-jumper ol li .unread_count { background: #cc241d; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+ts-jumper ol li.highlighted { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+
+ts-jumper ol:not(.keyboard_active) li:hover { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+
+ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #f9f5d7; }
+
+.basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+
+.share_dialog_attachment_container { color: #f9f5d7; }
+
+#share_dialog .file_list_item { border-color: #282828; }
+
+#generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #d79921; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container { border-color: #282828; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #1d2021; }
+
+#share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #f9f5d7; }
+
+.ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #1d2021; }
+
+.ts_tip .ts_tip_tip { color: #f9f5d7; }
+
+.ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #1d2021; }
+
+.ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #1d2021; }
+
+.ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #1d2021; }
+
+.ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #1d2021; }
+
+.ts_tip.success .ts_tip_tip { background: #ebdbb2; }
+
+.ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #ebdbb2; }
+
+.ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #ebdbb2; }
+
+.ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #ebdbb2; }
+
+.ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #ebdbb2; }
+
+.c-tooltip__tip { background-color: #1d2021; color: #f9f5d7; }
+
+.c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+
+.c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+
+.c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+
+.c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #1d2021; }
+
+.c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+
+.c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+
+.c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+
+.c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #1d2021; }
+
+.c-tooltip__tip--success { background-color: #98971a; }
+
+.c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #98971a; }
+
+.c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #98971a; }
+
+.c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #98971a; }
+
+.c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #98971a; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #1d2021; }
+
+#coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #1d2021; }
+
+#coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(235, 219, 178, 0.5) !important; }
+
+#coachmark_interior { color: #f9f5d7; }
+
+#coachmark_interior .coachmark_close_btn { color: #f9f5d7; }
+
+.menu_member_header { background: #282828; }
+
+.menu_member_header .member_details .member_name_and_presence { color: #f9f5d7; }
+
+.menu_member_header .member_details .member_name_and_presence .member_name { color: #f9f5d7; }
+
+.menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+
+.menu_member_header .member_details .member_title { color: #d79921; }
+
+.menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #d79921; }
+
+.menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #689d6a; }
+
+.menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #cc241d; }
+
+.menu_member_header .member_details_divider { border-color: #1d2021; }
+
+.menu_member_footer { background: #282828; border-top: 1px solid #1d2021; }
+
+.menu_member_footer p { color: #d79921; }
+
+.menu_member_footer #menu_member_dm_input p { color: #f9f5d7; }
+
+.member_meta { color: #689d6a; }
+
+.mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #f9f5d7 !important; }
+
+.greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #d79921 !important; }
+
+.clear_blue { color: #689d6a !important; }
+
+.moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #cc241d !important; }
+
+.seafoam_green { color: #98971a !important; }
+
+.candy_red_bg { background-color: #cc241d !important; }
+
+.off_white_bg, .neutral_white_bg { background-color: #282828 !important; }
+
+.yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #282828 !important; }
+
+.sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #1d2021 !important; }
+
+.sk_black { color: inherit; }
+
+.monkey_scroll_bar { z-index: 99; }
+
+.client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+
+nav.top.persistent { background: #282828; }
+
+nav.top.persistent .logo { background-position: 50% 0 !important; }
+
+.widescreen #header_team_name a i { margin-left: 1.5em; }
+
+.widescreen #user_menu { border-right: none; }
+
+header #menu_toggle { color: #689d6a; }
+
+header #header_team_nav { background: #282828; border: 1px solid #282828; }
+
+header #header_team_nav li.active a { background: #1d2021; color: #f9f5d7; }
+
+header .header_btns a { color: #689d6a; }
+
+header .header_btns a .label { color: #d79921; }
+
+header .vert_divider { border-left: 1px solid #282828; }
+
+footer, #autocomplete_menu.search_menu footer.unified { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+
+footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #f9f5d7; }
+
+footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #f9f5d7; }
+
+.plastic_row h3 { color: #f9f5d7; }
+
+.plastic_row h4 a { color: #f9f5d7; }
+
+.plastic_row .icon { color: #f9f5d7; }
+
+.plastic_row .chevron { color: #d79921; }
+
+.plastic_row .description { color: #f9f5d7; }
+
+.plastic_row:active { background: #1d2021; border-color: #282828; }
+
+.plastic_row:active .chevron { color: #f9f5d7; }
+
+html.no_touch .plastic_row:hover { background: #1d2021; border-color: #282828; }
+
+html.no_touch .plastic_row:hover .chevron { color: #f9f5d7; }
+
+html.no_touch .pagination ul > li > a:hover { background-color: #282828; }
+
+html.no_touch .pagination ul > .disabled > a:hover { background: #282828; color: #d79921; }
+
+html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #cc241d; }
+
+.card, .tab_pane { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+.card h3 a { color: #f9f5d7; }
+
+#page_contents .card { background: rgba(40, 40, 40, 0.8) !important; }
+
+#page_contents .card p { color: #f9f5d7; }
+
+.tab_set a.secondary { color: #689d6a; }
+
+.tab_set a.selected, .tab_set a.secondary.selected { background: #282828; border: 1px solid #282828; border-bottom-color: #282828; color: #cc241d; }
+
+.tab_actions { background: #282828; border: 1px solid #282828; border-color: #282828; }
+
+.accordion_section { border-bottom-color: #1d2021; }
+
+.accordion_section h4 { color: #f9f5d7; }
+
+.accordion_section h4 a { color: #f9f5d7; }
+
+.no_touch .accordion_section h4 a:hover { color: #f9f5d7; }
+
+.accordion_section_fixed { border-bottom-color: #1d2021 !important; }
+
+.pager li > a, .pager li > span { background-color: #1d2021; background-image: none; border-color: #282828; color: #689d6a; }
+
+.pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+
+.pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+
+.pager .disabled > a, .pager .disabled > span { color: #d79921; }
+
+.pagination ul > li > a, .pagination ul > li > span { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+
+.pagination ul > li > a:focus { background-color: #282828; }
+
+.pagination ul > .active > a, .pagination ul > .active > span { background-color: #282828; }
+
+.pagination ul > .disabled > span { background: #282828; color: #d79921; }
+
+.pagination ul > .disabled > a { background: #282828; color: #689d6a; }
+
+.pagination ul > .disabled > a:focus { background: #282828; color: #cc241d; }
+
+.loading_hash_animation img { display: none; }
+
+.icon_search_close { color: #689d6a; }
+
+.icon_search_close:hover { color: #cc241d; }
+
+.help { border-top-color: #282828; color: #d79921; }
+
+.two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+
+.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+.two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+.two_factor_choice:hover .two_factor_link { color: #f9f5d7; }
+
+a.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:link { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+
+a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+
+a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #f9f5d7; }
+
+.backup_codes { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+
+#channel_specific_settings tr { border-top-color: #1d2021; }
+
+#channel_specific_settings tr.channel_override_row.muted td { background: rgba(29, 32, 33, 0.5); }
+
+#channel_specific_settings .extra_left_border { border-left-color: #1d2021; }
+
+#channel_specific_settings .extra_right_border { border-right-color: #1d2021; }
+
+#channel_specific_settings .revert_to_default { color: #d79921; }
+
+#channel_specific_settings .revert_to_default:hover { color: #cc241d; }
+
+.admin_list_item { border-bottom-color: #1d2021; color: #d79921; }
+
+.admin_list_item:hover { background-color: #282828; }
+
+.admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #f9f5d7; }
+
+.admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #d79921; }
+
+.admin_list_item .pill.group { background: #282828; }
+
+.admin_list_item .two_factor_auth_badge:hover { background: #282828; }
+
+.admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+
+.admin_list_item.invite_item.bouncing { background: #ebdbb2; }
+
+.admin_list_item.invite_item.bouncing .email { color: #cc241d; }
+
+.admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #1d2021; }
+
+.admin_list_item.expanded .btn_outline { border-color: #1d2021; color: #f9f5d7 !important; }
+
+.admin_list_item.expanded .btn_outline:hover { border-color: #282828; color: #f9f5d7 !important; }
+
+.admin_list_item.expanded .sub_action { color: #689d6a; }
+
+.admin_list_item.expanded .sub_action:hover { color: #cc241d; }
+
+@media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #689d6a; } }
+
+.billing_selection { border-color: #282828; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection:hover { border-color: #ebdbb2; }
+
+.billing_selection.active { background: #1d2021; border-color: #ebdbb2; }
+
+.billing_selection.billing_selection--refactor { border-color: #1d2021; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.billing_selection.billing_selection--refactor:hover { border-color: #ebdbb2; }
+
+.billing_selection.billing_selection--refactor.active { background: #1d2021; border-color: #ebdbb2; }
+
+.billing_selection .billing_selection__price { color: #f9f5d7; }
+
+#billing_contacts_container { background: #282828; border-top: 1px solid #282828; }
+
+.billing_contact { border-bottom: 1px solid #1d2021; }
+
+table.billing tr:hover td { background: #282828; }
+
+.link_billing_statement { color: #f9f5d7 !important; }
+
+.link_invoice_id, .link_statement_id { color: #689d6a !important; }
+
+.billing_invoice tbody tbody tr { color: #f9f5d7 !important; }
+
+.billing_settings_label_name { color: #f9f5d7; }
+
+table tr { border-bottom-color: #1d2021; }
+
+table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
+
+.slackbot_response_fieldset .delete_response { color: #d79921; }
+
+.slackbot_response_fieldset .delete_response:hover { color: #cc241d; }
+
+.author_cell { color: #f9f5d7; }
+
+.message_cell.disabled { color: #d79921; }
+
+#message_container #msg_limit { color: #f9f5d7; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #1d2021; }
+
+.statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #1d2021; }
+
+.inactive { background-image: none; }
+
+.c3 line, .c3 path { stroke: #ebdbb2; }
+
+.c3-chart-arc .c3-gauge-value { fill: #ebdbb2; }
+
+.c3-chart-arc path { stroke: #282828; }
+
+.c3-chart-arc text { fill: #282828; }
+
+.c3-chart-arcs .c3-chart-arcs-background { fill: #1d2021; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #282828; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #ebdbb2; }
+
+.c3-circle._expanded_ { stroke: #282828; }
+
+.c3-grid line { stroke: #ebdbb2; }
+
+.c3-grid text { fill: #f9f5d7; }
+
+.c3-legend-background { fill: #282828; stroke: #1d2021; }
+
+.c3-region { fill: #1d2021; }
+
+.c3-selected-circle { fill: #282828; }
+
+.c3-tooltip { background-color: #282828; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+
+.c3-tooltip td { background-color: #282828; border-left-color: #1d2021; }
+
+.c3-tooltip th { background-color: #282828; color: #f9f5d7; }
+
+.c3-tooltip tr { border-color: #1d2021; }
+
+.ent_alert a { color: #689d6a; }
+
+.ent_alert a:link, .ent_alert a:visited { color: #cc241d; }
+
+.ent_alert_page.ent_alert_error { background: #cc241d; }
+
+.ent_alert_page.ent_alert_success { background: #98971a; }
+
+.ent_analytics__disclaimer { border-top-color: #ebdbb2; color: #d79921; }
+
+.ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+
+.ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+
+.ent_avatar { background-color: #1d2021; }
+
+.ent_callout__difference--increase { color: #98971a; }
+
+.ent_callout__icon_border { background-color: #282828; border-color: #ebdbb2; }
+
+.ent_callout__icon_image, .ent_callout__icon--filled { border-color: #ebdbb2; }
+
+.ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #1d2021; }
+
+.ent_callout__icon--limit_reached { border-color: #ebdbb2; }
+
+.ent_callout__insight { color: #d79921; }
+
+.ent_callout__limit { color: #d79921; }
+
+.ent_callout__meter_bar_container { background: #1d2021; }
+
+.ent_callout__meter_bar_border { border-color: #1d2021; }
+
+.ent_callout__meter_bar_fill--empty { background: #ebdbb2; border-color: #ebdbb2; }
+
+.ent_callout__meter_bar_fill--filled { background: #ebdbb2; border-color: #ebdbb2; }
+
+.ent_callout__meter_bar_fill--limit_reached { background: #cc241d; border-color: #cc241d; }
+
+.ent_callout__meter_bar_gleam { background: rgba(235, 219, 178, 0.5); }
+
+.ent_callout__title { color: #f9f5d7; }
+
+.ent_copy_muted { color: #d79921; }
+
+.ent_copy { color: #f9f5d7; }
+
+.ent_csv_popover__footer_text { color: #d79921; }
+
+.ent_csv_popover__footer { background: #282828; border-top-color: #ebdbb2; }
+
+.ent_csv_popover__subtitle { color: #d79921; }
+
+.ent_csv_popover__title { color: #f9f5d7; }
+
+.ent_data_table__cell--header { color: #d79921; }
+
+.ent_data_table__cell--positive { color: #f9f5d7; }
+
+.ent_data_table__cell--sortable:hover { background-color: #282828; }
+
+.ent_data_table__cell--sorting { color: #d79921; }
+
+.ent_data_table__cell { border-bottom-color: #ebdbb2; color: #f9f5d7; }
+
+.ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #ebdbb2; }
+
+.ent_data_table__column_group { background-color: #282828; }
+
+.ent_data_table__data_link, a.ent_data_table__data_link { color: #f9f5d7; }
+
+.ent_data_table__row--hovered { background-color: #1d2021; }
+
+.ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+
+.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+
+.ent_data_table__secondary_text { color: #d79921; }
+
+.ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #282828; }
+
+.ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #ebdbb2; }
+
+.ent_data_table--rounded_top { border-top-color: #ebdbb2; }
+
+.ent_data_table { border-bottom-color: #ebdbb2; border-left-color: #ebdbb2; border-right-color: #ebdbb2; }
+
+.ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #f9f5d7; }
+
+.ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #d79921; }
+
+.ent_graph__legend_item--defocus { fill: #d79921 !important; }
+
+.ent_graph__legend_text { fill: #f9f5d7; }
+
+.ent_graph__svg_container .c3-axis path { stroke: #ebdbb2; }
+
+.ent_graph__svg_container .c3-grid line { stroke: #ebdbb2; }
+
+.ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #ebdbb2; }
+
+.ent_graph__svg_container .c3-tooltip { border-color: #ebdbb2; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+
+.ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #282828; color: #f9f5d7; }
+
+.ent_graph__svg_container .c3-tooltip th { border-bottom-color: #ebdbb2; }
+
+.ent_graph__svg_container .c3-xgrid-focus line { stroke: #d79921; }
+
+.ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #282828 !important; }
+
+.ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #282828 !important; }
+
+.ent_graph__svg_container text { fill: #d79921; }
+
+.ent_graph__tooltip { color: #d79921; }
+
+.ent_graph_empty__overlay { background: #282828; }
+
+.ent_graph_empty__text { color: #f9f5d7; }
+
+.ent_graph_header--primary { color: #f9f5d7; }
+
+.ent_graph_header--secondary { color: #d79921; }
+
+.ent_graph_tabs__tab--selected { color: #f9f5d7; }
+
+.ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #ebdbb2; }
+
+.ent_graph_tabs__tab { color: #d79921; }
+
+.ent_graph_tabs { border-bottom-color: #ebdbb2; }
+
+.ent_header { color: #f9f5d7; }
+
+.ent_icon_button { color: #d79921; }
+
+.ent_icon_button:hover { color: #f9f5d7; }
+
+.ent_infographic_container { border-top-color: #ebdbb2; }
+
+.ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(40, 40, 40, 0.8), #282828); }
+
+.ent_modal__title--small { color: #f9f5d7; }
+
+.ent_modal_background { background-color: #1d2021; }
+
+.ent_modal_breadcrumb_animated_step { background: #1d2021; }
+
+.ent_modal_breadcrumb_circle_icon { background: #1d2021; }
+
+.ent_modal_breadcrumb_line { background: #1d2021; }
+
+.ent_modal_breadcrumb_text { color: #d79921; }
+
+.ent_modal_footer { background-color: #282828; }
+
+.ent_modal_title { color: #f9f5d7; }
+
+.ent_table__header--title { color: #f9f5d7; }
+
+.ent_table__header { background-color: #1d2021; border-color: #ebdbb2; }
+
+.ent_table_banner__contents { background: #1d2021; border-top-color: #ebdbb2; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+
+.ent_table_banner__header { color: #f9f5d7; }
+
+.ent_table_banner__secondary_text { color: #d79921; }
+
+.ent_table_customizer__header_subtitle { color: #d79921; }
+
+.ent_table_customizer_disabled_list_header { color: #d79921; }
+
+.ent_table_customizer_footer { background-color: #1d2021; border-top-color: #282828; color: #d79921; }
+
+.ent_table_customizer_header { border-bottom-color: #1d2021; }
+
+.ent_table_customizer_list_item--disabled { color: #d79921; }
+
+.ent_updated_at { color: #d79921; }
+
+.enterprise { background-color: #282828; }
+
+.enterprise .btn.candy_red { color: #cc241d !important; }
+
+.enterprise_analytics { background-color: #282828; }
+
+.enterprise_org { background-color: #282828; }
+
+.enterprise_search_bar .ent_clear_search_icon { color: #d79921; }
+
+.enterprise_search_bar::before { color: #f9f5d7; }
+
+@keyframes color_fade { from { color: #d79921; }
+  to { color: #f9f5d7; } }
+
+.file_header .title a { color: #689d6a; }
+
+.file_header .title a:hover { color: #cc241d; }
+
+.file_actions_cog { color: #689d6a !important; }
+
+.file_actions_cog:hover { color: #cc241d !important; }
+
+.file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #282828; }
+
+.action_cog { color: #689d6a; }
+
+.action_cog i { color: #689d6a; }
+
+html.no_touch .action_cog:hover { color: #cc241d; }
+
+html.no_touch .action_cog:hover i { color: #cc241d; }
+
+.help_pages.help_pages p { color: #f9f5d7; }
+
+.help_pages.help_pages a { border-bottom-color: #1d2021; }
+
+.help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #1d2021; }
+
+.help_pages.help_pages .o-hero__header { color: #f9f5d7; }
+
+.help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #1d2021; }
+
+.help_pages.help_pages .c-form__container .c-form__feedback { color: #cc241d; }
+
+.help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; }
+
+.help_pages.help_pages .drop_zone { background: #1d2021; border-color: #ebdbb2; }
+
+.help_pages.help_pages .drop_zone_attachment { border-bottom-color: #1d2021; }
+
+.help_pages.help_pages .drop_zone_remove_attachment { background-color: #1d2021; }
+
+.help_pages.help_pages .c-form__notice { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+
+.help_pages.help_pages .c-form__notice.is-error { border-left-color: #cc241d; }
+
+.help_pages.help_pages .c-nav--footer { border-top-color: #1d2021; }
+
+@media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #1d2021; } }
+
+.widescreen:not(.nav_open) { color: #f9f5d7; }
+
+@media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(29, 32, 33, 0.9); } }
+
+.widescreen:not(.nav_open) nav#site_nav h3 { color: #f9f5d7; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a { color: #689d6a; }
+
+.widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #cc241d; }
+
+.widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #d79921; }
+
+nav#site_nav { background: #282828; }
+
+nav#site_nav #user_menu_contents:hover { background: #1d2021; color: #f9f5d7; }
+
+header { background: #282828; }
+
+header #header_team_nav li a { color: #f9f5d7; }
+
+header #header_team_nav li a:hover { background: #1d2021; color: #f9f5d7; }
+
+header #header_team_nav li a .team_icon.ts_icon_plus { background: #282828; color: #d79921; }
+
+header #header_team_nav #add_team_option { border-top: 1px solid #282828; }
+
+html.no_touch header #header_team_nav li a { color: #f9f5d7; }
+
+html.no_touch header #header_team_nav li a:hover { background: #1d2021; color: #f9f5d7; }
+
+html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #cc241d; }
+
+html.no_touch header .header_btns a:hover { color: #cc241d; }
+
+html.no_touch header .header_btns a:hover .label { color: #d79921; }
+
+nav#site_nav h3, #header_team_name, header #header_team_name a { color: #689d6a; }
+
+nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #cc241d; }
+
+#home_footer a { color: #cc241d; }
+
+.admin_pref:not(:first-of-type) { border-top-color: #1d2021; }
+
+.admin_pref.locked { background-color: rgba(204, 36, 29, 0.2); }
+
+.admin_pref .admin_pref_locked_label { color: #d79921; }
+
+.tooltip-inner { background-color: #ebdbb2; color: #f9f5d7; }
+
+.tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #ebdbb2; }
+
+.tooltip.right .tooltip-arrow { border-right-color: #ebdbb2; }
+
+.tooltip.left .tooltip-arrow { border-left-color: #ebdbb2; }
+
+.tooltip.bottom .tooltip-arrow { border-bottom-color: #ebdbb2; }
+
+.api #header_logo img { display: none; }
+
+body.api header .header_links a { color: #f9f5d7; }
+
+body.api header .header_links a.active { background: #1d2021; }
+
+body.api .reverse_header { background-color: #282828; color: #f9f5d7; }
+
+body.api pre { overflow-x: auto; }
+
+body.api pre code { color: #f9f5d7; }
+
+body.api #page_contents .card { background: #282828; }
+
+body.api .scopes_to_methods code { color: #f9f5d7; }
+
+body.api .scopes_to_methods .selected code { color: #cc241d; }
+
+body.api .scopes_to_methods li { color: #f9f5d7; }
+
+body.api .scopes_to_methods .selected li { color: #f9f5d7; }
+
+body.api .section_title { border-bottom: 2px solid #1d2021; }
+
+body.api .example { border: 1px solid #282828; }
+
+body.api .example h5 { background-color: #282828; color: #f9f5d7; }
+
+body.api .alert { background: #1d2021; }
+
+body.api .hljs { background-image: none; }
+
+body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+
+body.api .hljs-number { color: #a5d6a7; }
+
+body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+
+body.api .hljs-variable { color: #9fa8da; }
+
+body.api .hljs-template-variable { color: #c5e1a5; }
+
+body.api .hljs-comment { color: #ffcc80; }
+
+body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+
+body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+
+body.api .hljs-meta { color: #eee; }
+
+body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+
+body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+
+body.api .hljs-tag { color: #a5d6a7; }
+
+body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+
+body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+
+body.api .hljs-quote { color: #b0bec5; }
+
+body.api .hljs-link, body.api .hljs-regexp { color: #689d6a; }
+
+body.api span.btn { background-color: #1d2021; }
+
+body.api span.deprecation, body.api span.warning { background-color: #cc241d; border-color: #cc241d; }
+
+nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+
+#api_nav .footer_nav a { color: #689d6a; }
+
+#api_nav .footer_nav a:hover { color: #cc241d; }
+
+#api_nav .footer_nav .footer_signature { color: #cc241d; }
+
+.api_articles .api_articles_section { border-bottom-color: #1d2021; }
+
+.api_articles .article_tag_count { color: #d79921; }
+
+.api.feature_related_content #api_related_content h2 { color: #f9f5d7; }
+
+.api.feature_related_content #api_related_content .article_link_title_wrapper { color: #689d6a; }
+
+.tab_menu { background-color: #282828; }
+
+.tab_menu.grey { background-color: #282828; }
+
+.tab_menu .tab { color: #f9f5d7; }
+
+.tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(204, 36, 29, 0.4); }
+
+.tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #cc241d; color: #f9f5d7; }
+
+.tab_menu .tab:disabled { color: #d79921; }
+
+.page_faq h3, .page_scim h3 { background-color: #1d2021; }
+
+.application_config aside { color: #d79921; }
+
+.page_apps_directory_home { background-color: #1d2021 !important; }
+
+.page_apps_directory_home .nav_title { color: #f9f5d7 !important; }
+
+.page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #d79921; }
+
+.page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #ebdbb2; }
+
+.splash_container__background { background-color: #282828; }
+
+.splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+
+.splash_interactive__button { border-color: #1d2021; }
+
+.splash_interactive__button--active { box-shadow: 0 0 10px 1px #ebdbb2; }
+
+.splash_interactive__window { background-color: #1d2021; border-color: #1d2021; }
+
+.splash_interactive__window:hover .splash_interactive__window_headline { color: #f9f5d7; }
+
+.splash_interactive__window::after { background: linear-gradient(to bottom, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+
+.splash_interactive__window_response { background-color: #fff; }
+
+a.splash_interactive__window_link { color: #f9f5d7; }
+
+.splash_interactive__window_message_content_text--drive { color: #d79921; }
+
+.search_input.apps_search_input { border-color: #ebdbb2; }
+
+.menu_launcher, .menu_launcher_large { background-color: #1d2021; border-color: #1d2021 !important; color: #f9f5d7; }
+
+.menu_launcher_large { border-color: #1d2021; }
+
+.menu.avatar_menu ul li:hover ts-icon { background: #1d2021; color: #f9f5d7; }
+
+.menu.avatar_menu ul li a { color: #f9f5d7; }
+
+.menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #1d2021; color: #d79921; }
+
+.menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
+
+#page .media_list { background-color: #282828; border: 1px solid #1d2021; }
+
+#page .media_list > li + li::before { border-top-color: #1d2021; }
+
+#page .media_list > li.interactive a { color: #f9f5d7; }
+
+#page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #1d2021; border-color: #ebdbb2; }
+
+#page .media_list > li .media_list_text { color: #f9f5d7; }
+
+#page .media_list.media_list_with_arrows a::before { color: #d79921; }
+
+#page .media_list_title { color: #f9f5d7; }
+
+#page .media_list_subtitle { color: #d79921; }
+
+#page .sidebar_menu_list_item { color: #f9f5d7; }
+
+#page .sidebar_menu_list_item.is_active { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+
+#page .sidebar_menu_list_item.is_active a { color: #f9f5d7; }
+
+#page .sidebar_menu_list_item:not(.is_active):hover { background-color: #1d2021; border-color: #1d2021; }
+
+#page .sidebar_menu_list_item a { color: #f9f5d7; }
+
+#page ul.breadcrumbs li { color: #d79921; }
+
+#page ul.breadcrumbs li:not(:first-child)::before { color: #d79921; }
+
+#page ul.navigation_list li a { color: #f9f5d7; }
+
+#page ul.navigation_list li a:hover { background-color: #1d2021; }
+
+#page ul.navigation_list li a::after { color: #f9f5d7; }
+
+#page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+
+#page .tag { background-color: #282828; border: 1px solid #282828; }
+
+#page .tag:hover { background-color: #1d2021 !important; }
+
+#page .app_desc_btn { background-color: #1d2021; color: #f9f5d7; }
+
+#page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+
+#page .service_panel { background-color: #282828; }
+
+#page .service_card { background-color: #1d2021; border: 1px solid #282828; }
+
+.app_card, .large_app_card { background-color: #1d2021; border: 1px solid #282828; }
+
+nav.top.persistent ul a { color: #f9f5d7; }
+
+nav.top.apps_nav { background: transparent; }
+
+nav.top.apps_nav.persistent .nav_title { border-color: #ebdbb2; }
+
+nav.top.apps_nav.clear_nav .nav_title a { color: #f9f5d7; }
+
+nav.top.apps_nav .nav_title a { color: #f9f5d7; }
+
+nav.top.apps_nav ul a.active { color: #cc241d; }
+
+.plastic_typeahead { background: #282828; border: 1px solid #282828; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+
+.plastic_typeahead_item { color: #f9f5d7; }
+
+.plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #1d2021; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #1d2021; border-top-color: #282828; color: #f9f5d7; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #d79921; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #1d2021; }
+
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #1d2021; }
+
+a.plastic_typeahead_item { color: #f9f5d7; }
+
+.apps_typeahead_item_media { background: #282828; }
+
+.search_input_container .search_input:focus ~ .icon_search_input { color: #f9f5d7; }
+
+.icon_search_input { color: #d79921; }
+
+.quote_block { color: #f9f5d7; }
+
+.quote_block::before { background-color: #1d2021; }
+
+.well { background: #282828; border-color: #232323; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+
+.service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #d79921; }
+
+.c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+
+.c-tabs__tab { color: #d79921; }
+
+.c-tabs__tab:hover { color: #f9f5d7; }
+
+.c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
+
+.c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+
+a.c-tabs__tab--plastic { color: #d79921; }
+
+a.c-tabs__tab--plastic:hover { color: #f9f5d7; }
+
+a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
+
+.p-detail_scope { box-shadow: inset 0 1px 0 0 #1d2021; }
+
+.p-detail_scope:last-child { border-bottom-color: #1d2021; }
+
+.p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #1d2021; }
+
+.p-detail_arrow_icon { color: #d79921; }
+
+.p-detail_arrow_icon:hover { color: #f9f5d7; }
+
+.p-detail_permissions { background: #282828; border-color: #1d2021; }
+
+table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #1d2021; }
+
+.section_rollup { border-bottom-color: #1d2021; }
+
+.section_rollup:first-of-type { border-top-color: #1d2021; }
+
+.section_rollup:hover:not(.is_active) { background: rgba(29, 32, 33, 0.5); color: #f9f5d7; }
+
+.is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #98971a; color: #282828; }
+
+.developer_apps_functionality_link:hover { border-color: #1d2021; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
+
+.developer_apps_functionality_link::before { background-color: #1d2021; }
+
+.developer_apps_functionality_link_enabled::before { background-color: #98971a; }
+
+.legal-hero { background-color: #1d2021; }
+
+.legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #1d2021; }
+
+.legal-hero .o-hero__header__headline--larger { color: #f9f5d7; }
+
+.legal-main { background-color: #282828; }
+
+.legal-main.v--no-switch { background-color: #282828; border-bottom-color: #1d2021; border-top-color: #1d2021; }
+
+.legal-main p { color: #f9f5d7; }
+
+.legal-main a { border-bottom-color: #1d2021; }
+
+@media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #f9f5d7; }
+  .legal-main .c-nav--sidebar__listitem a.is-selected { color: #d79921; } }
+
+.legal-main .t-contains-subtle-links a:not(.c-button) { color: #f9f5d7; }
+
+.legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #d79921; }
+
+@media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #282828; } }
+
+.t-no-header .legal-hero.o-hero.v--short { background-color: #282828; }
+
+.c-oauth_scope_info__spacer_icon { color: #cc241d; }
+
+.c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #1d2021; }
+
+.c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #1d2021; border-top-color: #1d2021; }
+
+.c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #1d2021; }
+
+a.p-oauth_nav__anchor { color: #d79921; }
+
+.p-oauth_nav__team-switcher .menu_launcher { border-color: #282828; }
+
+.p-oauth_nav__team-switcher .menu_launcher:hover { border: #1d2021; }
+
+.p-oauth_page, .p-oauth_page--error { background: #1d2021; }
+
+.p-oauth_page__title { color: #f9f5d7; }
+
+.p-oauth_page_single_channel_picker { border-bottom-color: #282828; }
+
+ts-rocket { color: #f9f5d7; }
+
+ts-rocket a { color: #689d6a; }
+
+ts-rocket a caret::before { background-color: #282828; border-color: #282828; }
+
+ts-rocket hr { border-color: #282828; }
+
+ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #282828; }
+
+ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #282828; }
+
+ts-rocket .cl.text { background-color: #282828; border-bottom: 1px solid #282828; }
+
+ts-rocket .cl.text .checkbox.checked + li { color: #d79921; }
+
+ts-rocket > div > .checklist { background-color: #282828; border-bottom: 1px solid #282828; }
+
+ts-rocket > div > .checklist .checkbox.checked + li { color: #d79921; }
+
+ts-rocket > div > .checklist li::before { background: #282828; }
+
+ts-rocket > div > .checklist li.checked { color: #d79921; }
+
+ts-rocket .unfurl .unfurl-container { background-color: #282828; }
+
+ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(204, 36, 29, 0.1); }
+
+ts-rocket .unfurl .attachment_bar { background-color: #282828 !important; }
+
+ts-rocket .unfurl .unfurl-remove::before { color: #d79921; }
+
+ts-rocket .unfurl .unfurl-remove:hover::before { color: #f9f5d7; }
+
+ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(235, 219, 178, 0.5) !important; }
+
+ts-rocket caret::before { background-color: #282828; border: 1px solid #282828; }
+
+ts-rocket carriage { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-rocket selection { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-rocket ime { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(235, 219, 178, 0.5); }
+
+.focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #282828; }
+
+nav { background: #282828; }
+
+nav .space { background-color: #282828; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+
+nav .space::after { border-left: 1px solid #1d2021; }
+
+nav .comments { background-color: #282828; }
+
+nav .space_buttons .btn_outline { background-color: #282828; }
+
+nav .space_buttons .btn_outline::after { border-color: #1d2021; }
+
+nav .space_btn_star { background: none; border: 0; }
+
+nav .space_btn_star:hover { background: none !important; }
+
+nav .space_btn_edit { background: #1d2021; }
+
+nav .space_btn_edit.editing { background: #ebdbb2; }
+
+nav .star_info { color: #d79921; }
+
+nav #space_status { border-left: 1px solid #1d2021; color: #d79921; }
+
+nav #space_status.slightly_concerned { color: #cc241d; }
+
+nav #edit_status { color: #d79921; }
+
+nav .comments_open.unread span.notif { background-color: #cc241d; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+
+nav .comments_close { color: #d79921; }
+
+nav .comments_close:hover::before { color: #689d6a !important; }
+
+ts-space header { background: transparent; }
+
+ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #f9f5d7; }
+
+ts-space header .owner_detail .inline-edit { background: none; }
+
+ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #f9f5d7; }
+
+ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #f9f5d7; }
+
+ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #d79921; }
+
+ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #d79921; }
+
+ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(235, 219, 178, 0.5); }
+
+ts-space header .owner_detail small { color: #d79921; }
+
+ts-space header .divider { border-top: 1px solid #1d2021; }
+
+ts-space a.feedback { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+
+ts-space a.feedback:hover { background-color: #282828; color: #f9f5d7; }
+
+comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+
+#space_alert { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+
+#space_alert.error { background-color: #cc241d; }
+
+#space_alert span#space_alert_text { color: #f9f5d7; }
+
+#space_alert a { color: #689d6a; }
+
+#space_alert button#space_alert_close::before { color: #d79921; }
+
+#space_alert button#space_alert_close:hover::before { color: #d79921; }
+
+#space_alert .btn_outline.btn_transparent { background-color: #282828 !important; color: #f9f5d7 !important; }
+
+#space_alert .btn_outline.btn_transparent::after { border-color: #1d2021; }
+
+#space_find_bar { background-color: #282828; border-bottom: 1px solid rgba(235, 219, 178, 0.1); border-left: 1px solid rgba(235, 219, 178, 0.07); border-right: 1px solid rgba(235, 219, 178, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+
+#space_find_bar #space_find_info.no_matches { color: #cc241d; }
+
+#space_find_bar #space_find_next .ts_icon { background-color: #1d2021; }
+
+#space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #f9f5d7; }
+
+#space_find_bar #space_find_next:hover .ts_icon { background-color: #ebdbb2; }
+
+#space_find_bar #space_find_close::before { color: #d79921; }
+
+#space_find_bar #space_find_close:hover::before { color: #d79921; }
+
+#connected_members .connected_members_count { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+
+#connected_members .toggle_more_members_popover { background: #1d2021; color: #d79921; }
+
+#connected_members_overflow_popover { border-bottom: 1px solid #282828; border-left: 1px solid rgba(40, 40, 40, 0.11); border-right: 1px solid rgba(40, 40, 40, 0.11); border-top: 1px solid rgba(40, 40, 40, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .arrow::after { background-color: #282828; }
+
+#connected_members_overflow_popover .arrow_shadow::after { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+
+#connected_members_overflow_popover .monkey_scroll_wrapper { background: #282828; }
+
+#connection_status #connection_label { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+
+#shortcuts_spaces_dialog { background-color: rgba(40, 40, 40, 0.8); text-shadow: 0 1px 1px rgba(40, 40, 40, 0.7); }
+
+#shortcuts_spaces_dialog .modal-body { color: #f9f5d7; }
+
+#shortcuts_spaces_dialog .col .keyboard { background-color: #ebdbb2; border-bottom: 2px solid #282828; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+
+#shortcuts_spaces_dialog .close:hover { background-color: #ebdbb2; }
+
+#shortcuts_spaces_dialog .close .ts_icon::before { color: #d79921 !important; }
+
+.textstyle_menu .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #282828; }
+
+.textstyle_menu .arrow::after { background-color: #282828; }
+
+.textstyle_menu .content { background-color: #282828; box-shadow: 0 0 0 1px #282828, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .arrow-shadow::after { background-color: #282828; }
+
+.textstyle_menu.link .arrow::after { background-color: #282828; }
+
+.textstyle_menu.link .content { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.textstyle_menu.link .content input[type=text] { background-color: #1d2021; }
+
+.textstyle_menu.link .content > a.link { color: #689d6a; }
+
+.textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #d79921; }
+
+.textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #282828; }
+
+.textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #1d2021; }
+
+.textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #1d2021; border: 1px solid #ebdbb2; }
+
+.textstyle_menu.style a.deformat::before { border-left: 1px solid #1d2021; }
+
+.textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #d79921; }
+
+.para_menu .insert .tip { color: #d79921; }
+
+.para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+
+.para_menu .insert .tooltip .arrow::after { background-color: #282828; }
+
+.para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+
+.para_menu .format .options .arrow::after { background-color: #282828; }
+
+.para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #1d2021; }
+
+.para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+
+.para_menu .format .options .content ul:first-child { border-bottom: 1px solid #282828; }
+
+.para_menu .format .options.show .tooltip > div { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #f9f5d7; }
+
+.para_menu .format .options.show .tooltip span { background-color: #1d2021; }
+
+.para_menu .options a:hover { border: 1px solid #1d2021; }
+
+.para_menu .options a.active { background-color: #282828; border: 1px solid #282828; }
+
+.para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+
+.para_menu .options a span { filter: grayscale(2) brightness(5); }
+
+.para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+
+.para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); }

--- a/css/raw/variants/gruvbox-dark.css
+++ b/css/raw/variants/gruvbox-dark.css
@@ -36,7 +36,7 @@ h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
 
 ::-webkit-scrollbar-track { background: #282828 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #282828 !important; }
 
-::-webkit-scrollbar-thumb { background: #1d2021 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
+::-webkit-scrollbar-thumb { background: #504945 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
 
 ::-webkit-scrollbar-corner { background: #1d2021 !important; }
 
@@ -44,17 +44,17 @@ h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
 
 .monkey_scroll_bar { background: #282828; }
 
-.monkey_scroll_handle_inner { background: #1d2021; border: 1px solid #ebdbb2; }
+.monkey_scroll_handle_inner { background: #504945; border: 1px solid #ebdbb2; }
 
 .monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
 
 #client-ui .monkey_scroll_bar { background: #282828; }
 
-#client-ui .monkey_scroll_handle_inner { background: #1d2021; border: 3px solid #1d2021; }
+#client-ui .monkey_scroll_handle_inner { background: #504945; border: 3px solid #1d2021; }
 
 .c-scrollbar--monkey .c-scrollbar__track { background: #282828; }
 
-.c-scrollbar--monkey .c-scrollbar__bar { background: #1d2021; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
+.c-scrollbar--monkey .c-scrollbar__bar { background: #504945; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
 
 .client_channels_list_container { background-color: #282828; border-right-color: #1d2021; }
 
@@ -74,9 +74,9 @@ h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
 
 .p-channel_sidebar__channel--im .c-presence--away { color: #d79921; }
 
-.p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #1d2021 !important; }
+.p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #504945 !important; }
 
-.p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #1d2021 !important; }
+.p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #504945 !important; }
 
 .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #f9f5d7; }
 
@@ -84,7 +84,7 @@ h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
 
 .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #cc241d; }
 
-.p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #1d2021; }
+.p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #504945; }
 
 .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #fdfcf2 !important; }
 
@@ -170,7 +170,7 @@ body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_me
 
 .p-degraded_list__loading { background-color: #1d2021; color: #f9f5d7; }
 
-input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #1d2021; border-color: #282828; color: #f9f5d7; }
+input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #504945; border-color: #282828; color: #f9f5d7; }
 
 input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(40, 40, 40, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
 
@@ -178,7 +178,7 @@ input[type=file]:focus { outline: #f9f5d7 dotted thin; }
 
 input[type=radio]:focus, input[type=checkbox]:focus { outline: #f9f5d7 dotted thin; }
 
-select { background: #1d2021; }
+select { background: #504945; }
 
 select, textarea { border: 1px solid #282828; color: #f9f5d7; }
 
@@ -202,7 +202,7 @@ legend small { color: #d79921; }
 
 .uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
 
-textarea { background-color: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+textarea { background-color: #504945; border: 1px solid #282828; color: #f9f5d7; }
 
 textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
 
@@ -222,17 +222,17 @@ input::placeholder, textarea::placeholder { color: #f9f5d7 !important; filter: n
 
 input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #f9f5d7 !important; }
 
-input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #1d2021 !important; }
+input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #504945 !important; }
 
 .form-actions { background-color: #282828; border-top: 1px solid #282828; }
 
 .help-block, .help-inline { color: #d79921; }
 
-.input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #1d2021; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+.input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #504945; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
 
-.btn { background-color: #1d2021; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+.btn { background-color: #504945; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
 
-.btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #1d2021; color: #f9f5d7; }
+.btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #504945; color: #f9f5d7; }
 
 .btn.btn_border { border: 2px solid #282828; }
 
@@ -248,7 +248,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .btn.btn_outline.disabled:hover { background: #282828 !important; color: #689d6a !important; }
 
-.btn.btn_attachment { border-color: #1d2021; }
+.btn.btn_attachment { border-color: #504945; }
 
 .btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #282828; border-color: #ebdbb2; }
 
@@ -266,13 +266,13 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .btn_outline::after { border: 1px solid #282828; }
 
-.btn_outline.btn_transparent { color: rgba(29, 32, 33, 0.9) !important; }
+.btn_outline.btn_transparent { color: rgba(80, 73, 69, 0.9) !important; }
 
 .btn_outline.btn_transparent::after { border: 1px solid rgba(29, 32, 33, 0.5); }
 
-.btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(29, 32, 33, 0.9) !important; color: #cc241d !important; }
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(80, 73, 69, 0.9) !important; color: #cc241d !important; }
 
-.btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(29, 32, 33, 0.8) !important; }
+.btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(80, 73, 69, 0.8) !important; }
 
 .btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #1d2021; color: #cc241d !important; }
 
@@ -284,7 +284,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .btn_link:hover, .btn_link:focus { color: #cc241d; }
 
-.btn-group.open .btn.dropdown-toggle { background-color: #1d2021; }
+.btn-group.open .btn.dropdown-toggle { background-color: #504945; }
 
 .btn-group.open .btn-primary.dropdown-toggle { background-color: #282828; }
 
@@ -298,11 +298,11 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .input_note { color: #f9f5d7; }
 
-.c-enhanced_text_input { background-color: #1d2021; border-color: #282828; color: #d79921; }
+.c-enhanced_text_input { background-color: #504945; border-color: #282828; color: #d79921; }
 
-.c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #1d2021; }
+.c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #504945; }
 
-.c-filter_input { background: #1d2021; }
+.c-filter_input { background: #504945; }
 
 .p-share_dialog_message_input { color: #f9f5d7; }
 
@@ -312,7 +312,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .lazy_filter_select.disabled input.lfs_input { background: #ebdbb2; }
 
-.lazy_filter_select .lfs_input_container { background-color: #1d2021; border-color: #282828; }
+.lazy_filter_select .lfs_input_container { background-color: #504945; border-color: #282828; }
 
 .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #282828; }
 
@@ -356,7 +356,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
 
-#msg_form #msg_input { background: padding-box #1d2021; border-color: #282828; border-left: 0; color: #f9f5d7; }
+#msg_form #msg_input { background: padding-box #504945; border-color: #282828; border-left: 0; color: #f9f5d7; }
 
 #msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #f9f5d7; }
 
@@ -364,7 +364,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #msg_form .msg_mentions_button:hover { color: #f9f5d7; }
 
-#msg_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+#msg_input { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 #msg_input::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
 
@@ -388,7 +388,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #msg_input_message { background-color: #282828; color: #f9f5d7; }
 
-#primary_file_button { background: padding-box #1d2021; border-color: #282828; color: #d79921; }
+#primary_file_button { background: padding-box #504945; border-color: #282828; color: #d79921; }
 
 #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #282828; border-color: #282828; color: #f9f5d7; }
 
@@ -404,15 +404,15 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #special_formatting_text { color: #d79921; }
 
-#message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+#message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #504945; border-color: #282828; color: #f9f5d7; }
 
-.inline_message_input_container .ql-container { border-color: #1d2021; color: #f9f5d7; }
+.inline_message_input_container .ql-container { border-color: #504945; color: #f9f5d7; }
 
 .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #ebdbb2; }
 
 .c-message--editing { background: #282828; border-color: #282828; color: #f9f5d7; }
 
-.c-message__editor__input, .c-message__editor__input--legacy { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+.c-message__editor__input, .c-message__editor__input--legacy { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 .c-message__editor__input.focus, .c-message__editor__input--legacy.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
 
@@ -424,27 +424,27 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message .c-button--outline:hover { color: #cc241d; }
 
-.c-message .c-button--primary { background-color: #1d2021; color: #f9f5d7; }
+.c-message .c-button--primary { background-color: #504945; color: #f9f5d7; }
 
-#message_edit_container .message_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+#message_edit_container .message_input { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 #message_edit_container .message_input.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
 
-.ql-editor::-webkit-scrollbar-thumb { background-color: rgba(29, 32, 33, 0.5); color: #1d2021; }
+.ql-editor::-webkit-scrollbar-thumb { background-color: rgba(80, 73, 69, 0.5); color: #1d2021; }
 
-.ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(29, 32, 33, 0.8); }
+.ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(80, 73, 69, 0.8); }
 
 .ql-placeholder, .texty_legacy .ql-placeholder { color: #f9f5d7; filter: none; }
 
-.ql-container.texty_single_line_input { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+.ql-container.texty_single_line_input { background: #504945; border: 1px solid #282828; color: #f9f5d7; }
 
 .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
 
-.c-input_select { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+.c-input_select { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 .p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
 
-.c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+.c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 .c-input_select_options_list__option { color: #f9f5d7; }
 
@@ -456,7 +456,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-calendar_view_header__stepper_btn, .c-calendar_view_header__title_btn { color: #f9f5d7; }
 
-.c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #1d2021; }
+.c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #504945; }
 
 .c-date_picker_calendar__date--disabled, .c-date_picker_calendar__date--disabled:hover { background-color: #282828; }
 
@@ -472,7 +472,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .menu .menu_filter_container input.menu_filter { border: 1px solid #282828; }
 
-.menu .menu_filter_container input.menu_filter:focus { border-color: #1d2021; }
+.menu .menu_filter_container input.menu_filter:focus { border-color: #504945; }
 
 .menu .menu_filter_container .icon_search { color: #d79921; }
 
@@ -516,9 +516,9 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #cc241d; }
 
-.menu input { background: #282828; border: 1px solid #1d2021; }
+.menu input { background: #282828; border: 1px solid #504945; }
 
-.menu textarea { background: #282828; border: 1px solid #1d2021; }
+.menu textarea { background: #282828; border: 1px solid #504945; }
 
 .menu #menu_footer .menu_footer { background: #282828; border-top: 1px solid #282828; }
 
@@ -526,7 +526,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .menu #menu_list_container #menu_list .menu_list_item a { color: #f9f5d7; }
 
-.menu #menu_list_container #menu_list .menu_list_item.active a { background: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+.menu #menu_list_container #menu_list .menu_list_item.active a { background: #504945; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
 
 .c-menu { background-color: #282828; }
 
@@ -552,7 +552,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #autocomplete_menu .pickmeup { border-bottom: 1px solid #282828; }
 
-#autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #1d2021; }
+#autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #504945; }
 
 #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #f9f5d7; }
 
@@ -600,21 +600,21 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #d79921; }
 
-#autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+#autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
 
-#autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(29, 32, 33, 0.25); border: #ebdbb2; }
+#autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(80, 73, 69, 0.25); border: #ebdbb2; }
 
 #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
 
 .search_light_grey { color: #f9f5d7 !important; }
 
-.highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+.highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
 
-.highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+.highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
 
 .highlighter_underlay .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
 
-.highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #1d2021; }
+.highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #504945; }
 
 .highlighter_underlay .ghost_text { color: #f9f5d7; }
 
@@ -626,19 +626,19 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #ebdbb2; color: #f9f5d7 !important; }
 
-.pickmeup .pmu-instance .pmu-today-border { border: 2px solid #1d2021 !important; color: #ebdbb2 !important; }
+.pickmeup .pmu-instance .pmu-today-border { border: 2px solid #504945 !important; color: #ebdbb2 !important; }
 
-.pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #1d2021; color: #f9f5d7; }
+.pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #504945; color: #f9f5d7; }
 
 .pickmeup .pmu-instance .pmu-not-in-month { background: #1d2021; color: #d79921; }
 
-.pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #1d2021; }
+.pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #504945; }
 
 .pickmeup .pmu-instance .pmu-disabled { background: #1d2021; color: #d79921; }
 
 .pickmeup .pmu-instance .pmu-disabled:hover { background: #1d2021; color: #d79921; }
 
-.pickmeup .pmu-instance .pmu-selected { background: #1d2021; color: #f9f5d7; }
+.pickmeup .pmu-instance .pmu-selected { background: #504945; color: #f9f5d7; }
 
 .pickmeup .pmu-instance nav { color: #689d6a; }
 
@@ -652,13 +652,13 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .pickmeup .pmu-instance .pmu-days * { border: 1px solid #282828; }
 
-.p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #504945; color: #f9f5d7; }
 
-.p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+.p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #504945; border-color: #282828; color: #f9f5d7; }
 
-.p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #1d2021; color: #ebdbb2; }
+.p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #504945; color: #ebdbb2; }
 
-#menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #1d2021; }
+#menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #504945; }
 
 #menu.date_picker li.date_picker_item a { color: #f9f5d7; }
 
@@ -668,7 +668,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #file_member_filter { background: #282828; }
 
-#client-ui .member_filter { border: 1px solid #1d2021; }
+#client-ui .member_filter { border: 1px solid #504945; }
 
 #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #1d2021; }
 
@@ -676,9 +676,9 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #client-ui #team_list_container #team_filter .member_filter { background-color: #1d2021; border-left: 1px solid #282828; }
 
-#client-ui #file_member_filter { border-color: #1d2021; }
+#client-ui #file_member_filter { border-color: #504945; }
 
-#client-ui #file_member_filter .member_filter { border-color: #1d2021; }
+#client-ui #file_member_filter .member_filter { border-color: #504945; }
 
 #client-ui .team_tabs_container { border-bottom: 1px solid #282828; }
 
@@ -690,11 +690,11 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .filter_header { background-color: #1d2021; }
 
-.popover_menu { background-color: #1d2021; border-top: 1px solid #1d2021; }
+.popover_menu { background-color: #1d2021; border-top: 1px solid #504945; }
 
 .popover_menu .arrow::after { background-color: #282828; }
 
-.popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #1d2021, 0 0 3px rgba(0, 0, 0, 0.08); }
+.popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #504945, 0 0 3px rgba(0, 0, 0, 0.08); }
 
 .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #1d2021 !important; }
 
@@ -724,7 +724,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #282828; }
 
-.tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #1d2021; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+.tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #504945; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
 
 .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #f9f5d7 !important; }
 
@@ -802,11 +802,11 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #282828; color: #f9f5d7; }
 
-#canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #1d2021; color: #f9f5d7; }
+#canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #504945; color: #f9f5d7; }
 
 #recent_mentions_toggle:hover { color: #cc241d; }
 
-#rxn_toast_div { background: #282828; border: 1px solid #1d2021; }
+#rxn_toast_div { background: #282828; border: 1px solid #504945; }
 
 .presence { color: #d79921; }
 
@@ -834,7 +834,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .day_container .day_divider .day_divider_label { background: #1d2021; }
 
-.search_form { border-color: #1d2021; }
+.search_form { border-color: #504945; }
 
 .search_form .search_input { background: transparent; }
 
@@ -866,13 +866,13 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .p-search_filter__title_text { background: #282828; color: #f9f5d7; }
 
-.p-search_filter__datepicker_trigger { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.p-search_filter__datepicker_trigger { background: #282828; border-color: #504945; color: #f9f5d7; }
 
 .p-search_filter__datepicker_trigger:hover { color: #d79921; }
 
-.c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #504945; color: #f9f5d7; }
 
-.c-search_autocomplete footer { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.c-search_autocomplete footer { background: #282828; border-color: #504945; color: #f9f5d7; }
 
 .c-search_autocomplete__suggestion_item { color: #f9f5d7; }
 
@@ -920,7 +920,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message--deleting { background: rgba(204, 36, 29, 0.6); }
 
-.c-message--standalone { border-color: rgba(29, 32, 33, 0.1); }
+.c-message--standalone { border-color: rgba(80, 73, 69, 0.1); }
 
 .c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
 
@@ -934,7 +934,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message__body { color: #f9f5d7; }
 
-.c-message__body--unknown { background: rgba(29, 32, 33, 0.1); }
+.c-message__body--unknown { background: rgba(80, 73, 69, 0.1); }
 
 .c-message__body--automated { color: #d79921; }
 
@@ -950,19 +950,19 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message__resend_controls { color: #d79921; }
 
-.c-message__resend_column { background-color: rgba(29, 32, 33, 0.1); }
+.c-message__resend_column { background-color: rgba(80, 73, 69, 0.1); }
 
 .c-message__resend, .c-message__cancel { color: #f9f5d7; }
 
 .c-message__edited_label { color: #d79921; }
 
-.c-message__tombstone_icon { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+.c-message__tombstone_icon { background: rgba(80, 73, 69, 0.1); color: #d79921; }
 
-.c-message__bot_label { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+.c-message__bot_label { background: rgba(80, 73, 69, 0.1); color: #d79921; }
 
 .c-message__comment:before { color: #d79921; }
 
-.c-message__call_attachment { background: #1d2021; border-color: rgba(29, 32, 33, 0.1); }
+.c-message__call_attachment { background: #1d2021; border-color: rgba(80, 73, 69, 0.1); }
 
 .c-message__call_icon { color: #f9f5d7; }
 
@@ -978,7 +978,7 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message_actions__container { background: #1d2021; border-color: #282828; }
 
-.c-message_actions__container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+.c-message_actions__container:hover { border-color: #504945; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
 
 .c-message_actions__button { border-right-color: #282828; color: #689d6a; }
 
@@ -994,9 +994,9 @@ input[disabled], input[readonly], textarea[disabled], textarea[readonly] { backg
 
 .c-message_group__divider_text { background-color: #1d2021; color: #f9f5d7; }
 
-.c-message_list__unread_divider__separator { border-color: #1d2021; }
+.c-message_list__unread_divider__separator { border-color: #504945; }
 
-.c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #1d2021; }
+.c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #504945; }
 
 .c-message_list__spinner { color: #d79921; }
 
@@ -1060,9 +1060,9 @@ ts-message.automated .message_body { color: rgba(249, 245, 215, 0.8); }
 
 ts-message .action_hover_container { border: 1px solid #282828; }
 
-ts-message .action_hover_container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+ts-message .action_hover_container:hover { border-color: #504945; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
 
-ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #1d2021; }
+ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #504945; }
 
 ts-message .action_hover_container .btn_msg_action { background: #1d2021; border-right: 1px solid #282828; color: #689d6a; }
 
@@ -1104,7 +1104,7 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 #convo_container { background-color: #1d2021; }
 
-#convo_container #message_edit_container { border-bottom: 1px solid #1d2021; border-top: 1px solid #1d2021; }
+#convo_container #message_edit_container { border-bottom: 1px solid #504945; border-top: 1px solid #504945; }
 
 #convo_container ts-conversation::after { background: rgba(40, 40, 40, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(40, 40, 40, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(40, 40, 40, 0.08) 100%); }
 
@@ -1112,9 +1112,9 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 #convo_container ts-conversation ts-message.selected { background: #1d2021; }
 
-#convo_container ts-conversation ts-relatives::after { background: #1d2021; }
+#convo_container ts-conversation ts-relatives::after { background: #504945; }
 
-#convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #1d2021; color: #d79921; }
+#convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #504945; color: #d79921; }
 
 #convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #f9f5d7; }
 
@@ -1122,15 +1122,15 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #292d2f; }
 
-#msgs_div .unread_divider hr { border-top: 1px solid #1d2021; }
+#msgs_div .unread_divider hr { border-top: 1px solid #504945; }
 
-#msgs_div .unread_divider .divider_label { background: #1d2021; color: #1d2021; }
+#msgs_div .unread_divider .divider_label { background: #1d2021; color: #504945; }
 
 #msgs_div .unread_divider.no_unreads hr { border-top-color: #282828; }
 
 #msgs_div .unread_divider.no_unreads .divider_label { color: #d79921; }
 
-.channel_archive_messages.card .col:first-child { border-right: 1px solid #1d2021; }
+.channel_archive_messages.card .col:first-child { border-right: 1px solid #504945; }
 
 .star { color: #d79921; }
 
@@ -1171,15 +1171,15 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 @keyframes to-grey { 0% { color: inherit; }
   100% { color: #d79921; } }
 
-@keyframes fade-background-highlight { 0% { background: #1d2021; }
+@keyframes fade-background-highlight { 0% { background: #504945; }
   100% { background: transparent; } }
 
-@keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #1d2021, 0 0 0 0.5px #ebdbb2; }
-  100% { box-shadow: 0 0 4px 0 #1d2021, 0 0 0 0 #ebdbb2; } }
+@keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #504945, 0 0 0 0.5px #ebdbb2; }
+  100% { box-shadow: 0 0 4px 0 #504945, 0 0 0 0 #ebdbb2; } }
 
 .c-message_attachment { color: #f9f5d7; }
 
-.c-message_attachment__border { background-color: #1d2021; }
+.c-message_attachment__border { background-color: #504945; }
 
 .c-message_attachment__delete { color: #689d6a; }
 
@@ -1187,7 +1187,7 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .c-message_attachment__pretext { color: #f9f5d7; }
 
-.c-message_attachment__part + .c-message_attachment__part::before { color: #1d2021; }
+.c-message_attachment__part + .c-message_attachment__part::before { color: #504945; }
 
 .c-message_attachment__author .c-message_attachment__autor--distinct { color: #689d6a; }
 
@@ -1217,13 +1217,13 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .c-message_attachment__select { border-color: #282828; }
 
-.c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #1d2021; }
+.c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #504945; }
 
 .c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #1d2021; border-color: #282828; }
 
 .c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #d79921; }
 
-.c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #1d2021; }
+.c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #504945; }
 
 .c-message__reply_bar_description { color: #d79921; }
 
@@ -1263,7 +1263,7 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .attachment_still_pending ts-inline-saver { color: #d79921; }
 
-.msg_inline_attachment_column.column_border { background-color: #1d2021; }
+.msg_inline_attachment_column.column_border { background-color: #504945; }
 
 .msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #282828; }
 
@@ -1271,7 +1271,7 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #cc241d; }
 
-.msg_inline_img { background: #1d2021; }
+.msg_inline_img { background: #504945; }
 
 .msg_inline_room_preview_collapser { color: #d79921; }
 
@@ -1353,15 +1353,15 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(235, 219, 178, 0.9); border: 1px solid rgba(40, 40, 40, 0.1); }
 
-.file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(29, 32, 33, 0.8), rgba(29, 32, 33, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
+.file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(80, 73, 69, 0.8), rgba(80, 73, 69, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
 
-.file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(29, 32, 33, 0.8); color: #f9f5d7; }
+.file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(80, 73, 69, 0.8); color: #f9f5d7; }
 
 .file_container .c-file__title, .c-file_container .c-file__title { color: #f9f5d7; }
 
 .c-file_container--has_thumb .c-file__actions::before { background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), #282828 20px); }
 
-.message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #1d2021; color: #f9f5d7; }
+.message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #504945; color: #f9f5d7; }
 
 .msg_inline_video_buttons_div { background-color: rgba(29, 32, 33, 0.4); }
 
@@ -1375,7 +1375,7 @@ ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !im
 
 .post_body ul.checklist li.checked { color: #d79921; }
 
-.post_body ul.list.checklist li { border-bottom: 1px solid #1d2021; }
+.post_body ul.list.checklist li { border-bottom: 1px solid #504945; }
 
 .post_body ul.list.checklist li.checked { color: #d79921; }
 
@@ -1387,7 +1387,7 @@ ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, 
 
 ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
 
-.inline_color_block { border-color: #1d2021; }
+.inline_color_block { border-color: #504945; }
 
 .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #1d2021; }
 
@@ -1399,7 +1399,7 @@ ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
 
 .p-message_pane__limited_history_foreword { background: #282828; background-image: none; color: #f9f5d7; }
 
-.p-message_pane__unread_banner__banner { background: #1d2021; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+.p-message_pane__unread_banner__banner { background: #504945; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
 
 .messages_banner { color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
 
@@ -1417,13 +1417,13 @@ ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
 
 #archives_return a:hover { color: rgba(249, 245, 215, 0.8); }
 
-#messages_unread_status { background: #1d2021; }
+#messages_unread_status { background: #504945; }
 
 #messages_unread_status:hover { background: #ebdbb2; }
 
 #messages_unread_status:hover .clear_unread_messages { background: #ebdbb2; }
 
-#messages_unread_status:hover .clear_unread_messages:hover { background: #1d2021; }
+#messages_unread_status:hover .clear_unread_messages:hover { background: #504945; }
 
 #messages_unread_status.quiet { background: #ebdbb2; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
 
@@ -1441,7 +1441,7 @@ ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
 
 code { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
 
-code a.app_preview_link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+code a.app_preview_link { background: #282828; border: 1px solid #504945; color: #f9f5d7; }
 
 .file_list_item.snippet .snippet_preview { background: #282828; }
 
@@ -1615,7 +1615,7 @@ pre span.mention { padding: 2px 0 !important; }
 
 body > pre { background: #ebdbb2; }
 
-.special_formatting_quote .quote_bar { background-color: #1d2021; }
+.special_formatting_quote .quote_bar { background-color: #504945; }
 
 #threads_msgs_scroller_div { background: #1d2021; }
 
@@ -1625,7 +1625,7 @@ body > pre { background: #ebdbb2; }
 
 #threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #282828; }
 
-#threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #1d2021; color: #f9f5d7; }
+#threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #504945; color: #f9f5d7; }
 
 #threads_msgs_scroller_div.loading { background: none; }
 
@@ -1633,9 +1633,9 @@ body > pre { background: #ebdbb2; }
 
 #threads_view_banner.messages_banner { background: #282828; }
 
-#threads_view_banner.messages_banner:hover { background: #1d2021; }
+#threads_view_banner.messages_banner:hover { background: #504945; }
 
-#threads_view_banner.messages_banner:hover .clear_unread_messages { background: #1d2021; }
+#threads_view_banner.messages_banner:hover .clear_unread_messages { background: #504945; }
 
 #threads_msgs.new_banner_is_showing::before { background: #1d2021; }
 
@@ -1665,7 +1665,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 #convo_loading_indicator { background-image: none; }
 
-.reply_input_container .inline_message_input_container .ql-container { background-color: #1d2021; border: 1px solid #282828; }
+.reply_input_container .inline_message_input_container .ql-container { background-color: #504945; border: 1px solid #282828; }
 
 .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
 
@@ -1689,7 +1689,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .unread_group.marked_as_read .unread_group_header { background: #1d2021; }
 
-.unread_group .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+.unread_group .unread_group_header { background: #282828; border-top-color: #504945; color: #f9f5d7; }
 
 .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #f9f5d7; }
 
@@ -1697,7 +1697,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #1d2021; }
 
-.unread_group.active .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+.unread_group.active .unread_group_header { background: #282828; border-top-color: #504945; color: #f9f5d7; }
 
 .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #d79921; }
 
@@ -1777,7 +1777,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .message_location_label { color: #d79921; }
 
-.p-flexpane_header { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.p-flexpane_header { background: #282828; border-color: #504945; color: #f9f5d7; }
 
 #client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #282828; }
 
@@ -1793,7 +1793,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 #details_tab .conversation_details .member_username:hover { color: #f9f5d7; }
 
-#details_tab .conversation_details .member_info_timezone { border-top-color: #1d2021; }
+#details_tab .conversation_details .member_info_timezone { border-top-color: #504945; }
 
 #details_tab .channel_page_section { background: #1d2021; border-top: 1px solid #282828; }
 
@@ -1811,7 +1811,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 #details_tab .channel_page_member_tabs .icon_member_header { color: #d79921; }
 
-#details_tab .pinned_item:hover { border-color: #1d2021; }
+#details_tab .pinned_item:hover { border-color: #504945; }
 
 #details_tab .channel_page_action .leave_link { color: #689d6a; }
 
@@ -1829,7 +1829,7 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .channel_page_member_row.away a { color: #689d6a; }
 
-.channel_page_member_row:hover { background-color: #1d2021; border-color: #282828; }
+.channel_page_member_row:hover { background-color: #504945; border-color: #282828; }
 
 .pinned_item { color: #f9f5d7; }
 
@@ -1851,17 +1851,17 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .p-channel_insights_activity_bar_container:hover { background-color: rgba(40, 40, 40, 0.05); }
 
-.p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #1d2021; }
+.p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #504945; }
 
-.p-channel_insights__activity { border-color: #1d2021; }
+.p-channel_insights__activity { border-color: #504945; }
 
-.p-channel_insights__activity_bar { background-color: rgba(29, 32, 33, 0.5); }
+.p-channel_insights__activity_bar { background-color: rgba(80, 73, 69, 0.5); }
 
 .p-channel_insights__channel .channel_link { color: #f9f5d7; }
 
 .p-channel_insights__date_heading span { background-color: #1d2021; color: #f9f5d7; }
 
-.p-channel_insights__date_heading::before { background-color: #1d2021; }
+.p-channel_insights__date_heading::before { background-color: #504945; }
 
 .p-channel_insights__drawer_title { color: #d79921; }
 
@@ -1875,9 +1875,9 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 .p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #1d2021 90%); }
 
-.p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #1d2021; }
+.p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #504945; }
 
-.p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #1d2021; }
+.p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #504945; }
 
 .p-channel_insights__title { color: #f9f5d7; }
 
@@ -1899,21 +1899,21 @@ ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
 
 #file_list_toggle_users.active { color: #d79921; }
 
-.file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+.file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7 !important; }
 
-.filetype_button { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+.filetype_button { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7 !important; }
 
 .filetype_button:hover { background: #ebdbb2; }
 
-.filetype_button:hover .file_download_label { background: #1d2021; color: #f9f5d7; }
+.filetype_button:hover .file_download_label { background: #504945; color: #f9f5d7; }
 
 .filetype_button .file_title { color: #f9f5d7; }
 
-.filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #1d2021; }
+.filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #504945; }
 
-a.filetype_button_web { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+a.filetype_button_web { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
 
-a.filetype_button_web .filetype_icon { background-color: #1d2021; }
+a.filetype_button_web .filetype_icon { background-color: #504945; }
 
 a.file_download_link { color: #689d6a; }
 
@@ -1923,7 +1923,7 @@ a:hover .file_inline_icon { color: #d79921; }
 
 a.gsheet img, a.pdf img { background: #1d2021 !important; }
 
-html.no_touch a.filetype_button_web:hover { border-color: #1d2021; }
+html.no_touch a.filetype_button_web:hover { border-color: #504945; }
 
 html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
@@ -1959,7 +1959,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 .file_list_item .bullet { color: #d79921; }
 
-.file_list_item .icon { background: #ebdbb2; border-color: #1d2021; }
+.file_list_item .icon { background: #ebdbb2; border-color: #504945; }
 
 .file_list_item .ts_icon_comment { color: #d79921; }
 
@@ -1979,7 +1979,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 .file_list_item.post .preview, .file_list_item.space .preview { color: #f9f5d7; }
 
-.file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #1d2021; }
+.file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #504945; }
 
 .file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #689d6a; }
 
@@ -2021,7 +2021,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 .icon_quote { color: #f9f5d7; }
 
-.edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+.edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #504945; border-color: #282828; color: #f9f5d7; }
 
 .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #282828; }
 
@@ -2049,7 +2049,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 .active .tab_container .file_list_item { background-color: #1d2021; }
 
-.c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #1d2021; border-color: #282828; color: #fff; }
+.c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #504945; border-color: #282828; color: #fff; }
 
 .c-file__meta { color: #f9f5d7; }
 
@@ -2071,7 +2071,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 .p-file_list__file.c-pillow_file_container, .p-file_list__file.c-pillow_file_container--full_width { background: #282828; border-color: #282828; color: #f9f5d7; }
 
-.p-file_list__file.c-pillow_file_container--full_width:hover { background: #1d2021; border-color: #1d2021; }
+.p-file_list__file.c-pillow_file_container--full_width:hover { background: #504945; border-color: #504945; }
 
 .p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021 25%, #1d2021); color: #f9f5d7; }
 
@@ -2083,7 +2083,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 #user_groups_pane .mention { background: rgba(204, 36, 29, 0.25); border: 0; border-radius: 3px; padding: 2px; }
 
-#user_groups_container .info_panel { background: #1d2021; border: 1px solid #1d2021; }
+#user_groups_container .info_panel { background: #1d2021; border: 1px solid #504945; }
 
 #user_groups_container .mention { background-color: rgba(204, 36, 29, 0.25) !important; }
 
@@ -2093,7 +2093,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 #user_groups_header a.icon_close:hover { color: #cc241d; }
 
-.user_group_item { border-bottom: 1px solid #1d2021; }
+.user_group_item { border-bottom: 1px solid #504945; }
 
 .user_group_item a { color: #689d6a; }
 
@@ -2117,7 +2117,7 @@ html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
 
 a.internal_member_link { background: #282828; color: #f9f5d7; }
 
-a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #504945; color: #f9f5d7; }
 
 a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #282828; color: #f9f5d7; }
 
@@ -2149,7 +2149,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 #search_results_team .team_results_heading { color: #f9f5d7; }
 
-#search_results_team .team_result { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+#search_results_team .team_result { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
 
 #search_results_team .team_result a { color: #689d6a; }
 
@@ -2161,7 +2161,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .suggestion { color: #f9f5d7; }
 
-.suggestion.active, .suggestion:hover { background: #1d2021; }
+.suggestion.active, .suggestion:hover { background: #504945; }
 
 #paging_in_options .search_paging { color: #d79921; }
 
@@ -2181,7 +2181,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .search_segmented_control.active { background: #282828; color: #cc241d !important; }
 
-.search_result_with_extract { background: #282828; border-color: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+.search_result_with_extract { background: #282828; border-color: #504945; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
 
 .search_result_with_extract:hover { border-color: #ebdbb2; }
 
@@ -2193,7 +2193,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .search_module_header { color: #f9f5d7; }
 
-.search_module_footer { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+.search_module_footer { background-color: #282828; border-bottom-color: #504945; border-left-color: #504945; border-right-color: #504945; }
 
 .search_module_footer p { color: #f9f5d7; }
 
@@ -2205,7 +2205,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .search_module_footer ts-icon { color: #f9f5d7; }
 
-.top_results_search_message_result { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+.top_results_search_message_result { background-color: #282828; border-bottom-color: #504945; border-left-color: #504945; border-right-color: #504945; }
 
 .top_results_search_message_result.duplicate { background-color: #282828; }
 
@@ -2217,19 +2217,19 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .top_results_search_message_result .jump { color: #f9f5d7; }
 
-.top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #1d2021 !important; }
+.top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #504945 !important; }
 
-.top_results_search_message_result:first-child { border-top: 2px solid #1d2021; }
+.top_results_search_message_result:first-child { border-top: 2px solid #504945; }
 
 .sli_expert_search { background-color: #1d2021; color: #f9f5d7; }
 
-.sli_expert_search__result { border-color: #1d2021; }
+.sli_expert_search__result { border-color: #504945; }
 
 .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #f9f5d7 !important; }
 
 .sli_expert_search__fg_face::before { background-color: #1d2021; }
 
-.sli_expert_search_cta { border-color: #1d2021; }
+.sli_expert_search_cta { border-color: #504945; }
 
 .sli_expert_search_cta:hover { border-color: #ebdbb2; }
 
@@ -2247,19 +2247,19 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #282828; color: #f9f5d7; }
 
-.feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #1d2021; }
+.feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #504945; }
 
 .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #1d2021; }
 
-.feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+.feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #504945; }
 
-.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #1d2021; }
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #504945; }
 
-.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #1d2021; }
+.feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #504945; }
 
-.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #1d2021; }
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #504945; }
 
-.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #1d2021; }
+.feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #504945; }
 
 .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #d79921; }
 
@@ -2271,17 +2271,17 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .feature_sli_file_search #search_results.all { background-color: #1d2021; }
 
-.feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+.feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #504945; }
 
 .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #d79921; }
 
-.feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #1d2021; }
+.feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #504945; }
 
 .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #ebdbb2; }
 
 .feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #ebdbb2; }
 
-.feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #1d2021; }
+.feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #504945; }
 
 .feature_sli_file_search #search_results.files { background-color: #1d2021; }
 
@@ -2293,7 +2293,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .feature_sli_file_search #search_results_container .heading { background-color: #1d2021; }
 
-#client-ui .file_list_item.file_list_item--redesign { border-color: #1d2021; }
+#client-ui .file_list_item.file_list_item--redesign { border-color: #504945; }
 
 #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #d79921; }
 
@@ -2315,7 +2315,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 .p-shortcuts_flexpane__sub_heading { color: #d79921; }
 
-.c-keyboard_key { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
+.c-keyboard_key { background: #504945; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
 
 .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #d79921; }
 
@@ -2369,7 +2369,7 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 #disabled_members_tab.active a { color: #689d6a; }
 
-.team_list_item { border-top: 1px solid #1d2021; color: #689d6a; }
+.team_list_item { border-top: 1px solid #504945; color: #689d6a; }
 
 .team_list_item .member_name { color: #f9f5d7; }
 
@@ -2377,11 +2377,11 @@ span.match { background: rgba(204, 36, 29, 0.25); }
 
 #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #282828 !important; }
 
-#client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #1d2021 !important; }
+#client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #504945 !important; }
 
 #client-ui .searchable_member_list .team_list_item { border-bottom-color: #282828; }
 
-#client-ui .searchable_member_list .team_list_item:hover { background: #1d2021; }
+#client-ui .searchable_member_list .team_list_item:hover { background: #504945; }
 
 .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #f9f5d7 !important; }
 
@@ -2419,11 +2419,11 @@ ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_c
 
 .c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #f9f5d7; }
 
-.c-member .external_team_badge { background-color: #1d2021; box-shadow: 0 0 0 2px #1d2021; }
+.c-member .external_team_badge { background-color: #504945; box-shadow: 0 0 0 2px #504945; }
 
 .c-member .external_team_badge.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
 
-.c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #1d2021; }
+.c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #504945; }
 
 .c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #f9f5d7; }
 
@@ -2493,7 +2493,7 @@ ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_c
 
 .p-emoji_picker__group_tab:hover { background: #282828; color: #cc241d; }
 
-.p-emoji_picker__group_tab--active { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+.p-emoji_picker__group_tab--active { background: #504945; border-bottom-color: #282828; color: #f9f5d7; }
 
 .p-emoji_picker__icon_search { color: #d79921; }
 
@@ -2515,7 +2515,7 @@ ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_c
 
 .p-emoji_picker__emoji_deluxe_label { color: #d79921; }
 
-input[type="text"].p-emoji_picker__input:focus { border-color: #1d2021; box-shadow: none; }
+input[type="text"].p-emoji_picker__input:focus { border-color: #504945; box-shadow: none; }
 
 #message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #d79921; }
 
@@ -2531,7 +2531,7 @@ input[type="text"].p-emoji_picker__input:focus { border-color: #1d2021; box-shad
 
 .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #d79921; }
 
-.rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #1d2021; }
+.rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #504945; }
 
 .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #282828; }
 
@@ -2585,19 +2585,19 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .p-apps_browser__apps_list--loading::before { background-color: #282828; }
 
-.p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #1d2021; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+.p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #504945; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
 
 .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #282828; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
 
 .p-apps_browser__category_header { background: #1d2021; color: #d79921; }
 
-.p-apps_browser__app { border-top-color: #1d2021; }
+.p-apps_browser__app { border-top-color: #504945; }
 
 .p-apps_browser__app--selected { background: #282828; border-color: #ebdbb2; }
 
 .p-apps_browser__app_info { color: #f9f5d7; }
 
-.p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+.p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
 
 .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #ebdbb2; color: #f9f5d7; }
 
@@ -2649,7 +2649,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .channel_prefs_notifications_table { border-bottom-color: #282828; color: #f9f5d7; }
 
-.channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #1d2021 !important; }
+.channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #504945 !important; }
 
 .channel_prefs__muting_checkbox_label { color: #f9f5d7; }
 
@@ -2667,7 +2667,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #d79921; }
 
-#channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #1d2021; }
+#channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #504945; }
 
 #channel_browser .channel_browser_divider { background: transparent; color: #d79921; }
 
@@ -2681,7 +2681,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #282828; color: #f9f5d7; }
 
-#invite_members_container .lfs_input_container { background: #1d2021; }
+#invite_members_container .lfs_input_container { background: #504945; }
 
 #notifications_not_working p.highlight_yellow_bg a { color: #f9f5d7; }
 
@@ -2695,7 +2695,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .c-dialog__body .p-share_dialog_message_input { background-color: #282828; border-color: #282828; color: #f9f5d7; }
 
-.c-dialog__body .p-share_dialog_message_input.focus { border-color: #1d2021; box-shadow: unset; }
+.c-dialog__body .p-share_dialog_message_input.focus { border-color: #504945; box-shadow: unset; }
 
 .c-dialog__body .p-file_upload_dialog__preview, .c-dialog__body .p-file_upload_dialog__preview_image { background-color: #282828; border-color: #282828; }
 
@@ -2703,15 +2703,15 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .c-dialog__body input.c-input_text .c-input_character_count { background-color: #282828; color: #f9f5d7; }
 
-.c-dialog__body input.c-input_text:focus { border-color: #1d2021; box-shadow: unset; }
+.c-dialog__body input.c-input_text:focus { border-color: #504945; box-shadow: unset; }
 
 .c-dialog__footer { background: #222222; }
 
-.c-dialog__footer .c-button { background-color: #1d2021; color: #f9f5d7; }
+.c-dialog__footer .c-button { background-color: #504945; color: #f9f5d7; }
 
 .c-dialog__footer .p-file_upload_dialog__footer_share_inputs { color: #f9f5d7; }
 
-#im_browser .im_browser_row { border-top: 1px solid #1d2021; }
+#im_browser .im_browser_row { border-top: 1px solid #504945; }
 
 #im_browser .im_browser_row.multiparty { color: #f9f5d7; }
 
@@ -2721,9 +2721,9 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #im_browser .im_browser_row.disabled { color: #d79921; }
 
-#im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #1d2021 !important; }
+#im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #504945 !important; }
 
-#im_browser_tokens { background: #1d2021; border: 1px solid #ebdbb2; }
+#im_browser_tokens { background: #504945; border: 1px solid #ebdbb2; }
 
 #im_browser_tokens.active { border-color: #ebdbb2; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
 
@@ -2743,15 +2743,15 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #d79921; }
 
-.fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #1d2021; }
+.fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #504945; }
 
 .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #d79921; }
 
-.fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #1d2021; }
+.fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #504945; }
 
 .fs_modal_file_viewer_content .viewer { background-color: #282828; color: #f9f5d7 !important; }
 
-.fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #1d2021; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+.fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #504945; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
 
 .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(235, 219, 178, 0.25); color: #f9f5d7; }
 
@@ -2773,7 +2773,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #d79921; }
 
-#fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #1d2021; }
+#fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #504945; }
 
 #fs_modal.help_modal .help_modal_header a { color: #f9f5d7; }
 
@@ -2805,11 +2805,11 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #admin_invites_channel_picker_container { border-bottom: 1px solid #282828; }
 
-#admin_invites_add_row { background: #1d2021; border: 1px solid #282828; }
+#admin_invites_add_row { background: #504945; border: 1px solid #282828; }
 
-#admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #1d2021; }
+#admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #504945; }
 
-#channel_invite_tokens { background-color: #1d2021; border-color: #ebdbb2; }
+#channel_invite_tokens { background-color: #504945; border-color: #ebdbb2; }
 
 #channel_invite_tokens.active { border-color: #d79921; box-shadow: 0 0 7px rgba(215, 153, 33, 0.15); }
 
@@ -2817,7 +2817,7 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #channel_invite_tokens .member_token.ra { background: rgba(204, 36, 29, 0.4); }
 
-#admin_invites_alert { background: #1d2021; border-color: #ebdbb2; }
+#admin_invites_alert { background: #504945; border-color: #ebdbb2; }
 
 .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #f9f5d7; }
 
@@ -2827,11 +2827,11 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #f9f5d7; }
 
-#shortcuts_dialog.modal ul ul { border-left-color: #1d2021; }
+#shortcuts_dialog.modal ul ul { border-left-color: #504945; }
 
 #shortcuts_dialog.modal .info_block { color: #d79921; }
 
-#shortcuts_dialog.modal .close { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+#shortcuts_dialog.modal .close { background: #504945; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
 
 #shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(40, 40, 40, 0.9); }
 
@@ -2879,11 +2879,11 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 .jumbomoji_disabled_note { color: rgba(215, 153, 33, 0.6); }
 
-#edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #1d2021; border: 1px solid #282828; }
+#edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #504945; border: 1px solid #282828; }
 
-#edit_team_profile_container .lazy_filter_select.disabled { background: #1d2021; }
+#edit_team_profile_container .lazy_filter_select.disabled { background: #504945; }
 
-#edit_team_profile_container .lazy_filter_select.disabled input { background: #1d2021; }
+#edit_team_profile_container .lazy_filter_select.disabled input { background: #504945; }
 
 #edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #282828; }
 
@@ -2899,9 +2899,9 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #d79921; }
 
-#edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #1d2021; }
+#edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #504945; }
 
-#edit_team_profile_add .row:last-child { border-bottom: 1px solid #1d2021; }
+#edit_team_profile_add .row:last-child { border-bottom: 1px solid #504945; }
 
 #edit_team_profile_add .row:not(.header_row):hover { background: #282828; border: 1px solid #282828; }
 
@@ -2925,19 +2925,19 @@ a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d7
 
 #edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #d79921; }
 
-#edit_team_profile_custom .row .col input { background: #1d2021; border: 1px solid #282828; }
+#edit_team_profile_custom .row .col input { background: #504945; border: 1px solid #282828; }
 
 #edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #d79921; }
 
 #edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #282828; }
 
-.profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #1d2021; }
+.profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #504945; }
 
 .profile_field_preview_protector .profile_field_preview::after { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
 
 .profile_field_preview_protector .profile_field_preview::before { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
 
-.profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #1d2021; color: #d79921; }
+.profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #504945; color: #d79921; }
 
 .profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #282828, rgba(255, 255, 255, 0)); }
 
@@ -2979,21 +2979,21 @@ ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .me
 
 #share_dialog_input_container #file_comment_textarea.ql-container { border-color: #282828; }
 
-#share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #1d2021; }
+#share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #504945; }
 
 #share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #f9f5d7; }
 
-.ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #1d2021; }
+.ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #504945; }
 
 .ts_tip .ts_tip_tip { color: #f9f5d7; }
 
-.ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #1d2021; }
+.ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #504945; }
 
-.ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #1d2021; }
+.ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #504945; }
 
-.ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #1d2021; }
+.ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #504945; }
 
-.ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #1d2021; }
+.ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #504945; }
 
 .ts_tip.success .ts_tip_tip { background: #ebdbb2; }
 
@@ -3005,23 +3005,23 @@ ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .me
 
 .ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #ebdbb2; }
 
-.c-tooltip__tip { background-color: #1d2021; color: #f9f5d7; }
+.c-tooltip__tip { background-color: #504945; color: #f9f5d7; }
 
-.c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+.c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #504945; }
 
-.c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+.c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #504945; }
 
-.c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+.c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #504945; }
 
-.c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #1d2021; }
+.c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #504945; }
 
-.c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+.c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #504945; }
 
-.c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+.c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #504945; }
 
-.c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+.c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #504945; }
 
-.c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #1d2021; }
+.c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #504945; }
 
 .c-tooltip__tip--success { background-color: #98971a; }
 
@@ -3033,9 +3033,9 @@ ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .me
 
 .c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #98971a; }
 
-#coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #1d2021; }
+#coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #504945; }
 
-#coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #1d2021; }
+#coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #504945; }
 
 #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(235, 219, 178, 0.5) !important; }
 
@@ -3059,9 +3059,9 @@ ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .me
 
 .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #cc241d; }
 
-.menu_member_header .member_details_divider { border-color: #1d2021; }
+.menu_member_header .member_details_divider { border-color: #504945; }
 
-.menu_member_footer { background: #282828; border-top: 1px solid #1d2021; }
+.menu_member_footer { background: #282828; border-top: 1px solid #504945; }
 
 .menu_member_footer p { color: #d79921; }
 
@@ -3085,7 +3085,7 @@ ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .me
 
 .yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #282828 !important; }
 
-.sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #1d2021 !important; }
+.sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #504945 !important; }
 
 .sk_black { color: inherit; }
 
@@ -3197,21 +3197,21 @@ html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #c
 
 .two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
 
-.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+.two_factor_choice { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
 
 .two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
 
 .two_factor_choice:hover .two_factor_link { color: #f9f5d7; }
 
-a.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+a.two_factor_choice { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
 
-a.two_factor_choice:link { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+a.two_factor_choice:link { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
 
 a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
 
 a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #f9f5d7; }
 
-.backup_codes { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+.backup_codes { background: #282828; border-color: #504945; color: #f9f5d7; }
 
 #channel_specific_settings tr { border-top-color: #1d2021; }
 
@@ -3259,13 +3259,13 @@ a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_
 
 .billing_selection:hover { border-color: #ebdbb2; }
 
-.billing_selection.active { background: #1d2021; border-color: #ebdbb2; }
+.billing_selection.active { background: #504945; border-color: #ebdbb2; }
 
-.billing_selection.billing_selection--refactor { border-color: #1d2021; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+.billing_selection.billing_selection--refactor { border-color: #504945; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
 
 .billing_selection.billing_selection--refactor:hover { border-color: #ebdbb2; }
 
-.billing_selection.billing_selection--refactor.active { background: #1d2021; border-color: #ebdbb2; }
+.billing_selection.billing_selection--refactor.active { background: #504945; border-color: #ebdbb2; }
 
 .billing_selection .billing_selection__price { color: #f9f5d7; }
 
@@ -3297,9 +3297,9 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 #message_container #msg_limit { color: #f9f5d7; }
 
-.statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #1d2021; }
+.statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #504945; }
 
-.statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #1d2021; }
+.statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #504945; }
 
 .inactive { background-image: none; }
 
@@ -3311,7 +3311,7 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 .c3-chart-arc text { fill: #282828; }
 
-.c3-chart-arcs .c3-chart-arcs-background { fill: #1d2021; }
+.c3-chart-arcs .c3-chart-arcs-background { fill: #504945; }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #282828; }
 
@@ -3323,19 +3323,19 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 .c3-grid text { fill: #f9f5d7; }
 
-.c3-legend-background { fill: #282828; stroke: #1d2021; }
+.c3-legend-background { fill: #282828; stroke: #504945; }
 
-.c3-region { fill: #1d2021; }
+.c3-region { fill: #504945; }
 
 .c3-selected-circle { fill: #282828; }
 
 .c3-tooltip { background-color: #282828; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
 
-.c3-tooltip td { background-color: #282828; border-left-color: #1d2021; }
+.c3-tooltip td { background-color: #282828; border-left-color: #504945; }
 
 .c3-tooltip th { background-color: #282828; color: #f9f5d7; }
 
-.c3-tooltip tr { border-color: #1d2021; }
+.c3-tooltip tr { border-color: #504945; }
 
 .ent_alert a { color: #689d6a; }
 
@@ -3351,7 +3351,7 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 .ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
 
-.ent_avatar { background-color: #1d2021; }
+.ent_avatar { background-color: #504945; }
 
 .ent_callout__difference--increase { color: #98971a; }
 
@@ -3359,7 +3359,7 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 .ent_callout__icon_image, .ent_callout__icon--filled { border-color: #ebdbb2; }
 
-.ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #1d2021; }
+.ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #504945; }
 
 .ent_callout__icon--limit_reached { border-color: #ebdbb2; }
 
@@ -3487,11 +3487,11 @@ table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
 
 .ent_modal_background { background-color: #1d2021; }
 
-.ent_modal_breadcrumb_animated_step { background: #1d2021; }
+.ent_modal_breadcrumb_animated_step { background: #504945; }
 
 .ent_modal_breadcrumb_circle_icon { background: #1d2021; }
 
-.ent_modal_breadcrumb_line { background: #1d2021; }
+.ent_modal_breadcrumb_line { background: #504945; }
 
 .ent_modal_breadcrumb_text { color: #d79921; }
 
@@ -3556,29 +3556,29 @@ html.no_touch .action_cog:hover i { color: #cc241d; }
 
 .help_pages.help_pages p { color: #f9f5d7; }
 
-.help_pages.help_pages a { border-bottom-color: #1d2021; }
+.help_pages.help_pages a { border-bottom-color: #504945; }
 
 .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #1d2021; }
 
 .help_pages.help_pages .o-hero__header { color: #f9f5d7; }
 
-.help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #1d2021; }
+.help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #504945; }
 
 .help_pages.help_pages .c-form__container .c-form__feedback { color: #cc241d; }
 
-.help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; }
+.help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #504945; color: #f9f5d7; }
 
 .help_pages.help_pages .drop_zone { background: #1d2021; border-color: #ebdbb2; }
 
-.help_pages.help_pages .drop_zone_attachment { border-bottom-color: #1d2021; }
+.help_pages.help_pages .drop_zone_attachment { border-bottom-color: #504945; }
 
 .help_pages.help_pages .drop_zone_remove_attachment { background-color: #1d2021; }
 
-.help_pages.help_pages .c-form__notice { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+.help_pages.help_pages .c-form__notice { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
 
 .help_pages.help_pages .c-form__notice.is-error { border-left-color: #cc241d; }
 
-.help_pages.help_pages .c-nav--footer { border-top-color: #1d2021; }
+.help_pages.help_pages .c-nav--footer { border-top-color: #504945; }
 
 @media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #1d2021; } }
 
@@ -3644,7 +3644,7 @@ nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:
 
 body.api header .header_links a { color: #f9f5d7; }
 
-body.api header .header_links a.active { background: #1d2021; }
+body.api header .header_links a.active { background: #504945; }
 
 body.api .reverse_header { background-color: #282828; color: #f9f5d7; }
 
@@ -3668,7 +3668,7 @@ body.api .example { border: 1px solid #282828; }
 
 body.api .example h5 { background-color: #282828; color: #f9f5d7; }
 
-body.api .alert { background: #1d2021; }
+body.api .alert { background: #504945; }
 
 body.api .hljs { background-image: none; }
 
@@ -3752,11 +3752,11 @@ nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25
 
 .splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
 
-.splash_interactive__button { border-color: #1d2021; }
+.splash_interactive__button { border-color: #504945; }
 
 .splash_interactive__button--active { box-shadow: 0 0 10px 1px #ebdbb2; }
 
-.splash_interactive__window { background-color: #1d2021; border-color: #1d2021; }
+.splash_interactive__window { background-color: #1d2021; border-color: #504945; }
 
 .splash_interactive__window:hover .splash_interactive__window_headline { color: #f9f5d7; }
 
@@ -3770,25 +3770,25 @@ a.splash_interactive__window_link { color: #f9f5d7; }
 
 .search_input.apps_search_input { border-color: #ebdbb2; }
 
-.menu_launcher, .menu_launcher_large { background-color: #1d2021; border-color: #1d2021 !important; color: #f9f5d7; }
+.menu_launcher, .menu_launcher_large { background-color: #504945; border-color: #1d2021 !important; color: #f9f5d7; }
 
 .menu_launcher_large { border-color: #1d2021; }
 
-.menu.avatar_menu ul li:hover ts-icon { background: #1d2021; color: #f9f5d7; }
+.menu.avatar_menu ul li:hover ts-icon { background: #504945; color: #f9f5d7; }
 
 .menu.avatar_menu ul li a { color: #f9f5d7; }
 
-.menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #1d2021; color: #d79921; }
+.menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #504945; color: #d79921; }
 
 .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
 
-#page .media_list { background-color: #282828; border: 1px solid #1d2021; }
+#page .media_list { background-color: #282828; border: 1px solid #504945; }
 
-#page .media_list > li + li::before { border-top-color: #1d2021; }
+#page .media_list > li + li::before { border-top-color: #504945; }
 
 #page .media_list > li.interactive a { color: #f9f5d7; }
 
-#page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #1d2021; border-color: #ebdbb2; }
+#page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #504945; border-color: #ebdbb2; }
 
 #page .media_list > li .media_list_text { color: #f9f5d7; }
 
@@ -3814,7 +3814,7 @@ a.splash_interactive__window_link { color: #f9f5d7; }
 
 #page ul.navigation_list li a { color: #f9f5d7; }
 
-#page ul.navigation_list li a:hover { background-color: #1d2021; }
+#page ul.navigation_list li a:hover { background-color: #504945; }
 
 #page ul.navigation_list li a::after { color: #f9f5d7; }
 
@@ -3822,9 +3822,9 @@ a.splash_interactive__window_link { color: #f9f5d7; }
 
 #page .tag { background-color: #282828; border: 1px solid #282828; }
 
-#page .tag:hover { background-color: #1d2021 !important; }
+#page .tag:hover { background-color: #504945 !important; }
 
-#page .app_desc_btn { background-color: #1d2021; color: #f9f5d7; }
+#page .app_desc_btn { background-color: #504945; color: #f9f5d7; }
 
 #page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
 
@@ -3850,15 +3850,15 @@ nav.top.apps_nav ul a.active { color: #cc241d; }
 
 .plastic_typeahead_item { color: #f9f5d7; }
 
-.plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #1d2021; }
+.plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #504945; }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #1d2021; border-top-color: #282828; color: #f9f5d7; }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #d79921; }
 
-.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #1d2021; }
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #504945; }
 
-.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #1d2021; }
+.plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #504945; }
 
 a.plastic_typeahead_item { color: #f9f5d7; }
 
@@ -3870,13 +3870,13 @@ a.plastic_typeahead_item { color: #f9f5d7; }
 
 .quote_block { color: #f9f5d7; }
 
-.quote_block::before { background-color: #1d2021; }
+.quote_block::before { background-color: #504945; }
 
 .well { background: #282828; border-color: #232323; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
 
 .service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #d79921; }
 
-.c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+.c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #504945; }
 
 .c-tabs__tab { color: #d79921; }
 
@@ -3884,7 +3884,7 @@ a.plastic_typeahead_item { color: #f9f5d7; }
 
 .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
 
-.c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+.c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #504945; }
 
 a.c-tabs__tab--plastic { color: #d79921; }
 
@@ -3892,19 +3892,19 @@ a.c-tabs__tab--plastic:hover { color: #f9f5d7; }
 
 a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
 
-.p-detail_scope { box-shadow: inset 0 1px 0 0 #1d2021; }
+.p-detail_scope { box-shadow: inset 0 1px 0 0 #504945; }
 
-.p-detail_scope:last-child { border-bottom-color: #1d2021; }
+.p-detail_scope:last-child { border-bottom-color: #504945; }
 
-.p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #1d2021; }
+.p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #504945; }
 
 .p-detail_arrow_icon { color: #d79921; }
 
 .p-detail_arrow_icon:hover { color: #f9f5d7; }
 
-.p-detail_permissions { background: #282828; border-color: #1d2021; }
+.p-detail_permissions { background: #282828; border-color: #504945; }
 
-table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #1d2021; }
+table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #504945; }
 
 .section_rollup { border-bottom-color: #1d2021; }
 
@@ -3914,9 +3914,9 @@ table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-co
 
 .is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #98971a; color: #282828; }
 
-.developer_apps_functionality_link:hover { border-color: #1d2021; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
+.developer_apps_functionality_link:hover { border-color: #504945; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
 
-.developer_apps_functionality_link::before { background-color: #1d2021; }
+.developer_apps_functionality_link::before { background-color: #504945; }
 
 .developer_apps_functionality_link_enabled::before { background-color: #98971a; }
 
@@ -3928,11 +3928,11 @@ table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-co
 
 .legal-main { background-color: #282828; }
 
-.legal-main.v--no-switch { background-color: #282828; border-bottom-color: #1d2021; border-top-color: #1d2021; }
+.legal-main.v--no-switch { background-color: #282828; border-bottom-color: #504945; border-top-color: #504945; }
 
 .legal-main p { color: #f9f5d7; }
 
-.legal-main a { border-bottom-color: #1d2021; }
+.legal-main a { border-bottom-color: #504945; }
 
 @media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #f9f5d7; }
   .legal-main .c-nav--sidebar__listitem a.is-selected { color: #d79921; } }
@@ -3947,17 +3947,17 @@ table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-co
 
 .c-oauth_scope_info__spacer_icon { color: #cc241d; }
 
-.c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #1d2021; }
+.c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #504945; }
 
-.c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #1d2021; border-top-color: #1d2021; }
+.c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #504945; border-top-color: #504945; }
 
-.c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #1d2021; }
+.c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #504945; }
 
 a.p-oauth_nav__anchor { color: #d79921; }
 
 .p-oauth_nav__team-switcher .menu_launcher { border-color: #282828; }
 
-.p-oauth_nav__team-switcher .menu_launcher:hover { border: #1d2021; }
+.p-oauth_nav__team-switcher .menu_launcher:hover { border: #504945; }
 
 .p-oauth_page, .p-oauth_page--error { background: #1d2021; }
 
@@ -4021,25 +4021,25 @@ nav { background: #282828; }
 
 nav .space { background-color: #282828; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
 
-nav .space::after { border-left: 1px solid #1d2021; }
+nav .space::after { border-left: 1px solid #504945; }
 
 nav .comments { background-color: #282828; }
 
 nav .space_buttons .btn_outline { background-color: #282828; }
 
-nav .space_buttons .btn_outline::after { border-color: #1d2021; }
+nav .space_buttons .btn_outline::after { border-color: #504945; }
 
 nav .space_btn_star { background: none; border: 0; }
 
 nav .space_btn_star:hover { background: none !important; }
 
-nav .space_btn_edit { background: #1d2021; }
+nav .space_btn_edit { background: #504945; }
 
 nav .space_btn_edit.editing { background: #ebdbb2; }
 
 nav .star_info { color: #d79921; }
 
-nav #space_status { border-left: 1px solid #1d2021; color: #d79921; }
+nav #space_status { border-left: 1px solid #504945; color: #d79921; }
 
 nav #space_status.slightly_concerned { color: #cc241d; }
 
@@ -4069,7 +4069,7 @@ ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-
 
 ts-space header .owner_detail small { color: #d79921; }
 
-ts-space header .divider { border-top: 1px solid #1d2021; }
+ts-space header .divider { border-top: 1px solid #504945; }
 
 ts-space a.feedback { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
 
@@ -4091,13 +4091,13 @@ comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
 
 #space_alert .btn_outline.btn_transparent { background-color: #282828 !important; color: #f9f5d7 !important; }
 
-#space_alert .btn_outline.btn_transparent::after { border-color: #1d2021; }
+#space_alert .btn_outline.btn_transparent::after { border-color: #504945; }
 
 #space_find_bar { background-color: #282828; border-bottom: 1px solid rgba(235, 219, 178, 0.1); border-left: 1px solid rgba(235, 219, 178, 0.07); border-right: 1px solid rgba(235, 219, 178, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
 
 #space_find_bar #space_find_info.no_matches { color: #cc241d; }
 
-#space_find_bar #space_find_next .ts_icon { background-color: #1d2021; }
+#space_find_bar #space_find_next .ts_icon { background-color: #504945; }
 
 #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #f9f5d7; }
 
@@ -4143,7 +4143,7 @@ comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
 
 .textstyle_menu.link .content { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
 
-.textstyle_menu.link .content input[type=text] { background-color: #1d2021; }
+.textstyle_menu.link .content input[type=text] { background-color: #504945; }
 
 .textstyle_menu.link .content > a.link { color: #689d6a; }
 
@@ -4151,37 +4151,37 @@ comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
 
 .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #282828; }
 
-.textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #1d2021; }
+.textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #504945; }
 
-.textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #1d2021; border: 1px solid #ebdbb2; }
+.textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #504945; border: 1px solid #ebdbb2; }
 
-.textstyle_menu.style a.deformat::before { border-left: 1px solid #1d2021; }
+.textstyle_menu.style a.deformat::before { border-left: 1px solid #504945; }
 
 .textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #d79921; }
 
 .para_menu .insert .tip { color: #d79921; }
 
-.para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+.para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #504945; }
 
 .para_menu .insert .tooltip .arrow::after { background-color: #282828; }
 
-.para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+.para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #504945, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
 
-.para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+.para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #504945; }
 
 .para_menu .format .options .arrow::after { background-color: #282828; }
 
-.para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #1d2021; }
+.para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #504945; }
 
-.para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+.para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #504945, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
 
 .para_menu .format .options .content ul:first-child { border-bottom: 1px solid #282828; }
 
 .para_menu .format .options.show .tooltip > div { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #f9f5d7; }
 
-.para_menu .format .options.show .tooltip span { background-color: #1d2021; }
+.para_menu .format .options.show .tooltip span { background-color: #504945; }
 
-.para_menu .options a:hover { border: 1px solid #1d2021; }
+.para_menu .options a:hover { border: 1px solid #504945; }
 
 .para_menu .options a.active { background-color: #282828; border: 1px solid #282828; }
 

--- a/css/variants/gruvbox-dark.css
+++ b/css/variants/gruvbox-dark.css
@@ -1,0 +1,2100 @@
+@-moz-document regexp("https://[^./]*\\.slack\\.com/(?!pricing)(?!security).*") { body { background: #1d2021; color: #f9f5d7; }
+  a { color: #689d6a; }
+  a:link, a:visited { color: #689d6a; }
+  a:hover, a:active, a:focus { color: #cc241d; }
+  hr { border-bottom: 1px solid #282828; border-top: 1px solid #1d2021; }
+  h1, h2, h3, h4 { color: #f9f5d7; }
+  h1 a { color: #f9f5d7; }
+  h1 a:active, h1 a:hover, h1 a:link, h1 a:visited { color: #f9f5d7; }
+  .bordered { border: 1px solid #282828; }
+  .top_border { border-top: 1px solid #282828; }
+  .bottom_border { border-bottom: 1px solid #282828; }
+  .left_border { border-left: 1px solid #282828; }
+  .right_border { border-right: 1px solid #282828; }
+  .bullet { color: #d79921; }
+  .alert, .c-alert, .c-alert--boxed { background-color: #282828; border-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .alert h4, .c-alert h4, .c-alert--boxed h4 { color: #f9f5d7; }
+  .alert-info { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+  .alert-info h4 { color: #f9f5d7; }
+  ::-webkit-scrollbar-track { background: #282828 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #282828 !important; }
+  ::-webkit-scrollbar-thumb { background: #1d2021 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
+  ::-webkit-scrollbar-corner { background: #1d2021 !important; }
+  .supports_custom_scrollbar #messages_container::after { background: none !important; }
+  .monkey_scroll_bar { background: #282828; }
+  .monkey_scroll_handle_inner { background: #1d2021; border: 1px solid #ebdbb2; }
+  .monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
+  #client-ui .monkey_scroll_bar { background: #282828; }
+  #client-ui .monkey_scroll_handle_inner { background: #1d2021; border: 3px solid #1d2021; }
+  .c-scrollbar--monkey .c-scrollbar__track { background: #282828; }
+  .c-scrollbar--monkey .c-scrollbar__bar { background: #1d2021; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
+  .client_channels_list_container { background-color: #282828; border-right-color: #1d2021; }
+  #col_channels { color: #f9f5d7; }
+  .p-channel_sidebar { background-color: #282828; color: #f9f5d7; }
+  .p-channel_sidebar__channel, .p-channel_sidebar__channel:link, .p-channel_sidebar__channel:visited, .p-channel_sidebar__channel:hover, .p-channel_sidebar__link, .p-channel_sidebar__link:link, .p-channel_sidebar__link:visited, .p-channel_sidebar__link:hover { color: rgba(249, 245, 215, 0.8) !important; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover { color: #f9f5d7; }
+  .p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover { background: #1d2021 !important; }
+  .p-channel_sidebar__header { color: #f9f5d7 !important; }
+  .p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #f9f5d7; }
+  .p-channel_sidebar__channel--im .c-presence--away { color: #d79921; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #1d2021 !important; }
+  .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #1d2021 !important; }
+  .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #f9f5d7; }
+  .p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #f9f5d7; }
+  .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #cc241d; }
+  .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #1d2021; }
+  .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #fdfcf2 !important; }
+  .p-channel_sidebar__close_container:hover { background: #282828; }
+  .p-channel_sidebar__jumper { background: transparent !important; }
+  .channels_list_holder h2 { color: #f9f5d7 !important; }
+  .channels_list_holder h2.hoverable:not(.jquery_hover):hover { color: #f9f5d7; opacity: 0.8; }
+  .channels_list_holder ul { color: #f9f5d7 !important; }
+  .channels_list_holder ul li { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li > a { background: #282828; color: rgba(249, 245, 215, 0.8) !important; }
+  .channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li > a:hover { background: #1d2021 !important; border-bottom-right-radius: 0.25rem; border-top-right-radius: 0.25rem; }
+  .channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover { background: #1d2021; }
+  .channels_list_holder ul li.mention a { color: #f9f5d7; }
+  .channels_list_holder ul li.unread:not(.muted_channel) .primary_action { color: #fdfcf2 !important; }
+  .channels_list_holder ul li.unread .prefix { color: #f9f5d7 !important; opacity: 1; }
+  .channels_list_holder .group_close, .channels_list_holder .im_close, .channels_list_holder .mpim_close { color: #689d6a !important; }
+  .channels_list_holder .unread_highlights { background: #cc241d; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .channels_list_holder .unread_msgs { background: #1d2021; color: #f9f5d7; }
+  #channel_list_invites_link { border-bottom: 1px dotted #689d6a; color: #689d6a !important; font-size: 0.9rem; }
+  #channel_list_invites_link:hover { border-bottom: 1px solid #689d6a; }
+  #quick_switcher_btn { background: #282828; border-top: 2px solid #282828; }
+  #quick_switcher_btn > i { color: #d79921; }
+  #quick_switcher_btn:active, #quick_switcher_btn:hover { background: #1d2021; border-color: #1d2021; }
+  #quick_switcher_btn:active > i, #quick_switcher_btn:hover > i { color: #689d6a; }
+  #quick_switcher_btn:active #quick_switcher_label, #quick_switcher_btn:hover #quick_switcher_label { color: #689d6a; }
+  #quick_switcher_label { color: #d79921; }
+  .p-channel_insights__channel .channel_link { color: #689d6a; }
+  .p-channel_insights__date_heading::before { background-color: #282828; }
+  .p-channel_insights__date_heading span { background-color: #1d2021; color: #d79921; }
+  .p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #282828 90%); }
+  .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #282828; }
+  .c-dialog__content { border-radius: 0.6rem; }
+  .c-dialog__header, .c-dialog__body, .c-dialog__footer { background: #282828; }
+  .c-dialog__title { color: #f9f5d7; }
+  .c-dialog .p-custom_status_input__duration_picker_select { padding-left: 11px; }
+  .c-dialog .p-custom_status_input__duration_picker_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
+  .loading #loading-zone { background: #1d2021; }
+  #loading_welcome { background-image: none; }
+  #loading_message p { color: #f9f5d7; }
+  #loading_message #loading_message_attribution { color: #d79921; }
+  #loading_team_menu_bg, #loading_user_menu_bg { background: #1d2021; border: none; }
+  .infinite_spinner_bg, .infinite_spinner_blue { stroke: #f9f5d7; }
+  body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #282828; }
+  .p-degraded_list__loading { background-color: #1d2021; color: #f9f5d7; }
+  input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #1d2021; border-color: #282828; color: #f9f5d7; }
+  input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(40, 40, 40, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+  input[type=file]:focus { outline: #f9f5d7 dotted thin; }
+  input[type=radio]:focus, input[type=checkbox]:focus { outline: #f9f5d7 dotted thin; }
+  select { background: #1d2021; }
+  select, textarea { border: 1px solid #282828; color: #f9f5d7; }
+  select:active, select:focus, textarea:active, textarea:focus { border-color: #282828; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
+  input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #282828 !important; }
+  .no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover { border-color: #282828; }
+  .no_touch label.select:hover select { border-color: #282828; }
+  .no_touch label.select:not(.disabled):hover::after { color: #282828; }
+  label.disabled { color: #f9f5d7; }
+  legend { border-bottom: 1px solid #ebdbb2; }
+  legend small { color: #d79921; }
+  .uneditable-input, .uneditable-textarea { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  .uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+  textarea { background-color: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
+  ::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  ::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  ::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  [data-placeholder]:empty::before { color: #f9f5d7 !important; }
+  input::-webkit-input-placeholder, textarea::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  input::-moz-placeholder, textarea::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  input::placeholder, textarea::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #f9f5d7 !important; }
+  input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #1d2021 !important; }
+  .form-actions { background-color: #282828; border-top: 1px solid #282828; }
+  .help-block, .help-inline { color: #d79921; }
+  .input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #1d2021; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .btn { background-color: #1d2021; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #1d2021; color: #f9f5d7; }
+  .btn.btn_border { border: 2px solid #282828; }
+  .btn.disabled, .btn:disabled { background-color: #282828 !important; }
+  .btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #282828 !important; }
+  .btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning { background-color: #cc241d !important; color: #f9f5d7 !important; }
+  .btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #1d2021 !important; border-color: #cc241d !important; color: #cc241d !important; }
+  .btn.btn_outline.disabled { background: #282828 !important; color: #689d6a !important; }
+  .btn.btn_outline.disabled:hover { background: #282828 !important; color: #689d6a !important; }
+  .btn.btn_attachment { border-color: #1d2021; }
+  .btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #282828; border-color: #ebdbb2; }
+  .btn.btn_attachment.btn_danger { border-color: #cc241d; }
+  .btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e34039; }
+  .btn.btn_attachment.btn_primary { border-color: #ebdbb2; }
+  .btn.btn_attachment.btn_primary:hover, .btn.btn_attachment.btn_primary:focus { border-color: #f6eeda; }
+  .btn_basic:focus, .btn_basic:hover { color: #f9f5d7; }
+  .btn_outline { background: #1d2021; color: #689d6a !important; }
+  .btn_outline::after { border: 1px solid #282828; }
+  .btn_outline.btn_transparent { color: rgba(29, 32, 33, 0.9) !important; }
+  .btn_outline.btn_transparent::after { border: 1px solid rgba(29, 32, 33, 0.5); }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(29, 32, 33, 0.9) !important; color: #cc241d !important; }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(29, 32, 33, 0.8) !important; }
+  .btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #1d2021; color: #cc241d !important; }
+  .btn_outline:active { color: #cc241d; }
+  .btn_outline.active { color: #cc241d !important; }
+  .btn_link { color: #689d6a; }
+  .btn_link:hover, .btn_link:focus { color: #cc241d; }
+  .btn-group.open .btn.dropdown-toggle { background-color: #1d2021; }
+  .btn-group.open .btn-primary.dropdown-toggle { background-color: #282828; }
+  .btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
+  .btn_info, .btn.btn_success { background-color: #1d2021 !important; }
+  .btn_warning, .btn_danger { background-color: #cc241d !important; }
+  .btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #f9f5d7; border-top-color: #f9f5d7; }
+  .input_note { color: #f9f5d7; }
+  .c-enhanced_text_input { background-color: #1d2021; border-color: #282828; color: #d79921; }
+  .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #1d2021; }
+  .c-filter_input { background: #1d2021; }
+  .p-share_dialog_message_input { color: #f9f5d7; }
+  .c-texty_input .ql-placeholder { color: #f9f5d7; }
+  .lazy_filter_select.disabled { background: #282828; }
+  .lazy_filter_select.disabled input.lfs_input { background: #ebdbb2; }
+  .lazy_filter_select .lfs_input_container { background-color: #1d2021; border-color: #282828; }
+  .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #282828; }
+  .lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(29, 32, 33, 0.15); }
+  .lazy_filter_select .lfs_list_container { background: #1d2021; border-color: #282828; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
+  .lazy_filter_select .lfs_list .lfs_item.selected { color: #f9f5d7; }
+  .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name { color: #f9f5d7 !important; }
+  .lazy_filter_select .lfs_list .lfs_item.disabled { color: #d79921; }
+  .lazy_filter_select .lfs_list .lfs_item.active { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+  .lazy_filter_select .lfs_token { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  .lazy_filter_select .lfs_token::after { color: #f9f5d7; }
+  .lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after { color: #f9f5d7; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected { color: #f9f5d7 !important; }
+  #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected .ts_icon:not(.presence_icon) { color: #d79921 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item { color: #d79921 !important; }
+  #select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #d79921 !important; }
+  #message_edit_form .emo_menu { color: rgba(249, 245, 215, 0.3); }
+  #message_edit_form .emo_menu.active .ts_icon_happy_smile, #message_edit_form .emo_menu:hover .ts_icon_happy_smile { color: #ebdbb2; }
+  #message_edit_form.focus .emo_menu { color: rgba(249, 245, 215, 0.6); }
+  #message_edit_form.focus #primary_file_button:not(:hover) { border-color: #282828; }
+  #message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #282828 !important; }
+  #message_edit_form.offline #primary_file_button { border-color: #282828; color: #d79921; }
+  #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+  #msg_form #msg_input { background: padding-box #1d2021; border-color: #282828; border-left: 0; color: #f9f5d7; }
+  #msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #f9f5d7; }
+  #msg_form .msg_mentions_button { color: #d79921; }
+  #msg_form .msg_mentions_button:hover { color: #f9f5d7; }
+  #msg_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  #msg_input::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
+  #msg_input::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  #msg_input::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
+  #msg_input[data-placeholder]:empty::before { color: #f9f5d7 !important; }
+  #msg_input:focus, #msg_input.focus { border-color: #282828; }
+  #msg_input:focus + #primary_file_button:not(:hover):not(.active), #msg_input.focus + #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+  #msg_input + #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
+  #msg_input + #primary_file_button.focus-ring:not(:hover):not(.active) { border-color: #282828; }
+  #msg_input.offline:not(.pretend-to-be-online) { background-color: #282828 !important; color: #d79921; }
+  #msg_input.disabled, #msg_input.ql-disabled { background-color: #282828; border-color: #282828; color: #d79921; }
+  #msg_input_message { background-color: #282828; color: #f9f5d7; }
+  #primary_file_button { background: padding-box #1d2021; border-color: #282828; color: #d79921; }
+  #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #282828; border-color: #282828; color: #f9f5d7; }
+  #footer, #footer.footer_msg_input { background: #1d2021; box-shadow: inset 1px 0 0 0 #1d2021; }
+  #footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #282828 !important; border-color: #282828 !important; }
+  #footer_archives_table { color: #d79921; }
+  #typing_text { color: #d79921; filter: none; }
+  #notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
+  #special_formatting_text { color: #d79921; }
+  #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .inline_message_input_container .ql-container { border-color: #1d2021; color: #f9f5d7; }
+  .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #ebdbb2; }
+  .c-message--editing { background: #282828; border-color: #282828; color: #f9f5d7; }
+  .c-message__editor__input, .c-message__editor__input--legacy { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-message__editor__input.focus, .c-message__editor__input--legacy.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-message__editor__warning { color: #cc241d; }
+  .c-message .c-button { border-color: #282828; }
+  .c-message .c-button--outline { background-color: #282828; color: #689d6a; }
+  .c-message .c-button--outline:hover { color: #cc241d; }
+  .c-message .c-button--primary { background-color: #1d2021; color: #f9f5d7; }
+  #message_edit_container .message_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  #message_edit_container .message_input.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(29, 32, 33, 0.5); color: #1d2021; }
+  .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(29, 32, 33, 0.8); }
+  .ql-placeholder, .texty_legacy .ql-placeholder { color: #f9f5d7; filter: none; }
+  .ql-container.texty_single_line_input { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
+  .c-input_select { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
+  .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-input_select_options_list__option { color: #f9f5d7; }
+  .c-label__text { color: #f9f5d7; }
+  .c-date_picker__dropdown { background-color: #282828; }
+  .c-calendar_view_header__stepper_btn:disabled, .c-calendar_view_header__title_btn:disabled { color: #d79921; }
+  .c-calendar_view_header__stepper_btn, .c-calendar_view_header__title_btn { color: #f9f5d7; }
+  .c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #1d2021; }
+  .c-date_picker_calendar__date--disabled, .c-date_picker_calendar__date--disabled:hover { background-color: #282828; }
+  .c-mini_calendar__month_button:disabled, .c-mini_calendar__month_button:disabled:hover { background-color: #282828; }
+  .c-calendar_month__day_of_week_heading { color: #f9f5d7; }
+  .menu { background: #282828; border: 1px solid #1d2021; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); color: #f9f5d7; }
+  .menu .menu_content { background: #282828 !important; }
+  .menu .menu_filter_container { background: #1d2021; }
+  .menu .menu_filter_container input.menu_filter { border: 1px solid #282828; }
+  .menu .menu_filter_container input.menu_filter:focus { border-color: #1d2021; }
+  .menu .menu_filter_container .icon_search { color: #d79921; }
+  .menu .menu_filter_container .icon_close { color: #d79921 !important; }
+  .menu #menu_header .menu_simple_header { background: #282828; border-color: #282828; color: #f9f5d7; }
+  .menu #menu_header .menu_simple_header a { color: #689d6a; }
+  .menu #menu_header .menu_simple_header a:hover { color: #cc241d; }
+  .menu #menu_header .menu_close { color: #f9f5d7; }
+  .menu .section_header .header_label { background-color: #282828; color: #d79921; }
+  .menu .section_header > div.header_label_container { color: #d79921; }
+  .menu ul li a { background: #282828; border-bottom: 0; color: #f9f5d7; }
+  .menu ul li a.delete_link { color: #cc241d; }
+  .menu ul li a:not(.inline_menu_link) { color: #f9f5d7; }
+  .menu ul li.highlighted a { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon { color: #f9f5d7; }
+  .menu ul li.highlighted a.delete_link { color: #cc241d; }
+  .menu ul li.disabled a { color: #d79921; }
+  .menu ul li i { color: #d79921; }
+  .menu ul li.divider { border-bottom-color: #1d2021; }
+  .menu ul li .menu_item_details { color: #d79921; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
+  .menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #cc241d; }
+  .menu input { background: #282828; border: 1px solid #1d2021; }
+  .menu textarea { background: #282828; border: 1px solid #1d2021; }
+  .menu #menu_footer .menu_footer { background: #282828; border-top: 1px solid #282828; }
+  .menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #282828; }
+  .menu #menu_list_container #menu_list .menu_list_item a { color: #f9f5d7; }
+  .menu #menu_list_container #menu_list .menu_list_item.active a { background: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .c-menu { background-color: #282828; }
+  .c-menu_item__label { color: #fff; }
+  .c-menu_item__header { color: #d79921; }
+  #autocomplete_menu { color: #f9f5d7; }
+  #autocomplete_menu header { background-color: #1d2021; }
+  #autocomplete_menu header .header_label { color: #d79921; }
+  #autocomplete_menu header hr { border-bottom-color: transparent; border-top-color: #282828; }
+  #autocomplete_menu h2 { color: #f9f5d7; }
+  #autocomplete_menu .no_results { color: #f9f5d7; }
+  #autocomplete_menu .keyword_match .modifier { color: #d79921; }
+  #autocomplete_menu .boxed { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu .pickmeup { border-bottom: 1px solid #282828; }
+  #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #1d2021; }
+  #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #f9f5d7; }
+  #autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #282828; }
+  #autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
+  #autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview { color: #f9f5d7; }
+  #autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu li.highlighted .modifier_icon, #autocomplete_menu.search_menu.unified li.highlighted .modifier_icon { color: #d79921; }
+  #autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn { color: #f9f5d7; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn { color: #689d6a; }
+  #autocomplete_menu.search_menu li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu li.highlighted .delete_btn:hover, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:focus, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn:hover { color: #cc241d; }
+  #autocomplete_menu.search_menu li.highlighted .muted_text, #autocomplete_menu.search_menu.unified li.highlighted .muted_text { color: #d79921; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover { background: transparent; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .muted_text, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .muted_text { color: #d79921; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .modifier_icon, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .modifier_icon { color: #d79921; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn { color: #f9f5d7; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn { color: #689d6a; }
+  #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn:hover, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:focus, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn:hover { color: #cc241d; }
+  #autocomplete_menu.search_menu .muted_text, #autocomplete_menu.search_menu.unified .muted_text { color: #d79921; }
+  #autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before { background-color: #282828; }
+  #autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn { color: #f9f5d7; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #f9f5d7; }
+  #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #282828; color: #f9f5d7; }
+  #autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #d79921; }
+  #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+  #autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(29, 32, 33, 0.25); border: #ebdbb2; }
+  #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
+  .search_light_grey { color: #f9f5d7 !important; }
+  .highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+  .highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+  .highlighter_underlay .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
+  .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #1d2021; }
+  .highlighter_underlay .ghost_text { color: #f9f5d7; }
+  .pickmeup { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
+  .pickmeup .pmu-instance .pmu-button { color: #f9f5d7; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #282828 !important; }
+  .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #ebdbb2; color: #f9f5d7 !important; }
+  .pickmeup .pmu-instance .pmu-today-border { border: 2px solid #1d2021 !important; color: #ebdbb2 !important; }
+  .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #1d2021; color: #f9f5d7; }
+  .pickmeup .pmu-instance .pmu-not-in-month { background: #1d2021; color: #d79921; }
+  .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #1d2021; }
+  .pickmeup .pmu-instance .pmu-disabled { background: #1d2021; color: #d79921; }
+  .pickmeup .pmu-instance .pmu-disabled:hover { background: #1d2021; color: #d79921; }
+  .pickmeup .pmu-instance .pmu-selected { background: #1d2021; color: #f9f5d7; }
+  .pickmeup .pmu-instance nav { color: #689d6a; }
+  .pickmeup .pmu-instance nav :first-child :hover { color: #cc241d; }
+  .pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #282828; }
+  .pickmeup .pmu-instance .pmu-day-of-week { color: #f9f5d7; }
+  .pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #282828; }
+  .pickmeup .pmu-instance .pmu-days * { border: 1px solid #282828; }
+  .p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #1d2021; color: #ebdbb2; }
+  #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #1d2021; }
+  #menu.date_picker li.date_picker_item a { color: #f9f5d7; }
+  #menu.date_picker li.date_picker_item a:hover { color: #f9f5d7; }
+  #menu.date_picker li.date_picker_item.highlighted a { color: #d79921; }
+  #file_member_filter { background: #282828; }
+  #client-ui .member_filter { border: 1px solid #1d2021; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #1d2021; }
+  #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #f9f5d7; }
+  #client-ui #team_list_container #team_filter .member_filter { background-color: #1d2021; border-left: 1px solid #282828; }
+  #client-ui #file_member_filter { border-color: #1d2021; }
+  #client-ui #file_member_filter .member_filter { border-color: #1d2021; }
+  #client-ui .team_tabs_container { border-bottom: 1px solid #282828; }
+  #team_filter .icon_search { color: #d79921; }
+  #team_filter a.icon_close { color: #689d6a; }
+  #team_filter a.icon_close:hover { color: #cc241d; }
+  .filter_header { background-color: #1d2021; }
+  .popover_menu { background-color: #1d2021; border-top: 1px solid #1d2021; }
+  .popover_menu .arrow::after { background-color: #282828; }
+  .popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #1d2021, 0 0 3px rgba(0, 0, 0, 0.08); }
+  .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #1d2021 !important; }
+  .popover_menu .content { background-color: #1d2021; }
+  .tab_complete_ui { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
+  .tab_complete_ui .tab_complete_ui_header { background: padding-box #282828; border-bottom: 1px solid #282828; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui ul.type_emoji li { color: #f9f5d7; }
+  .tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname { color: #f9f5d7; }
+  .tab_complete_ui ul.type_members .unify_broadcast { color: #f9f5d7; }
+  .tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast { color: #d79921; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name { color: #f9f5d7 !important; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider { border-bottom: 0; border-top-color: #282828; }
+  .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td { color: #d79921; }
+  .tab_complete_ui ul.type_cmds .cmdname { color: #f9f5d7; }
+  .tab_complete_ui ul.type_cmds .cmddesc { color: #d79921; }
+  .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #282828; }
+  .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #1d2021; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #f9f5d7 !important; }
+  .tab_complete_ui .not_in_channel { color: #d79921; }
+  #team_menu { background: #282828; border-bottom: 2px solid #282828; color: #f9f5d7; }
+  #team_menu.active, #team_menu:hover { background: #282828 !important; border-bottom-color: #282828 !important; }
+  #team_menu.active i, #team_menu:hover i { color: #f9f5d7; }
+  #team_menu i { color: #d79921; }
+  #team_menu .presence .presence_icon { text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  #team_menu .team_name_caret, #team_menu .notifications_menu_btn { color: #f9f5d7 !important; }
+  #team_menu_user { color: #d79921; }
+  #team_menu_user_name, #team_menu_user_details { color: #f9f5d7 !important; opacity: 0.75; }
+  .slack_menu_section::before { border-top-color: #1d2021; }
+  .slack_menu_header_secondary { color: #d79921; }
+  .slack_menu_download { background-color: #282828; }
+  .slack_menu_download ts-icon { color: #d79921; }
+  #menu_items_scroller::-webkit-scrollbar-track { background: #1d2021 !important; }
+  #limit_meter:hover #limit_meter_message_body { color: #f9f5d7; }
+  #limit_meter_message_body { color: #d79921; }
+  .channel_header { background: #1d2021; box-shadow: inset 1px 0 0 0 #1d2021; }
+  .channel_header .blue_on_hover:hover { color: #f9f5d7; }
+  #client_body:not(.onboarding)::before { background: #1d2021; border-bottom: 1px solid #282828; box-shadow: inset 1px 0 0 0 #1d2021; }
+  #client_body:not(.onboarding):not(.feature_global_nav_layout)::before { background: #1d2021; border-bottom: 1px solid #282828; box-shadow: inset 1px 0 0 0 #1d2021; }
+  .messages_header { color: #f9f5d7; }
+  .channel_title .channel_name_container .channel_name { color: #f9f5d7; }
+  .channel_title .channel_name_container .channel_name.muted { color: #d79921; }
+  .channel_title .channel_name_container .ts_icon_shared_channel.away, .channel_title .channel_name_container .mpdm_member.away { color: #d79921; }
+  .channel_title .channel_name_container .muted_icon { color: #d79921; }
+  .channel_title .channel_name_container .muted_icon:hover { color: #cc241d; }
+  #im_title.away { color: #d79921; }
+  .channel_header_info button { color: #689d6a; }
+  .channel_header_icon { color: #f9f5d7; }
+  .channel_calls_button .call_icon.call_window_offline { color: #d79921; }
+  .channel_actions_toggle.active:focus, .details_toggle.active:focus { color: #f9f5d7; }
+  #flex_menu_toggle.active, #flex_menu_toggle.active:focus { color: #f9f5d7; }
+  #flex_menu_toggle .flex_menu_download_circle { background: #1d2021; }
+  #flex_menu_toggle .flex_menu_download_circle canvas { background: #1d2021; }
+  #flex_menu_toggle.unread #help_icon_circle_count { background-color: #cc241d; color: #fff; }
+  #flex_menu_toggle.open #help_icon_circle_count { background-color: #282828; color: #f9f5d7; }
+  #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #282828; color: #f9f5d7; }
+  #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #1d2021; color: #f9f5d7; }
+  #recent_mentions_toggle:hover { color: #cc241d; }
+  #rxn_toast_div { background: #282828; border: 1px solid #1d2021; }
+  .presence { color: #d79921; }
+  #edit_topic_inner:not(.unable_to_post)::before { background: #1d2021; border-color: #282828; }
+  #edit_topic_trigger { color: #689d6a; }
+  .c-message_list__day_divider__label { color: #d79921; }
+  .c-message_list__day_divider__label__pill { background: #1d2021; position: relative; }
+  .c-message_list__day_divider__line { border-top-color: #282828; }
+  .day_divider, .mention_day_container_div .day_divider { background: #1d2021; color: #d79921; }
+  .day_divider hr, .mention_day_container_div .day_divider hr { border-bottom: 0; border-top: 1px solid #282828; }
+  .day_divider .day_divider_label { background: #1d2021; }
+  .day_container .day_msgs { border-top: 1px solid #282828; }
+  .day_container.unread_day_container .day_msgs { border-color: #ebdbb2; }
+  .day_container .day_divider { background: none; color: #d79921; }
+  .day_container .day_divider .day_divider_label { background: #1d2021; }
+  .search_form { border-color: #1d2021; }
+  .search_form .search_input { background: transparent; }
+  .search_form:hover { border-color: #ebdbb2; }
+  .search_focused .search_form { border-color: #ebdbb2; }
+  .search_clear_icon .ts_icon_times_circle { color: #d79921; }
+  #search_spinner { color: #f9f5d7; }
+  #search_container .search_input { background: transparent; }
+  #search_container .icon_search { color: #d79921; }
+  #search_container .icon_close { color: #689d6a; }
+  #team_filter .icon_search, #team_filter .ts_icon_spinner, #user_group_filter .icon_search, #user_group_filter .ts_icon_spinner, .searchable_member_list_search_bar .icon_search, .searchable_member_list_search_bar .ts_icon_spinner { color: #d79921; }
+  #team_filter a.icon_close, #user_group_filter a.icon_close, .searchable_member_list_search_bar a.icon_close { color: #689d6a; }
+  #team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover { color: #cc241d; }
+  .c-search { background: transparent; }
+  .c-search_message__body { color: #f9f5d7; }
+  .p-search_filter__more_link { color: #f9f5d7; }
+  .p-search_filter__title_text { background: #282828; color: #f9f5d7; }
+  .p-search_filter__datepicker_trigger { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .p-search_filter__datepicker_trigger:hover { color: #d79921; }
+  .c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .c-search_autocomplete footer { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .c-search_autocomplete__suggestion_item { color: #f9f5d7; }
+  .c-search_autocomplete__suggestion_item--selected { background-color: #282828; }
+  .c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #f9f5d7; }
+  .c-search__input_and_close { border-bottom-color: #282828; }
+  .c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close { color: #f9f5d7; }
+  #msgs_overlay_div { background: #1d2021; }
+  #col_messages { box-shadow: inset 1px 0 0 0 #1d2021; }
+  .c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight, .c-mrkdwn__mention, .c-mrkdwn__mention:hover, .c-mrkdwn__subteam--mention, .c-mrkdwn__subteam--mention:hover, .mention_yellow_bg { color: #d79921 !important; }
+  .c-message:hover .c-message__broadcast_preamble_outer, .c-message:hover .c-message__broadcast_preamble { color: #d79921; }
+  .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble_outer .c-message--focus .c-message__broadcast_preamble, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble_outer, .c-message--hover .c-message__broadcast_preamble .c-message--focus .c-message__broadcast_preamble { color: #d79921; }
+  .c-message:hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--hover:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight), .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(40, 40, 40, 0.1); }
+  .c-message:hover .c-message__body--automated, .c-message--hover .c-message__body--automated .c-message--focus .c-message__body--automated { color: #d79921; }
+  .c-message:hover .c-message__file_meta, .c-message--hover .c-message__file_meta .c-message--focus .c-message__file_meta { color: #d79921; }
+  .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) { background: rgba(40, 40, 40, 0.1); }
+  .c-message--pinned, .c-message--sli_highlight:not(.c-message--sli_highlight_negative), .c-message--starred { background: rgba(40, 40, 40, 0.2); }
+  .c-message--custom_response { background: rgba(40, 40, 40, 0.15); }
+  .c-message--sli_highlight_negative, .c-message--ephemeral { background: rgba(40, 40, 40, 0.1); }
+  .c-message--pinned .c-message__label__icon { color: #cc241d; }
+  .c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon { color: #f9f5d7; }
+  .c-message--sli_highlight .c-message__label .c-mrkdwn__member--link, .c-message--sli_highlight .c-message__label .c-mrkdwn__channel.internal_channel_link { color: #d79921; }
+  .c-message--sli_highlight_negative .c-message__label { background: rgba(40, 40, 40, 0.1); }
+  .c-message--resend .c-message__body { color: #d79921; }
+  .c-message--deleting { background: rgba(204, 36, 29, 0.6); }
+  .c-message--standalone { border-color: rgba(29, 32, 33, 0.1); }
+  .c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
+  .c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #d79921; }
+  .c-message__sender { color: #f9f5d7; }
+  .c-message__sender a { color: #f9f5d7; }
+  .c-message__sender .c-emoji__text_mode_icon { color: #d79921; }
+  .c-message__body { color: #f9f5d7; }
+  .c-message__body--unknown { background: rgba(29, 32, 33, 0.1); }
+  .c-message__body--automated { color: #d79921; }
+  .c-message__body--tombstone { color: #d79921; }
+  .c-message__label { color: #d79921; }
+  .c-message__label__highlight_title { color: #f9f5d7; }
+  .c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #d79921; }
+  .c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #f9f5d7; }
+  .c-message__resend_controls { color: #d79921; }
+  .c-message__resend_column { background-color: rgba(29, 32, 33, 0.1); }
+  .c-message__resend, .c-message__cancel { color: #f9f5d7; }
+  .c-message__edited_label { color: #d79921; }
+  .c-message__tombstone_icon { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+  .c-message__bot_label { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+  .c-message__comment:before { color: #d79921; }
+  .c-message__call_attachment { background: #1d2021; border-color: rgba(29, 32, 33, 0.1); }
+  .c-message__call_icon { color: #f9f5d7; }
+  .c-message__call--ended .c-message__call_icon { color: #d79921; }
+  .c-message__call_info { color: #f9f5d7; }
+  .c-message__call_name--linked { color: #f9f5d7; }
+  .c-message__call_name + .c-message__call_description::before { color: #d79921; }
+  .c-message__call_sub { color: #d79921; }
+  .c-message_actions__container { background: #1d2021; border-color: #282828; }
+  .c-message_actions__container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  .c-message_actions__button { border-right-color: #282828; color: #689d6a; }
+  .c-message_actions__button:hover { color: #f9f5d7; }
+  .c-message_actions__button:active { background: #282828; }
+  .c-message_group { background-color: #1d2021; border-color: #282828; }
+  .c-message_group:hover .c-message_group__header { color: #d79921; }
+  .c-message_group__header { color: #f9f5d7; }
+  .c-message_group__divider_text { background-color: #1d2021; color: #f9f5d7; }
+  .c-message_list__unread_divider__separator { border-color: #1d2021; }
+  .c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #1d2021; }
+  .c-message_list__spinner { color: #d79921; }
+  .c-message_list .c-scrollbar__bar { background: #282828; }
+  .c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(235, 219, 178, 0.8); }
+  ts-message { color: #f9f5d7; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) { background: rgba(40, 40, 40, 0.1); box-shadow: inset 1px 0 0 0 #1d2021; }
+  ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) { background: rgba(40, 40, 40, 0.2); }
+  ts-message.active .edited, ts-message.active .reply_bar .last_reply_at, ts-message.active .timestamp, ts-message.active.automated .message_body, ts-message.message--focus .edited, ts-message.message--focus .reply_bar .last_reply_at, ts-message.message--focus .timestamp, ts-message.message--focus.automated .message_body, ts-message:hover .edited, ts-message:hover .reply_bar .last_reply_at, ts-message:hover .timestamp, ts-message:hover.automated .message_body { color: #d79921; }
+  ts-message.active .meta, ts-message.message--focus .meta, ts-message:hover .meta { color: #d79921 !important; }
+  ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--focus .meta.msg_inline_file_preview_toggler a, ts-message:hover .meta.msg_inline_file_preview_toggler a { color: #d79921 !important; }
+  ts-message.is_pinned { background: rgba(40, 40, 40, 0.15); }
+  ts-message .timestamp { color: #689d6a; }
+  ts-message .temp_msg_controls { color: #d79921; }
+  ts-message .edited { color: rgba(215, 153, 33, 0.8); }
+  ts-message:hover .edited { color: #d79921; }
+  ts-message .only_visible_to_user { color: #d79921; }
+  ts-message.ephemeral { color: #f9f5d7; }
+  ts-message .bot_label { background: #282828; color: #d79921; }
+  ts-message .in_reply_to { background: #282828; color: #d79921; }
+  ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { border: 1px solid #282828; }
+  ts-message.unprocessed { color: rgba(249, 245, 215, 0.75); }
+  ts-message.highlight { background: rgba(204, 36, 29, 0.4); }
+  ts-message.highlight:hover { background: rgba(204, 36, 29, 0.4); }
+  ts-message .is_highlights_holder { color: #d79921; }
+  ts-message .is_highlights_holder ts-icon { color: #d79921; }
+  ts-message .is_highlights_holder .highlights_feedback_link { color: #d79921; }
+  ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) { color: #f9f5d7; }
+  ts-message .recap_highlight { background: rgba(204, 36, 29, 0.4); }
+  ts-message .recap_highlight a { color: #f9f5d7; }
+  ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(204, 36, 29, 0.75); }
+  ts-message.automated .message_body { color: rgba(249, 245, 215, 0.8); }
+  ts-message .action_hover_container { border: 1px solid #282828; }
+  ts-message .action_hover_container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #1d2021; }
+  ts-message .action_hover_container .btn_msg_action { background: #1d2021; border-right: 1px solid #282828; color: #689d6a; }
+  ts-message .action_hover_container .btn_msg_action:hover { color: #f9f5d7; }
+  ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #282828; color: #f9f5d7; }
+  ts-message.selected { background: #1d2021; }
+  ts-message.selected:not(.delete_mode) { background: #1d2021; }
+  ts-message.selected:hover { background: rgba(0, 0, 0, 0.15); }
+  ts-message .meta { color: #d79921; }
+  ts-message .meta.msg_inline_img_toggler .member, ts-message .meta.msg_inline_img_toggler .service_link, ts-message .meta.msg_inline_file_preview_toggler .member, ts-message .meta.msg_inline_file_preview_toggler .service_link { color: #689d6a !important; }
+  ts-message .meta.msg_inline_img_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_img_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_img_toggler a, ts-message .meta.msg_inline_file_preview_toggler .msg_inline_media_toggler, ts-message .meta.msg_inline_file_preview_toggler .ts_icon_dropbox, ts-message .meta.msg_inline_file_preview_toggler a { color: #d79921 !important; }
+  ts-message .pinned_item_message_header { color: #d79921; }
+  ts-message .mention { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+  ts-message .internal_member_link { background: #1d2021 !important; border: 0; color: #689d6a !important; }
+  ts-message .internal_member_link:hover { color: #cc241d !important; }
+  ts-message.show_recap:not(.is_pinned) { background: rgba(40, 40, 40, 0.15); }
+  ts-message.show_recap:not(.is_pinned):hover { background: rgba(40, 40, 40, 0.15); }
+  .ephemeral.message .message_content { color: #f9f5d7; }
+  ts-mention { background: rgba(235, 219, 178, 0.1) !important; color: #f9f5d7 !important; }
+  .selecting_messages ts-message:hover { background: #282828; }
+  .selecting_messages ts-message.multi_delete_mode:hover { background: rgba(204, 36, 29, 0.75); }
+  #convo_container { background-color: #1d2021; }
+  #convo_container #message_edit_container { border-bottom: 1px solid #1d2021; border-top: 1px solid #1d2021; }
+  #convo_container ts-conversation::after { background: rgba(40, 40, 40, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(40, 40, 40, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(40, 40, 40, 0.08) 100%); }
+  #convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(40, 40, 40, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(40, 40, 40, 0.08) 0, transparent 100%); }
+  #convo_container ts-conversation ts-message.selected { background: #1d2021; }
+  #convo_container ts-conversation ts-relatives::after { background: #1d2021; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #1d2021; color: #d79921; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #f9f5d7; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #1d2021; }
+  #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #292d2f; }
+  #msgs_div .unread_divider hr { border-top: 1px solid #1d2021; }
+  #msgs_div .unread_divider .divider_label { background: #1d2021; color: #1d2021; }
+  #msgs_div .unread_divider.no_unreads hr { border-top-color: #282828; }
+  #msgs_div .unread_divider.no_unreads .divider_label { color: #d79921; }
+  .channel_archive_messages.card .col:first-child { border-right: 1px solid #1d2021; }
+  .star { color: #d79921; }
+  .star_item { border-bottom: 1px solid #282828; }
+  .star_item .star_meta { color: #d79921; }
+  .bot_message .message_sender { color: #f9f5d7; }
+  .bot_message .message_sender a { color: #f9f5d7; }
+  .color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away) > .color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li > .color_USLACKBOT:not(.nuc) { color: #f9f5d7; }
+  #msgs_scroller_div #end_display_div #end_display_status { color: #d79921; }
+  #msgs_scroller_div #end_display_div #end_display_meta { color: #d79921; }
+  #msgs_scroller_div #end_display_div #end_display_meta h1 { color: #f9f5d7; }
+  #msgs_scroller_div #end_display_div p { color: #f9f5d7; }
+  .member_mentions_options { background-color: #282828; border-top: 1px solid #282828; }
+  .dm_badge .dm_badge_meta { color: #f9f5d7; }
+  .dm_badge a { color: #689d6a; }
+  .dm_badge a.member_preview_link { color: #689d6a; }
+  .dm_badge .dm_badge:hover a { color: #689d6a; }
+  .dm_badge .hint { color: #d79921; }
+  #toggle-subscription-status .subscription_desc { color: #d79921; }
+  .bot_label { background: #282828; color: #d79921; }
+  @keyframes to-grey { 0% { color: inherit; }
+    100% { color: #d79921; } }
+  @keyframes fade-background-highlight { 0% { background: #1d2021; }
+    100% { background: transparent; } }
+  @keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #1d2021, 0 0 0 0.5px #ebdbb2; }
+    100% { box-shadow: 0 0 4px 0 #1d2021, 0 0 0 0 #ebdbb2; } }
+  .c-message_attachment { color: #f9f5d7; }
+  .c-message_attachment__border { background-color: #1d2021; }
+  .c-message_attachment__delete { color: #689d6a; }
+  .c-message_attachment__delete:hover { color: #cc241d; }
+  .c-message_attachment__pretext { color: #f9f5d7; }
+  .c-message_attachment__part + .c-message_attachment__part::before { color: #1d2021; }
+  .c-message_attachment__author .c-message_attachment__autor--distinct { color: #689d6a; }
+  .c-message_attachment__author_link + .c-message_attachment__author_link { color: #689d6a; }
+  .c-message_attachment__title_link span { color: #f9f5d7; }
+  .c-message_attachment__text_expander { color: #689d6a; }
+  .c-message_attachment__footer { color: #689d6a; }
+  .c-message_attachment__image, .c-message_attachment__thumb, .c-message_attachment__video_thumb { box-shadow: 0 0 0 1px rgba(40, 40, 40, 0.1) inset; }
+  .c-message_attachment__video_html { background-color: rgba(29, 32, 33, 0.4); }
+  .c-message_attachment__video_buttons { background: rgba(40, 40, 40, 0.4); }
+  .c-message_attachment__video_link:visited, .c-message_attachment__video_link:link { color: #f9f5d7; }
+  .c-message_attachment__video_play, .c-message_attachment__video_link { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+  .c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover { color: #f9f5d7; }
+  .c-message_attachment__media_trigger .c-expandable_trigger { color: #689d6a; }
+  .c-message_attachment__media_trigger--too_large { color: #689d6a; }
+  .c-message_attachment__select { border-color: #282828; }
+  .c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #1d2021; }
+  .c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #1d2021; border-color: #282828; }
+  .c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #d79921; }
+  .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #1d2021; }
+  .c-message__reply_bar_description { color: #d79921; }
+  .c-message__file_meta { color: #d79921; }
+  .c-message__image_container { background: rgba(40, 40, 40, 0.1); }
+  .c-message__image_wrapper:after { border-color: transparent; }
+  .c-message_kit__file__meta { color: #f9f5d7; }
+  .attachment_group.has_container { background: #1d2021; border: 1px solid #282828; }
+  .attachment_group.has_container .inline_attachment::after { background-color: #282828; }
+  .attachment_group.has_container.has_link:hover { border-bottom-color: #282828; border-left-color: #282828; border-right-color: #282828; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .attachment_group .media_caret { color: #d79921; }
+  .attachment_group .attachment_source span { color: #d79921 !important; }
+  .attachment_group .attachment_source .attachment_source_name + .attachment_author_name::before { color: #d79921; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule { color: #d79921; }
+  .attachment_group .inline_attachment.reply_broadcast + .attachment_rule::after { border-bottom: 1px solid #282828; }
+  .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span { color: #d79921; }
+  .attachment_group .attachment_title a { color: #f9f5d7; }
+  .attachment_group .attachment_footer_text + .attachment_ts::before { color: #d79921; }
+  .attachment_group .delete_attachment_link ts-icon::before { color: #689d6a; }
+  .attachment_group .delete_attachment_link:hover ts-icon::before { color: #cc241d; }
+  .attachment_still_pending ts-inline-saver { color: #d79921; }
+  .msg_inline_attachment_column.column_border { background-color: #1d2021; }
+  .msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #282828; }
+  .msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #689d6a; }
+  .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #cc241d; }
+  .msg_inline_img { background: #1d2021; }
+  .msg_inline_room_preview_collapser { color: #d79921; }
+  .msg_inline_room_preview_collapser:hover { color: #d79921; }
+  .inline_attachment span.attachment_author_name { color: #689d6a; }
+  .inline_attachment span.attachment_author_subname, .inline_attachment span.attachment_service_name { color: #689d6a; }
+  .inline_attachment a span:active, .inline_attachment a span:hover { color: #cc241d !important; }
+  .inline_attachment .attachment_footer, .inline_attachment .attachment_ts { color: #689d6a; }
+  .inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a { color: #689d6a; }
+  .inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover { color: #cc241d !important; }
+  .inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover { color: #cc241d !important; }
+  .inline_attachment .iframe_placeholder, .inline_attachment iframe { background-color: #282828; }
+  .meta.msg_inline_file_preview_toggler, .meta.msg_inline_img_toggler, .dense_meta.msg_inline_file_preview_toggler, .dense_meta.msg_inline_img_toggler { color: #689d6a !important; }
+  .meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] { color: #689d6a !important; }
+  .meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover { color: #cc241d !important; }
+  .meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] { color: #cc241d !important; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title { color: #f9f5d7; }
+  .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover { color: #d79921; }
+  .meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover { color: #cc241d !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover { color: #cc241d !important; }
+  .meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon { color: #cc241d !important; }
+  .meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member { color: #689d6a !important; }
+  .delete_attachment_link { color: #689d6a; }
+  .delete_attachment_link:hover { color: #cc241d; }
+  .file_container, .c-file_container { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  .file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open { border-bottom-color: #282828; border-left-color: #282828; border-right-color: #282828; }
+  .file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after { background-image: -webkit-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: -moz-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: -o-linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); background-image: linear-gradient(top, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+  .file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon { background: #1d2021; box-shadow: 0 0 0 3px #1d2021; color: #f9f5d7; }
+  .file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet { background: #282828; }
+  .file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover { background: #282828; color: #f9f5d7; }
+  .file_container .file_header .file_header_meta, .c-file_container .file_header .file_header_meta { color: #d79921; }
+  .file_container .file_header + .file_body, .c-file_container .file_header + .file_body { border-top: 1px solid #282828; }
+  .file_container .preview_actions .btn, .c-file_container .preview_actions .btn { background-color: #282828; color: #f9f5d7 !important; }
+  .file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after { border-color: #282828; }
+  .file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header { background-color: rgba(235, 219, 178, 0.9); color: #f9f5d7 !important; }
+  .file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after { border: 2px solid #282828; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover { background-color: #282828; }
+  .file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after { border-color: #282828; }
+  .file_container.image_container .image_body, .c-file_container.image_container .image_body { background-color: #1d2021; }
+  .file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(235, 219, 178, 0.9); }
+  .file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #282828; }
+  .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(235, 219, 178, 0.9); border: 1px solid rgba(40, 40, 40, 0.1); }
+  .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(29, 32, 33, 0.8), rgba(29, 32, 33, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
+  .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(29, 32, 33, 0.8); color: #f9f5d7; }
+  .file_container .c-file__title, .c-file_container .c-file__title { color: #f9f5d7; }
+  .c-file_container--has_thumb .c-file__actions::before { background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), #282828 20px); }
+  .message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #1d2021; color: #f9f5d7; }
+  .msg_inline_video_buttons_div { background-color: rgba(29, 32, 33, 0.4); }
+  .msg_inline_video_buttons_div a { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+  .msg_inline_video_buttons_div a:visited { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
+  .post_body ul.checklist { background-color: #282828; }
+  .post_body ul.checklist li::before { background: #282828; }
+  .post_body ul.checklist li.checked { color: #d79921; }
+  .post_body ul.list.checklist li { border-bottom: 1px solid #1d2021; }
+  .post_body ul.list.checklist li.checked { color: #d79921; }
+  .post_body .message { background-color: #f9f5d7; }
+  .post_body code, .post_body pre { background: #282828; }
+  ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #d79921; }
+  ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
+  .inline_color_block { border-color: #1d2021; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #1d2021; }
+  .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #1d2021; border-bottom: 1px solid #1d2021; }
+  .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #1d2021; }
+  .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #f9f5d7; }
+  .p-message_pane__limited_history_foreword { background: #282828; background-image: none; color: #f9f5d7; }
+  .p-message_pane__unread_banner__banner { background: #1d2021; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner { color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .messages_banner a { color: #f9f5d7; }
+  .messages_banner a:hover { color: #f9f5d7; }
+  #connection_div { background: #cc241d; }
+  #archives_return { background: padding-box #ebdbb2; color: #f9f5d7; }
+  #archives_return.warning { background: #cc241d; }
+  #archives_return a { color: #f9f5d7; }
+  #archives_return a:hover { color: rgba(249, 245, 215, 0.8); }
+  #messages_unread_status { background: #1d2021; }
+  #messages_unread_status:hover { background: #ebdbb2; }
+  #messages_unread_status:hover .clear_unread_messages { background: #ebdbb2; }
+  #messages_unread_status:hover .clear_unread_messages:hover { background: #1d2021; }
+  #messages_unread_status.quiet { background: #ebdbb2; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #messages_unread_status.quiet a { color: #f9f5d7; }
+  .clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
+  #messages_container.has_top_messages_banner::before { background: none; }
+  .end_div_msg_lim { background-color: #282828; background-image: none; }
+  #archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #f9f5d7; }
+  #archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(249, 245, 215, 0.8); }
+  code { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  code a.app_preview_link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+  .file_list_item.snippet .snippet_preview { background: #282828; }
+  .snippet_preview, .snippet_body { background: #282828; }
+  .snippet_preview pre, .snippet_body pre { color: #f9f5d7 !important; }
+  .file_container .CodeMirror .CodeMirror-code > div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code > div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code > div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code > div::before, .c-file_container .sssh-code .sssh-line::before { background-color: #282828; border-right: 1px solid #282828; color: #d79921; }
+  .c-snippet .c-file_container { background-color: #1d2021; }
+  .c-snippet .c-file_container.c-file_container--gradient::after { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }
+  .CodeMirror { background: #282828; border: 1px solid #282828; color: #f9f5d7 !important; }
+  .CodeMirror pre { background: transparent !important; }
+  .CodeMirror div.CodeMirror-cursor { border-left: 1px solid #f9f5d7; }
+  .CodeMirror.cm-fat-cursor div.CodeMirror-cursor { background: #f9f5d7; }
+  .CodeMirror .CodeMirror-gutters { background-color: #282828; border-right: 1px solid #1d2021; }
+  .CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler { background-color: #282828; }
+  .CodeMirror-linenumber { color: #d79921 !important; }
+  .CodeMirror-guttermarker { color: #d79921; }
+  .CodeMirror-guttermarker-subtle { color: #d79921; }
+  .CodeMirror-ruler { border-left: 1px solid #ebdbb2; }
+  .cm-s-default .cm-keyword { color: #ce93d8; }
+  .cm-s-default .cm-atom { color: #9fa8da; }
+  .cm-s-default .cm-number { color: #a5d6a7; }
+  .cm-s-default .cm-def { color: #536dfe; }
+  .cm-s-default .cm-variable-2 { color: #9fa8da; }
+  .cm-s-default .cm-variable-3 { color: #c5e1a5; }
+  .cm-s-default .cm-comment { color: #ffcc80; }
+  .cm-s-default .cm-string { color: #ef9a9a; }
+  .cm-s-default .cm-string-2 { color: #ffab91; }
+  .cm-s-default .cm-meta { color: #eee; }
+  .cm-s-default .cm-qualifier { color: #eee; }
+  .cm-s-default .cm-builtin { color: #b39ddb; }
+  .cm-s-default .cm-bracket { color: #e6ee9c; }
+  .cm-s-default .cm-tag { color: #a5d6a7; }
+  .cm-s-default .cm-attribute { color: #40c4ff; }
+  .cm-s-default .cm-header { color: #80cbc4; }
+  .cm-s-default .cm-quote { color: #b0bec5; }
+  .cm-s-default .cm-hr { color: #282828; }
+  .cm-s-default .cm-link { color: #689d6a; }
+  .cm-negative { color: #cc241d; }
+  .cm-positive { color: #98971a; }
+  .cm-invalidchar, .cm-s-default .cm-error { color: #cc241d; }
+  div.CodeMirror span.CodeMirror-matchingbracket { color: #98971a; }
+  div.CodeMirror span.CodeMirror-nonmatchingbracket { color: #cc241d; }
+  .CodeMirror-matchingtag { background: #282828; }
+  .CodeMirror-activeline-background { background: #ebdbb2; }
+  .CodeMirror-selected { background: #ebdbb2; }
+  .CodeMirror-focused .CodeMirror-selected { background: #ebdbb2; }
+  .cm-searching { background: #ebdbb2; }
+  .sssh-keyword { color: #ce93d8; }
+  .sssh-atom { color: #9fa8da; }
+  .sssh-number { color: #a5d6a7; }
+  .sssh-def { color: #536dfe; }
+  .sssh-variable { color: #9fa8da; }
+  .sssh-variable-2 { color: #c5e1a5; }
+  .sssh-variable-3 { color: #c1a5e1; }
+  .sssh-operator { color: #f9f5d7; }
+  .sssh-property { color: #f9f5d7; }
+  .sssh-comment { color: #ffcc80; }
+  .sssh-string { color: #ef9a9a; }
+  .sssh-string-2 { color: #ffab91; }
+  .sssh-meta { color: #eee; }
+  .sssh-error { color: #cc241d; }
+  .sssh-qualifier { color: #eee; }
+  .sssh-builtin { color: #b39ddb; }
+  .sssh-bracket { color: #e6ee9c; }
+  .sssh-tag { color: #a5d6a7; }
+  .sssh-attribute { color: #40c4ff; }
+  .sssh-header { color: #80cbc4; }
+  .sssh-quote { color: #b0bec5; }
+  .sssh-hr { color: #282828; }
+  .sssh-link { color: #689d6a; }
+  .c-message--dense .c-timestamp__label { color: #689d6a; }
+  .c-message--dense .c-message__content_header .c-custom_status { border-color: #282828; }
+  .dense_theme ts-message { color: #f9f5d7; }
+  .dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp { color: #689d6a; }
+  .dense_theme ts-message .message_content .message_current_status { border-color: #282828; }
+  .c-message--light .c-message__sender .c-message__sender_link { color: #f9f5d7; }
+  .light_theme ts-message { color: #f9f5d7; }
+  .light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover { color: #f9f5d7 !important; }
+  .light_theme ts-message .comment::before { color: #d79921; }
+  .channel_overlay { border-color: #282828; color: #d79921; }
+  .channel_overlay.channel_overlay_redesign .channel_overlay_title { color: #f9f5d7; }
+  .channel_overlay.channel_overlay_redesign li { color: #d79921; }
+  .channel_overlay_title_wrap { border-color: #282828; }
+  .channel_overlay_title_shared { color: #f9f5d7; }
+  pre { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  pre span.mention { padding: 2px 0 !important; }
+  #page pre, body > pre { background: #282828; color: #f9f5d7 !important; }
+  body > pre { background: #ebdbb2; }
+  .special_formatting_quote .quote_bar { background-color: #1d2021; }
+  #threads_msgs_scroller_div { background: #1d2021; }
+  #threads_msgs_scroller_div:not(.loading)::before { background: #1d2021; }
+  #threads_msgs_scroller_div.loading::before { color: #d79921; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #282828; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #1d2021; color: #f9f5d7; }
+  #threads_msgs_scroller_div.loading { background: none; }
+  #threads_msgs_scroller_div.loading::before { color: #f9f5d7; }
+  #threads_view_banner.messages_banner { background: #282828; }
+  #threads_view_banner.messages_banner:hover { background: #1d2021; }
+  #threads_view_banner.messages_banner:hover .clear_unread_messages { background: #1d2021; }
+  #threads_msgs.new_banner_is_showing::before { background: #1d2021; }
+  .p-threads_footer__input .p-message_input_field, .p-threads_footer__input--legacy .p-message_input_field { background: #282828; }
+  .p-threads_footer__input .p-message_input_file_button, .p-threads_footer__input--legacy .p-message_input_file_button { background: #282828; }
+  ts-thread { background: #1d2021; }
+  ts-thread .reply_input_container .inline_message_input_container form textarea { border-color: #282828; color: #f9f5d7; }
+  ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general { background: #282828; border-color: #282828; }
+  ts-thread .thread_messages { background: #282828; border-color: #282828; }
+  ts-thread ts-message.new_reply { background: #1d2021; }
+  ts-thread ts-message.new_reply:hover { background: #282828; }
+  ts-thread .thread_header .thread_channel_name a { color: #f9f5d7; }
+  ts-thread .thread_header .thread_action_btns button { color: #d79921; }
+  ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
+  #convo_tab .thread_participants, ts-thread .thread_participants { color: #d79921; }
+  #convo_loading_indicator { background-image: none; }
+  .reply_input_container .inline_message_input_container .ql-container { background-color: #1d2021; border: 1px solid #282828; }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
+  .reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
+  .reply_input_container .inline_message_input_container .ql-container.focus ~ .emo_menu { color: #f9f5d7; }
+  .reply_input_container .inline_message_input_container .ql-container ~ .emo_menu { color: #d79921; }
+  #file_reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, #reply_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_container_info .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #d79921; }
+  #unread_msgs_scroller_div::after { background: transparent; }
+  #unread_msgs_scroller_div.loading { background-image: none; }
+  #unread_msgs_scroller_div.loading::before { color: #d79921; }
+  #unread_msgs_div .day_divider .day_divider_line { border-top-color: #282828; }
+  .unread_group.marked_as_read .unread_group_header { background: #1d2021; }
+  .unread_group .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+  .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #f9f5d7; }
+  .unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #d79921; }
+  .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #1d2021; }
+  .unread_group.active .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+  .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #d79921; }
+  .mark_as_read_checkmark { color: #d79921; }
+  .bottom_mark_all_read { border-top-color: #282828; }
+  .unread_group_header_name a { color: #f9f5d7; }
+  .unread_group_footer .unread_group_new .unread_group_new_text { color: #d79921; }
+  .unread_group_footer .unread_group_new:hover .unread_group_new_text { color: #d79921; }
+  .unread_empty_state_message { color: #d79921; }
+  .unread_empty_state_undo_inner { background: #282828; color: #f9f5d7; }
+  .unread_empty_state_undo_action { color: #f9f5d7; }
+  .unread_empty_state_refresh { background: rgba(29, 32, 33, 0.97); }
+  .unread_msgs_loading { background: #1d2021; background-image: none; }
+  #col_flex { background: transparent; }
+  #flex_contents { background: #1d2021; }
+  #flex_contents .heading { background: #111313; border-bottom-color: #282828; color: #689d6a; }
+  #flex_contents .heading a { color: #689d6a; }
+  #flex_contents .heading a:hover { color: #cc241d; }
+  #flex_contents .heading a.close_flexpane { color: #689d6a; }
+  #flex_contents .heading .cancel_link { color: #689d6a; }
+  #flex_contents .heading .menu_heading:hover { color: #f9f5d7; }
+  #flex_contents .heading .menu_icon { color: #689d6a; }
+  #flex_contents .heading .menu_icon:hover { color: #cc241d; }
+  #flex_contents .heading_text { color: #689d6a; }
+  #flex_contents .subheading:not(.empty) { background: #1d2021; border-top: 1px solid #282828; color: #d79921; }
+  #flex_contents .subheading:not(.empty) p a { color: #f9f5d7; }
+  #flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down { color: #d79921; }
+  #flex_contents .toolbar_container { background: #1d2021; }
+  #flex_contents .flexpane_tab_bar li .tab, #flex_contents .flexpane_tab_bar li a { color: #689d6a; }
+  #flex_contents .flexpane_tab_bar li:hover { border-bottom: 4px solid #282828; }
+  #flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab { color: #689d6a; }
+  #flex_contents .flexpane_tab_bar li.active { border-bottom: 4px solid #282828; }
+  #flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab { color: #689d6a; }
+  #flex_contents .help { border-top: 5px solid #282828; color: #f9f5d7; }
+  #flex_contents i.callout { color: #d79921; }
+  .close_flexpane { color: #d79921; }
+  .close_flexpane:focus, .close_flexpane:hover { color: #f9f5d7; }
+  #client-ui.flex_pane_showing #col_flex { border-left-color: #282828; }
+  .toolbar_container { background: #1d2021; border-bottom: 1px solid #282828; color: #f9f5d7; }
+  .msg_right_link { color: #689d6a; }
+  .message_location_label { color: #d79921; }
+  .p-flexpane_header { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  #client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #282828; }
+  #details_tab .heading { background: #111313; }
+  #details_tab .heading a.close_flexpane { color: #689d6a; }
+  #details_tab .heading a.close_flexpane:hover { color: #cc241d; }
+  #details_tab hr { border-top-color: #282828; }
+  #details_tab .conversation_details .member_name:hover { color: #d79921; }
+  #details_tab .conversation_details .member_username:hover { color: #f9f5d7; }
+  #details_tab .conversation_details .member_info_timezone { border-top-color: #1d2021; }
+  #details_tab .channel_page_section { background: #1d2021; border-top: 1px solid #282828; }
+  #details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #cc241d; }
+  #details_tab .channel_page_section .section_header a { color: #689d6a; }
+  #details_tab .channel_page_section .section_title { color: #f9f5d7; }
+  #details_tab .channel_page_section .disclosure_triangle { color: #689d6a; }
+  #details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(204, 36, 29, 0.25) !important; }
+  #details_tab .created_by { color: #f9f5d7; }
+  #details_tab .channel_page_member_tabs .icon_member_header { color: #d79921; }
+  #details_tab .pinned_item:hover { border-color: #1d2021; }
+  #details_tab .channel_page_action .leave_link { color: #689d6a; }
+  #details_tab .channel_page_action .leave_link:hover { color: #cc241d; }
+  #details_tab .channel_section_label .ts_icon_info_circle { color: #d79921; }
+  #details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text { color: #d79921; }
+  .channel_page_member_row { color: #f9f5d7; }
+  .channel_page_member_row a { color: #689d6a; }
+  .channel_page_member_row.away { color: #f9f5d7; }
+  .channel_page_member_row.away a { color: #689d6a; }
+  .channel_page_member_row:hover { background-color: #1d2021; border-color: #282828; }
+  .pinned_item { color: #f9f5d7; }
+  .pinned_item .pin_file_title { color: #689d6a; }
+  .pinned_item .pin_member_name a { color: #689d6a !important; }
+  .pinned_item .pin_metadata { color: #d79921; }
+  .pinned_item .remove_pin { color: #689d6a; }
+  .pinned_item .remove_pin:hover { color: #cc241d; }
+  .pinned_item .pinned_message_text .pin_truncate_fade { background: #1d2021; }
+  .pinned_item.delete_mode { border-color: #cc241d !important; }
+  .p-channel_insights .c-member__title { color: #d79921; }
+  .p-channel_insights_activity_bar_container:hover { background-color: rgba(40, 40, 40, 0.05); }
+  .p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #1d2021; }
+  .p-channel_insights__activity { border-color: #1d2021; }
+  .p-channel_insights__activity_bar { background-color: rgba(29, 32, 33, 0.5); }
+  .p-channel_insights__channel .channel_link { color: #f9f5d7; }
+  .p-channel_insights__date_heading span { background-color: #1d2021; color: #f9f5d7; }
+  .p-channel_insights__date_heading::before { background-color: #1d2021; }
+  .p-channel_insights__drawer_title { color: #d79921; }
+  .p-channel_insights__highlights_description { color: #d79921; }
+  .p-channel_insights__item--user .member_preview_link, .p-channel_insights__item--user .message_sender { color: #f9f5d7 !important; }
+  .p-channel_insights__member_count { color: #d79921; }
+  .p-channel_insights__member_count .ts_icon_user { color: #d79921; }
+  .p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #1d2021 90%); }
+  .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #1d2021; }
+  .p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #1d2021; }
+  .p-channel_insights__title { color: #f9f5d7; }
+  .p-channel_insights__user_title { color: #d79921; }
+  .p-download_item { padding: 12px 12px 4px 16px; margin: 0; }
+  .p-download_item__container .p-download_item__name_row { color: #f9f5d7; }
+  .p-download_item__actions { background: #1d2021; }
+  .p-download_item__link--open, .p-download_item__link--retry, .p-download_item__link--show { color: #f9f5d7; }
+  .p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #282828 25%, #282828); color: #f9f5d7; }
+  #file_list_toggle_users { color: #689d6a; }
+  #file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #cc241d; }
+  #file_list_toggle_users.active { color: #d79921; }
+  .file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+  .filetype_button { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+  .filetype_button:hover { background: #ebdbb2; }
+  .filetype_button:hover .file_download_label { background: #1d2021; color: #f9f5d7; }
+  .filetype_button .file_title { color: #f9f5d7; }
+  .filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #1d2021; }
+  a.filetype_button_web { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+  a.filetype_button_web .filetype_icon { background-color: #1d2021; }
+  a.file_download_link { color: #689d6a; }
+  a.file_download_link:hover { color: #cc241d; }
+  a:hover .file_inline_icon { color: #d79921; }
+  a.gsheet img, a.pdf img { background: #1d2021 !important; }
+  html.no_touch a.filetype_button_web:hover { border-color: #1d2021; }
+  html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
+  .file_header_detailed { color: #d79921; }
+  .file_header_detailed .member { color: #f9f5d7 !important; }
+  .file_inline_icon { color: #d79921; }
+  .file_header .member { color: #d79921 !important; }
+  .file_header .title { color: #f9f5d7; }
+  .file_header .title a { color: #689d6a; }
+  .file_header .title a:hover { color: #cc241d; }
+  .flexpane_file_title .member, .flexpane_file_title .service_link { color: #689d6a !important; }
+  .flexpane_file_title .title a, .flexpane_file_title .file_action_list a { color: #689d6a; }
+  .flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover { color: #cc241d; }
+  .file_actions_cog { color: #689d6a !important; }
+  .file_actions_cog:hover { color: #cc241d !important; }
+  .file_list_item { color: #f9f5d7; }
+  .file_list_item a { color: #689d6a; }
+  .file_list_item a.member { color: #cc241d; }
+  .file_list_item .bullet { color: #d79921; }
+  .file_list_item .icon { background: #ebdbb2; border-color: #1d2021; }
+  .file_list_item .ts_icon_comment { color: #d79921; }
+  .file_list_item .file_comment_link:hover { color: #689d6a; }
+  .file_list_item .file_comment_link:hover .ts_icon_comment { color: #d79921; }
+  .file_list_item .title a { color: #689d6a; }
+  .file_list_item .share_info .unshare_link { color: #689d6a; }
+  .file_list_item .share_info .unshare_link:hover { color: #cc241d; }
+  .file_list_item .actions a, .file_list_item .actions span { background-color: #282828; border: 1px solid #ebdbb2; color: #689d6a; }
+  .file_list_item .actions a:hover { background-color: #1d2021 !important; border-color: #ebdbb2; color: #cc241d; }
+  .file_list_item.post .preview, .file_list_item.space .preview { color: #f9f5d7; }
+  .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #1d2021; }
+  .file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #689d6a; }
+  .file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
+  .file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #282828; }
+  .unshare_link { color: #689d6a !important; }
+  .unshare_link i::before { color: #d79921 !important; }
+  .unshare_link i.ts_icon_minus_circle_small:hover::before { color: #cc241d !important; }
+  .snippet_preview pre { color: #f9f5d7; }
+  .file_preview_wrapper .file_preview { background: #1d2021; }
+  .file_preview_wrapper .file_preview:hover { background: #282828; }
+  #file_preview_container .file_meta { color: #d79921; }
+  .file_page_meta { color: #d79921; }
+  #file_page_preview img { background: #1d2021; border: 1px solid #282828; }
+  #file_page_preview img:hover { background: #282828; }
+  .comment_meta { color: #d79921; }
+  .comment .special_formatting_quote .content { color: #f9f5d7; }
+  .comment .member { color: #f9f5d7 !important; }
+  .comment_body { color: #f9f5d7; }
+  .comment_actions { color: #d79921; }
+  .comment_actions:hover { color: #f9f5d7; }
+  .icon_quote { color: #f9f5d7; }
+  .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #282828; }
+  .tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #1d2021; }
+  .tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #282828; }
+  .tab_container .star_item ts-message .timestamp { color: #d79921; }
+  .tab_container .file_list_item:focus, .tab_container .file_list_item:hover { background-color: #1d2021; border-color: #282828; }
+  .tab_container .file_list_item .star { color: #d79921; }
+  .tab_container .file_list_item .contents .file_comment_link { color: #689d6a; }
+  .tab_container .file_list_item .contents .file_comment_link .ts_icon { color: #689d6a; }
+  .tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover { color: #cc241d; }
+  .tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon { color: #cc241d; }
+  .tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #d79921; }
+  .tab_container .file_list_item .filetype_image { background-color: #282828; }
+  .active .tab_container .file_list_item { background-color: #1d2021; }
+  .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #1d2021; border-color: #282828; color: #fff; }
+  .c-file__meta { color: #f9f5d7; }
+  .c-file__slide--meta { background-color: #282828; }
+  .p-file_details__name, .p-file_details__share_channel { color: #f9f5d7; }
+  .p-file_details__meta_container .c-file__action_button { color: #fff; }
+  .c-pillow_file_container { background-color: #282828; }
+  .c-pillow_file_container .c-pillow_file__swap .c-pillow_file__slide { background-color: #282828; }
+  .c-pillow_file__description, .c-pillow_file__title { color: #f9f5d7; }
+  .p-file_list, .p-file_list__filters { background: #282828; }
+  .p-file_list__filters { border-color: #282828; }
+  .p-file_list__file.c-pillow_file_container, .p-file_list__file.c-pillow_file_container--full_width { background: #282828; border-color: #282828; color: #f9f5d7; }
+  .p-file_list__file.c-pillow_file_container--full_width:hover { background: #1d2021; border-color: #1d2021; }
+  .p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021 25%, #1d2021); color: #f9f5d7; }
+  .p-download_item__container .p-download_item__actions { background-color: #1d2021; }
+  .p-download_item__container .p-download_item__link__open, .p-download_item__container .p-download_item__link__retry, .p-download_item__container .p-download_item__link__show { color: #689d6a; }
+  .p-download_item__container .p-download_item__name_row { color: #f9f5d7; }
+  #user_groups_pane .mention { background: rgba(204, 36, 29, 0.25); border: 0; border-radius: 3px; padding: 2px; }
+  #user_groups_container .info_panel { background: #1d2021; border: 1px solid #1d2021; }
+  #user_groups_container .mention { background-color: rgba(204, 36, 29, 0.25) !important; }
+  #user_groups_header .user_groups_search .icon_search { color: #d79921; }
+  #user_groups_header a.icon_close { color: #689d6a; }
+  #user_groups_header a.icon_close:hover { color: #cc241d; }
+  .user_group_item { border-bottom: 1px solid #1d2021; }
+  .user_group_item a { color: #689d6a; }
+  #flex_contents .user_group_item:hover { background-color: #1d2021; }
+  #flex_contents .user_group_item:hover h4 { color: #f9f5d7; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit { background-color: #1d2021; }
+  #flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button { color: #f9f5d7; }
+  .user_group_invite_member_small .add_icon { color: #d79921; }
+  #user_group_member_invite_div .disabled .lfs_item.lfs_token { background-color: #ebdbb2; border-color: #ebdbb2; }
+  #flex_contents .subheading:not(.empty)#mentions_options { background-color: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+  .mention_day_container_div .day_divider::before { background: none; border-color: #282828; }
+  #member_mentions h3 a { color: #689d6a; }
+  a.internal_member_link { background: #282828; color: #f9f5d7; }
+  a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+  a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #282828; color: #f9f5d7; }
+  .mention_rxn .mention_rxn_summary { color: #f9f5d7; }
+  .mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #d79921; }
+  .search_message_result { background: #1d2021 !important; border-color: #282828 !important; color: #f9f5d7 !important; }
+  .search_message_result .search_message_result_meta { color: #d79921; }
+  .search_message_result .search_message_result_meta a { color: #689d6a; }
+  .search_message_result .search_message_result_meta .date_links a { color: #689d6a; }
+  .search_message_result_text .result_msg_format a { color: #689d6a; }
+  span.match { background: rgba(204, 36, 29, 0.25); }
+  #search_filters .tab { background: #1d2021; color: #f9f5d7; }
+  #search_filters .tab:hover { border-bottom: 4px solid #282828; }
+  #search_filters.files #filter_files, #search_filters.messages #filter_messages { border-bottom: 4px solid #282828; color: #f9f5d7; }
+  #search_file_list_toggle_users.active:hover { border: 2px solid #cc241d; color: #cc241d !important; }
+  .no_results { color: #f9f5d7; }
+  #search_results_team .team_results_heading { color: #f9f5d7; }
+  #search_results_team .team_result { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  #search_results_team .team_result a { color: #689d6a; }
+  #search_results_team .team_result:hover a { color: #cc241d; }
+  #search_results_team .team_result a:hover { color: #cc241d; }
+  #search_results_team .member_name { color: #f9f5d7 !important; }
+  .suggestion { color: #f9f5d7; }
+  .suggestion.active, .suggestion:hover { background: #1d2021; }
+  #paging_in_options .search_paging { color: #d79921; }
+  #search_results_items .search_paging { color: #f9f5d7; }
+  .search_paging i.disabled { color: #d79921; }
+  .search_paging a { color: #689d6a; }
+  .search_paging a:hover { color: #cc241d; }
+  .search_sort_prefix { color: #f9f5d7; }
+  .search_segmented_control { border-color: #282828; color: #689d6a !important; }
+  .search_segmented_control:hover { color: #cc241d !important; }
+  .search_segmented_control.active { background: #282828; color: #cc241d !important; }
+  .search_result_with_extract { background: #282828; border-color: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+  .search_result_with_extract:hover { border-color: #ebdbb2; }
+  .search_result_for_context::after { background: rgba(29, 32, 33, 0.1); }
+  .extract_expand_text, .extract_expand_icons { color: #689d6a; }
+  .search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #cc241d; }
+  .search_module_header { color: #f9f5d7; }
+  .search_module_footer { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+  .search_module_footer p { color: #f9f5d7; }
+  .search_module_footer #see_more { color: #f9f5d7; }
+  .search_module_footer #see_more a { color: #f9f5d7; }
+  .search_module_footer .top_results_feedback a { color: #f9f5d7; }
+  .search_module_footer ts-icon { color: #f9f5d7; }
+  .top_results_search_message_result { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+  .top_results_search_message_result.duplicate { background-color: #282828; }
+  .top_results_search_message_result .timestamp { color: #d79921; }
+  .top_results_search_message_result .channel { color: #d79921; }
+  .top_results_search_message_result .channel a { color: #d79921; }
+  .top_results_search_message_result .jump { color: #f9f5d7; }
+  .top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #1d2021 !important; }
+  .top_results_search_message_result:first-child { border-top: 2px solid #1d2021; }
+  .sli_expert_search { background-color: #1d2021; color: #f9f5d7; }
+  .sli_expert_search__result { border-color: #1d2021; }
+  .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #f9f5d7 !important; }
+  .sli_expert_search__fg_face::before { background-color: #1d2021; }
+  .sli_expert_search_cta { border-color: #1d2021; }
+  .sli_expert_search_cta:hover { border-color: #ebdbb2; }
+  .sli_expert_search_cta__text { color: #f9f5d7; }
+  .sli_expert_search_cta__text:hover { color: #f9f5d7; }
+  .sli_expert_search__plus_sign_overlay { background-color: #282828; color: #d79921; }
+  .sli_expert_search__arrow { color: #d79921; }
+  .sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #d79921; }
+  .sli_expert_search__partial_terms { color: #d79921; }
+  .feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #282828; color: #f9f5d7; }
+  .feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #d79921; }
+  .feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #d79921; }
+  .feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #f9f5d7; }
+  .feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #f9f5d7; }
+  .feature_sli_file_search #search_results.all { background-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #d79921; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #ebdbb2; }
+  .feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #ebdbb2; }
+  .feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.files { background-color: #1d2021; }
+  .feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #f9f5d7; }
+  .feature_sli_file_search #search_results_loading { background-color: #1d2021; }
+  .feature_sli_file_search #search_results_container #search_options { background-color: #1d2021; }
+  .feature_sli_file_search #search_results_container .heading { background-color: #1d2021; }
+  #client-ui .file_list_item.file_list_item--redesign { border-color: #1d2021; }
+  #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #d79921; }
+  #client-ui .file_list_item.file_list_item--redesign .message_sender { color: #d79921; }
+  .p-shortcuts_flexpane__shortcut { border-color: #282828; }
+  .p-shortcuts_flexpane__shortcut:last-of-type { border-bottom-color: #282828; }
+  .p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title { color: #f9f5d7; }
+  .p-shortcuts_flexpane__shortcut_title { color: #d79921; }
+  .p-shortcuts_flexpane__title { color: #f9f5d7; }
+  .p-shortcuts_flexpane__tip { color: #d79921; }
+  .p-shortcuts_flexpane__section_description { color: #d79921; }
+  .p-shortcuts_flexpane__sub_heading { color: #d79921; }
+  .c-keyboard_key { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
+  .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #d79921; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #689d6a; }
+  #member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #cc241d; }
+  #member_preview_scroller .member_data_table a, #team_list .member_data_table a { color: #689d6a; }
+  #member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover { color: #cc241d; }
+  #member_preview_scroller a.member_action_button, #team_list a.member_action_button { color: #689d6a !important; }
+  #member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover { border-color: #ebdbb2 !important; color: #cc241d !important; }
+  #member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr { color: #f9f5d7; }
+  #member_preview_scroller .member_data_table a, #member_preview_web_container .member_data_table a, #team_list .member_data_table a, .menu_member_header .member_data_table a { color: #689d6a !important; }
+  #member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover { color: #cc241d !important; }
+  #member_preview_scroller .member_data_table .bot_label, #member_preview_web_container .member_data_table .bot_label, #team_list .member_data_table .bot_label, .menu_member_header .member_data_table .bot_label { background: #282828; color: #d79921; }
+  #member_preview_scroller { background-color: #282828; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover { border-color: #282828; }
+  #member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder { color: rgba(249, 245, 215, 0.35) !important; }
+  #team_tab #member_preview_scroller { background-color: #1d2021; }
+  #team_tab #member_preview_scroller .member_details .member_name { color: #f9f5d7; }
+  #member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name { color: #f9f5d7; }
+  #member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title { color: #f9f5d7; }
+  #member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status { color: #d79921; }
+  #member_preview_scroller .member_details .member_restriction a, #member_preview_scroller .member_details .member_timezone_value a, #member_preview_scroller .member_details .member_current_status a, #member_preview_web_container .member_details .member_restriction a, #member_preview_web_container .member_details .member_timezone_value a, #member_preview_web_container .member_details .member_current_status a, .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a, .menu_member_header .member_details .member_current_status a { color: #689d6a; }
+  #member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover { color: #cc241d; }
+  #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover { color: #689d6a; }
+  #member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider { border-color: #282828; }
+  #disabled_members_tab a { color: #689d6a; }
+  #disabled_members_tab a:hover { background: #282828; color: #cc241d; }
+  #disabled_members_tab.active a { color: #689d6a; }
+  .team_list_item { border-top: 1px solid #1d2021; color: #689d6a; }
+  .team_list_item .member_name { color: #f9f5d7; }
+  #client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #f9f5d7 !important; }
+  #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #282828 !important; }
+  #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #1d2021 !important; }
+  #client-ui .searchable_member_list .team_list_item { border-bottom-color: #282828; }
+  #client-ui .searchable_member_list .team_list_item:hover { background: #1d2021; }
+  .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #f9f5d7 !important; }
+  #convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #f9f5d7; }
+  #convo_tab textarea.message_input { color: #f9f5d7; }
+  #reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea { border-color: #282828; color: #f9f5d7; }
+  #reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus { border-color: #282828; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container { color: #f9f5d7; }
+  #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container ts-icon.ts_icon_question_circle { color: #d79921 !important; }
+  #reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general { background: #1d2021; color: #d79921; }
+  #convo_container .convo_flexpane_divider { border-top-color: #282828; color: #d79921; }
+  #convo_container .convo_flexpane_divider .reply_count { background: #1d2021; }
+  #convo_container ts-conversation ts-message.selected .message_content .thread_channel_link { color: #689d6a; }
+  #convo_tab .message_input, #convo_tab textarea#msg_text { color: #f9f5d7; }
+  ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) { background-color: #222222; }
+  ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover { background-color: #222222; }
+  #whats_new_tab p { color: #f9f5d7; }
+  #whats_new_tab .flex_heading_controls label { color: #d79921; }
+  .c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #f9f5d7; }
+  .c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #f9f5d7; }
+  .c-member .external_team_badge { background-color: #1d2021; box-shadow: 0 0 0 2px #1d2021; }
+  .c-member .external_team_badge.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #1d2021; }
+  .c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #f9f5d7; }
+  .c-member--small .presence { color: #d79921; }
+  .c-member--small .team_image.icon_16 { border-color: #282828; }
+  .c-member--small .team_image.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .c-member--dark .c-member__current-status { color: #d79921; }
+  .c-member--dark .c-member__current-status::before { color: #d79921; }
+  .c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name { color: #d79921; }
+  .c-member--dark .c-member__display-name, .c-member--dark .presence { color: #f9f5d7; }
+  .c-member--medium { color: #d79921; }
+  .c-member--medium .presence { color: #d79921; }
+  .c-member__secondary-name--medium { color: #f9f5d7; }
+  .c-member--large { color: #d79921; }
+  .c-member__display-name--large, .c-member__title--large { color: #f9f5d7; }
+  .c-member__other-names--large { color: #d79921; }
+  .c-usergroup--small .c-usergroup__icon { background-color: #d79921; color: #f9f5d7; }
+  .c-usergroup__not-in-channel-context--small { color: #d79921; }
+  .p-emoji_picker { background: #282828 !important; color: #f9f5d7 !important; }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker[data-using-keyboard="true"] .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__list_item { text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .p-emoji_picker__list_item[data-color-index="0"]:hover, .p-emoji_picker__list_item[data-color-index="0"].key_selection { background: rgba(183, 232, 135, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="1"]:hover, .p-emoji_picker__list_item[data-color-index="1"].key_selection { background: rgba(181, 224, 254, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="2"]:hover, .p-emoji_picker__list_item[data-color-index="2"].key_selection { background: rgba(249, 239, 103, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="3"]:hover, .p-emoji_picker__list_item[data-color-index="3"].key_selection { background: rgba(243, 193, 253, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="4"]:hover, .p-emoji_picker__list_item[data-color-index="4"].key_selection { background: rgba(255, 225, 174, 0.5); }
+  .p-emoji_picker__list_item[data-color-index="5"]:hover, .p-emoji_picker__list_item[data-color-index="5"].key_selection { background: rgba(224, 223, 255, 0.5); }
+  .p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container { background: #1d2021; }
+  .p-emoji_picker__group_tabs { border-bottom-color: #282828; }
+  .p-emoji_picker__group_tab { color: #689d6a; }
+  .p-emoji_picker__group_tab:hover { background: #282828; color: #cc241d; }
+  .p-emoji_picker__group_tab--active { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+  .p-emoji_picker__icon_search { color: #d79921; }
+  .p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #1d2021; border-color: #1d2021; }
+  .p-emoji_picker__skintone_options { background: #1d2021; }
+  .p-emoji_picker__tip i, .p-emoji_picker__no_results i { color: #d79921; }
+  .p-emoji_picker__tip { color: #f9f5d7; }
+  .p-emoji_picker__no_results { color: #d79921; }
+  .p-emoji_picker__preview_text { background: #282828; color: #f9f5d7; }
+  .p-emoji_picker__footer { background: #282828; border-top-color: #282828; }
+  .p-emoji_picker__footer .p-emoji_picker__heading { background: #282828; }
+  .p-emoji_picker__emoji_deluxe_label { color: #d79921; }
+  input[type="text"].p-emoji_picker__input:focus { border-color: #1d2021; box-shadow: none; }
+  #message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #d79921; }
+  #message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #f9f5d7; }
+  #message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #f9f5d7; }
+  #message_edit_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus ~ .emo_menu, #msg_form .message_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus ~ .emo_menu, .current_status_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus ~ .emo_menu, .current_status_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus ~ .emo_menu, .inline_message_input_container .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus ~ .emo_menu, .share_channel_modal_contents .message_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus ~ .emo_menu { color: #f9f5d7; }
+  .current_status_emoji_picker { border-right-color: #282828; }
+  .current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #282828; }
+  .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #d79921; }
+  .rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #1d2021; }
+  .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #282828; }
+  .rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #f9f5d7; }
+  .rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(40, 40, 40, 0.08); border-color: rgba(235, 219, 178, 0.4) !important; }
+  .rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count { color: #f9f5d7; }
+  .rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count { color: #f9f5d7; }
+  .rxn.menu_rxn .ts_icon, .c-reaction.menu_rxn .ts_icon, .c-reaction_add.menu_rxn .ts_icon, .c-member_slug.menu_rxn .ts_icon { color: rgba(249, 245, 215, 0.25); }
+  a.c-member_slug--mention, a.c-member_slug--mention:hover { background-color: #d79921; color: #282828; }
+  .modal { background-color: #1d2021; border: 0; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  .modal .close, .modal label { color: #f9f5d7; }
+  .modal_input_note, .modal_input_note_full_width, .input_note_special { color: #d79921; }
+  .modal-footer { background: padding-box #1d2021; border-top: 1px solid transparent; box-shadow: none; }
+  .modal-header { background: padding-box #282828; border-bottom: 1px solid #282828; color: #f9f5d7; }
+  .modal-backdrop { background-color: #1d2021; }
+  .close { color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  #fs_modal_bg { background: #1d2021; }
+  #fs_modal { background: #1d2021; }
+  #fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 { color: #f9f5d7; }
+  #fs_modal #fs_modal_sidebar a { color: #f9f5d7; }
+  #fs_modal #fs_modal_sidebar a:hover { background: #282828; }
+  #fs_modal #fs_modal_sidebar a.active { background: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #fs_modal .fs_modal_btn { color: rgba(249, 245, 215, 0.5); }
+  #fs_modal .fs_modal_btn:hover { background: #ebdbb2; color: #f9f5d7; }
+  #fs_modal .fs_modal_btn:active { background: #ebdbb2; color: #f9f5d7; }
+  #fs_modal.fs_modal_header .fs_modal_btn:active { color: #f9f5d7; }
+  #fs_modal #fs_modal_footer { background-color: #282828; }
+  .p-apps_browser__apps_list--loading::before { background-color: #282828; }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #1d2021; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #282828; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
+  .p-apps_browser__category_header { background: #1d2021; color: #d79921; }
+  .p-apps_browser__app { border-top-color: #1d2021; }
+  .p-apps_browser__app--selected { background: #282828; border-color: #ebdbb2; }
+  .p-apps_browser__app_info { color: #f9f5d7; }
+  .p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #ebdbb2; color: #f9f5d7; }
+  .p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__app_description { color: #d79921; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a { color: #d79921; }
+  #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:active, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:hover, #fs_modal.p-apps_browser_modal .contents_container .contents .links_container a:visited { color: #f9f5d7; }
+  #incoming_call { background-color: rgba(40, 40, 40, 0.97); color: #f9f5d7; }
+  #fs_modal.channel_options_modal .channel_options_header { border-bottom-color: #282828; }
+  #fs_modal.channel_options_modal .convert_to_shared label { color: #d79921; }
+  #fs_modal.channel_options_modal .channel_option_item { border-top-color: #282828; }
+  #fs_modal.channel_options_modal .channel_option_item .channel_option_open { color: #f9f5d7; }
+  #fs_modal.channel_options_modal .channel_option_item:hover { background: rgba(40, 40, 40, 0.75); border-color: #282828; }
+  #channel_invite_container .lfs_list_container .lfs_item { border-top-color: #282828; }
+  #channel_invite_container .lfs_list_container .lfs_item.active { border-color: #282828; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row { border-top-color: #282828; }
+  #channel_invite_container.page_needs_enterprise .channel_invite_row.disabled { color: #d79921; }
+  #channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) { background: #1d2021; border-color: #282828; }
+  #channel_prefs_dialog { color: #f9f5d7; }
+  #at_channel_warning_dialog { background-color: #1d2021; }
+  #at_channel_warning_dialog.fullsize { background-color: #1d2021; }
+  #at_channel_warning_dialog.fullsize .modal-body { background-color: #1d2021; }
+  .channel_prefs_modal_header { color: #f9f5d7; }
+  .channel_prefs_body__section_header_title { color: #f9f5d7; }
+  .channel_prefs_body__section_header_icon::before { color: #f9f5d7; }
+  .channel_prefs_body__mute_help_text { color: #d79921; }
+  .channel_prefs_notifications_table { border-bottom-color: #282828; color: #f9f5d7; }
+  .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #1d2021 !important; }
+  .channel_prefs__muting_checkbox_label { color: #f9f5d7; }
+  .channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #f9f5d7 !important; }
+  .notification_prefs_icon::before { color: #f9f5d7; }
+  .channel_modal_header { color: #f9f5d7; }
+  #channel_browser .channel_browser_row { border-top: 1px solid #282828; color: #f9f5d7; }
+  #channel_browser .channel_browser_row_header { color: #f9f5d7; }
+  #channel_browser .channel_browser_creator_name { color: #d79921; }
+  #channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #d79921; }
+  #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #1d2021; }
+  #channel_browser .channel_browser_divider { background: transparent; color: #d79921; }
+  #channel_browser .channel_browser_sort_container::after { color: #f9f5d7; }
+  #channel_browser .channel_browser_channel_purpose { color: #f9f5d7; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #689d6a; }
+  .channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #d79921 !important; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #282828; color: #f9f5d7; }
+  #invite_members_container .lfs_input_container { background: #1d2021; }
+  #notifications_not_working p.highlight_yellow_bg a { color: #f9f5d7; }
+  .c-dialog__header { background: #282828; }
+  .c-dialog__header .c-dialog__title, .c-dialog__header .c-dialog__close { color: #f9f5d7; }
+  .c-dialog__header .c-dialog__close:hover { color: #689d6a; }
+  .c-dialog__body { background: #222222; }
+  .c-dialog__body .p-share_dialog_message_input { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+  .c-dialog__body .p-share_dialog_message_input.focus { border-color: #1d2021; box-shadow: unset; }
+  .c-dialog__body .p-file_upload_dialog__preview, .c-dialog__body .p-file_upload_dialog__preview_image { background-color: #282828; border-color: #282828; }
+  .c-dialog__body input.c-input_text { border-color: #282828; }
+  .c-dialog__body input.c-input_text .c-input_character_count { background-color: #282828; color: #f9f5d7; }
+  .c-dialog__body input.c-input_text:focus { border-color: #1d2021; box-shadow: unset; }
+  .c-dialog__footer { background: #222222; }
+  .c-dialog__footer .c-button { background-color: #1d2021; color: #f9f5d7; }
+  .c-dialog__footer .p-file_upload_dialog__footer_share_inputs { color: #f9f5d7; }
+  #im_browser .im_browser_row { border-top: 1px solid #1d2021; }
+  #im_browser .im_browser_row.multiparty { color: #f9f5d7; }
+  #im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #282828; }
+  #im_browser .im_browser_row .im_unread_cnt { background: #cc241d; color: #f9f5d7; }
+  #im_browser .im_browser_row.disabled { color: #d79921; }
+  #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #1d2021 !important; }
+  #im_browser_tokens { background: #1d2021; border: 1px solid #ebdbb2; }
+  #im_browser_tokens.active { border-color: #ebdbb2; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
+  #im_browser_tokens .member_token { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  #im_browser_tokens .member_token.ra { background: #cc241d; }
+  .fs_modal_file_viewer_header { background-color: #282828; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5); }
+  .fs_modal_file_viewer_header .btn { color: #f9f5d7; }
+  .fs_modal_file_viewer_header .star { color: #d79921; }
+  .fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #f9f5d7; }
+  .fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #f9f5d7; }
+  .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #d79921; }
+  .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #1d2021; }
+  .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #d79921; }
+  .fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #1d2021; }
+  .fs_modal_file_viewer_content .viewer { background-color: #282828; color: #f9f5d7 !important; }
+  .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #1d2021; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(235, 219, 178, 0.25); color: #f9f5d7; }
+  .fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(215, 153, 33, 0.8); }
+  .fs_modal_file_viewer_content .aside_panel { background-color: #1d2021; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .comment_header { background-color: transparent; border-bottom: 1px solid #282828; }
+  .fs_modal_file_viewer_content .no_comment { background-color: #1d2021; color: #d79921; }
+  .fs_modal_file_viewer_content .aside_close_btn { color: #f9f5d7; }
+  .fs_modal_file_viewer_content #file_comment { color: #f9f5d7; }
+  #file_comment_textarea.texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  #file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #282828; }
+  #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #d79921; }
+  #fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #1d2021; }
+  #fs_modal.help_modal .help_modal_header a { color: #f9f5d7; }
+  #fs_modal.help_modal .help_modal_divider { color: #d79921; }
+  #fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #282828; }
+  #fs_modal.help_modal .help_modal_article_row .channel_browser_open { color: #d79921; }
+  #fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted { background-color: #282828; border-color: #282828; }
+  .admin_invites_account_type_option { border-bottom: 1px solid #282828; }
+  .admin_invites_account_type_option p { color: #f9f5d7; }
+  .admin_invites_account_type_option .option_arrow { color: #d79921; }
+  .admin_invites_account_type_option:hover:not(.disabled) h3 { color: #f9f5d7; }
+  .admin_invites_account_type_option.disabled .account_type_disabled_hover { background: rgba(255, 255, 255, 0); }
+  .admin_invites_account_type_option.disabled:hover .account_type_disabled_hover { background: rgba(29, 32, 33, 0.95); }
+  .admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message { color: #d79921; }
+  .admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #cc241d; }
+  .admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(204, 36, 29, 0.4); }
+  #admin_invites_channel_picker_container { border-bottom: 1px solid #282828; }
+  #admin_invites_add_row { background: #1d2021; border: 1px solid #282828; }
+  #admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #1d2021; }
+  #channel_invite_tokens { background-color: #1d2021; border-color: #ebdbb2; }
+  #channel_invite_tokens.active { border-color: #d79921; box-shadow: 0 0 7px rgba(215, 153, 33, 0.15); }
+  #channel_invite_tokens .member_token { background: #1d2021; color: #f9f5d7; }
+  #channel_invite_tokens .member_token.ra { background: rgba(204, 36, 29, 0.4); }
+  #admin_invites_alert { background: #1d2021; border-color: #ebdbb2; }
+  .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #f9f5d7; }
+  .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #1d2021; color: #f9f5d7; }
+  #shortcuts_dialog { background: rgba(29, 32, 33, 0.95); text-shadow: 0 1px 1px rgba(40, 40, 40, 0.7); }
+  #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #f9f5d7; }
+  #shortcuts_dialog.modal ul ul { border-left-color: #1d2021; }
+  #shortcuts_dialog.modal .info_block { color: #d79921; }
+  #shortcuts_dialog.modal .close { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+  #shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(40, 40, 40, 0.9); }
+  #fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #d79921; }
+  #fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label { border: 1px solid #282828; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch { border: 1px solid #282828; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick { background: #282828; border: 1px solid #282828; }
+  #fs_modal.prefs_modal #prefs_sidebar #prefs_sidebar_theme::after { background: #cc241d; border-radius: 3px; content: "Light sidebar themes (e.g. Hoth) will break this Stylish theme."; display: block; font-size: 14px; line-height: 18px; margin: 12px 0 6px; padding: 6px; width: 100%; }
+  #fs_modal.prefs_modal legend { color: #f9f5d7; }
+  #fs_modal.prefs_modal .global_notification_block { background: #1d2021; border-color: #282828; }
+  #fs_modal.prefs_modal .global_notification_block.selected { background: #282828; border-color: #282828; }
+  #fs_modal.prefs_modal .channel_overrides_row { border-top-color: #282828; }
+  #fs_modal.prefs_modal .channel_overrides_row:hover { background: #282828; border-color: #282828; }
+  #fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary { color: #f9f5d7; }
+  #fs_modal.prefs_modal .notification_example.mac { background: #282828; box-shadow: 0 1px 8px 2px #282828; }
+  #fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows { background: #282828; color: #f9f5d7; }
+  #fs_modal.prefs_modal .badge_example { background: #cc241d; }
+  #fs_modal.prefs_modal .message_theme_preview { border-bottom-color: #282828; border-top-color: #282828; }
+  #fs_modal.prefs_modal .display_real_names_block_sample { background: #1d2021; }
+  .sidebar_menu_list_item { border: 0; color: #f9f5d7; }
+  .sidebar_menu_list_item.is_active { background-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .sidebar_menu_list_item:not(.is_active):hover { background-color: #282828; }
+  .jumbomoji_pref_disabled { color: #d79921; }
+  .jumbomoji_disabled_note { color: rgba(215, 153, 33, 0.6); }
+  #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #1d2021; border: 1px solid #282828; }
+  #edit_team_profile_container .lazy_filter_select.disabled { background: #1d2021; }
+  #edit_team_profile_container .lazy_filter_select.disabled input { background: #1d2021; }
+  #edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #282828; }
+  #edit_team_profile_list .row:nth-last-child(2):hover { border-color: #282828 !important; }
+  #edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #282828; border: 1px solid #282828; }
+  #edit_team_profile_list .row:nth-child(n+5).active .edit_team_profile_list_controls i.ts_icon_cog_o { color: #d79921; }
+  #edit_team_profile_list .edit_team_profile_list_controls i { color: #f9f5d7; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #d79921; }
+  #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #d79921; }
+  #edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #1d2021; }
+  #edit_team_profile_add .row:last-child { border-bottom: 1px solid #1d2021; }
+  #edit_team_profile_add .row:not(.header_row):hover { background: #282828; border: 1px solid #282828; }
+  #edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #f9f5d7; }
+  #edit_team_profile_add .row:not(.header_row):hover i { border-color: #282828; color: #f9f5d7; }
+  #edit_team_profile_add i { color: #d79921; }
+  #edit_team_profile_edit .profile_field_preview_protector label.select::after, #edit_team_profile_edit .profile_field_preview_protector label.select:hover::after { color: #d79921; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i { border: 1px solid #282828; }
+  #edit_team_profile_edit .row.option_row.show_remove_action i:hover { background-color: #cc241d; border-color: #cc241d !important; color: #f9f5d7; }
+  #edit_team_profile_edit .row i { border: 1px solid #282828; color: #f9f5d7; }
+  #edit_team_profile_custom .row .col .profile_field_preview { background: #282828; border: 2px solid #282828; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #282828; }
+  #edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #d79921; }
+  #edit_team_profile_custom .row .col input { background: #1d2021; border: 1px solid #282828; }
+  #edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #d79921; }
+  #edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #282828; }
+  .profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #1d2021; }
+  .profile_field_preview_protector .profile_field_preview::after { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview::before { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
+  .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #1d2021; color: #d79921; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #282828, rgba(255, 255, 255, 0)); }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #282828; }
+  .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #282828 transparent transparent; }
+  ts-jumper ts-jumper-container { background: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5); }
+  ts-jumper ts-jumper-help, ts-jumper .p-jumper__help { background: #1d2021; color: #d79921; }
+  ts-jumper input[type=text] { border: 1px solid #282828 !important; color: #f9f5d7; }
+  ts-jumper input[type=text]:focus { border: 1px solid rgba(40, 40, 40, 0.8) !important; color: #f9f5d7; }
+  ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder { color: #f9f5d7; }
+  ts-jumper ol li { color: #f9f5d7; }
+  ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username { color: #d79921; }
+  ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper ol li .member_real_name + .member_username, ts-jumper ol li .member_username + .member_real_name, ts-jumper ol li ts-icon { color: #d79921; }
+  ts-jumper ol li .unread_count { background: #cc241d; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  ts-jumper ol li.highlighted { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+  ts-jumper ol:not(.keyboard_active) li:hover { background: #ebdbb2 !important; color: #f9f5d7 !important; }
+  ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name + .member_username, ts-jumper ol li.highlighted .member_username + .member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name + .member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username + .member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon { color: #f9f5d7; }
+  .basic_share_dialog .share_dialog_divider { border-top-color: transparent; }
+  .share_dialog_attachment_container { color: #f9f5d7; }
+  #share_dialog .file_list_item { border-color: #282828; }
+  #generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #d79921; }
+  #share_dialog_input_container #file_comment_textarea.ql-container { border-color: #282828; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #1d2021; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #f9f5d7; }
+  .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #1d2021; }
+  .ts_tip .ts_tip_tip { color: #f9f5d7; }
+  .ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #1d2021; }
+  .ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #1d2021; }
+  .ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #1d2021; }
+  .ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #1d2021; }
+  .ts_tip.success .ts_tip_tip { background: #ebdbb2; }
+  .ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #ebdbb2; }
+  .ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #ebdbb2; }
+  .ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #ebdbb2; }
+  .ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #ebdbb2; }
+  .c-tooltip__tip { background-color: #1d2021; color: #f9f5d7; }
+  .c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+  .c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+  .c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #1d2021; }
+  .c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #1d2021; }
+  .c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+  .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+  .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
+  .c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #1d2021; }
+  .c-tooltip__tip--success { background-color: #98971a; }
+  .c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #98971a; }
+  .c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #98971a; }
+  .c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #98971a; }
+  .c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #98971a; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #1d2021; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #1d2021; }
+  #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(235, 219, 178, 0.5) !important; }
+  #coachmark_interior { color: #f9f5d7; }
+  #coachmark_interior .coachmark_close_btn { color: #f9f5d7; }
+  .menu_member_header { background: #282828; }
+  .menu_member_header .member_details .member_name_and_presence { color: #f9f5d7; }
+  .menu_member_header .member_details .member_name_and_presence .member_name { color: #f9f5d7; }
+  .menu_member_header .member_details .member_name_and_presence .presence.away { color: #fff; }
+  .menu_member_header .member_details .member_title { color: #d79921; }
+  .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #d79921; }
+  .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #689d6a; }
+  .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #cc241d; }
+  .menu_member_header .member_details_divider { border-color: #1d2021; }
+  .menu_member_footer { background: #282828; border-top: 1px solid #1d2021; }
+  .menu_member_footer p { color: #d79921; }
+  .menu_member_footer #menu_member_dm_input p { color: #f9f5d7; }
+  .member_meta { color: #689d6a; }
+  .mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver { color: #f9f5d7 !important; }
+  .greigh, .sky_blue, .severe_grey, .havana_blue, .burnt_violet, .plastic_grey, .cloud_silver, .sk_dark_gray, .sk_dark_grey, .subtle_silver, .old_petunia_grey { color: #d79921 !important; }
+  .clear_blue { color: #689d6a !important; }
+  .moscow_red, .yolk_orange, .mustard_yellow, .candy_red_on_hover:hover, .moscow_red_on_hover:hover { color: #cc241d !important; }
+  .seafoam_green { color: #98971a !important; }
+  .candy_red_bg { background-color: #cc241d !important; }
+  .off_white_bg, .neutral_white_bg { background-color: #282828 !important; }
+  .yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #282828 !important; }
+  .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #1d2021 !important; }
+  .sk_black { color: inherit; }
+  .monkey_scroll_bar { z-index: 99; }
+  .client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
+  nav.top.persistent { background: #282828; }
+  nav.top.persistent .logo { background-position: 50% 0 !important; }
+  .widescreen #header_team_name a i { margin-left: 1.5em; }
+  .widescreen #user_menu { border-right: none; }
+  header #menu_toggle { color: #689d6a; }
+  header #header_team_nav { background: #282828; border: 1px solid #282828; }
+  header #header_team_nav li.active a { background: #1d2021; color: #f9f5d7; }
+  header .header_btns a { color: #689d6a; }
+  header .header_btns a .label { color: #d79921; }
+  header .vert_divider { border-left: 1px solid #282828; }
+  footer, #autocomplete_menu.search_menu footer.unified { background-color: #282828; border-color: #282828; color: #f9f5d7; }
+  footer ul a, #autocomplete_menu.search_menu footer.unified ul a { color: #f9f5d7; }
+  footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited { color: #f9f5d7; }
+  .plastic_row h3 { color: #f9f5d7; }
+  .plastic_row h4 a { color: #f9f5d7; }
+  .plastic_row .icon { color: #f9f5d7; }
+  .plastic_row .chevron { color: #d79921; }
+  .plastic_row .description { color: #f9f5d7; }
+  .plastic_row:active { background: #1d2021; border-color: #282828; }
+  .plastic_row:active .chevron { color: #f9f5d7; }
+  html.no_touch .plastic_row:hover { background: #1d2021; border-color: #282828; }
+  html.no_touch .plastic_row:hover .chevron { color: #f9f5d7; }
+  html.no_touch .pagination ul > li > a:hover { background-color: #282828; }
+  html.no_touch .pagination ul > .disabled > a:hover { background: #282828; color: #d79921; }
+  html.no_touch .pager li > a:hover, html.no_touch .pager li > a:focus { color: #cc241d; }
+  .card, .tab_pane { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  .card h3 a { color: #f9f5d7; }
+  #page_contents .card { background: rgba(40, 40, 40, 0.8) !important; }
+  #page_contents .card p { color: #f9f5d7; }
+  .tab_set a.secondary { color: #689d6a; }
+  .tab_set a.selected, .tab_set a.secondary.selected { background: #282828; border: 1px solid #282828; border-bottom-color: #282828; color: #cc241d; }
+  .tab_actions { background: #282828; border: 1px solid #282828; border-color: #282828; }
+  .accordion_section { border-bottom-color: #1d2021; }
+  .accordion_section h4 { color: #f9f5d7; }
+  .accordion_section h4 a { color: #f9f5d7; }
+  .no_touch .accordion_section h4 a:hover { color: #f9f5d7; }
+  .accordion_section_fixed { border-bottom-color: #1d2021 !important; }
+  .pager li > a, .pager li > span { background-color: #1d2021; background-image: none; border-color: #282828; color: #689d6a; }
+  .pager li.previous > a, .pager li.previous > span { background-position: 0; padding-right: 0; text-align: center; }
+  .pager li.next > a, .pager li.next > span { background-position: 0; padding-left: 0; text-align: center; }
+  .pager .disabled > a, .pager .disabled > span { color: #d79921; }
+  .pagination ul > li > a, .pagination ul > li > span { background: #282828; border: 1px solid #282828; color: #f9f5d7; }
+  .pagination ul > li > a:focus { background-color: #282828; }
+  .pagination ul > .active > a, .pagination ul > .active > span { background-color: #282828; }
+  .pagination ul > .disabled > span { background: #282828; color: #d79921; }
+  .pagination ul > .disabled > a { background: #282828; color: #689d6a; }
+  .pagination ul > .disabled > a:focus { background: #282828; color: #cc241d; }
+  .loading_hash_animation img { display: none; }
+  .icon_search_close { color: #689d6a; }
+  .icon_search_close:hover { color: #cc241d; }
+  .help { border-top-color: #282828; color: #d79921; }
+  .two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
+  .two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  .two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  .two_factor_choice:hover .two_factor_link { color: #f9f5d7; }
+  a.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:link { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
+  a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #f9f5d7; }
+  .backup_codes { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  #channel_specific_settings tr { border-top-color: #1d2021; }
+  #channel_specific_settings tr.channel_override_row.muted td { background: rgba(29, 32, 33, 0.5); }
+  #channel_specific_settings .extra_left_border { border-left-color: #1d2021; }
+  #channel_specific_settings .extra_right_border { border-right-color: #1d2021; }
+  #channel_specific_settings .revert_to_default { color: #d79921; }
+  #channel_specific_settings .revert_to_default:hover { color: #cc241d; }
+  .admin_list_item { border-bottom-color: #1d2021; color: #d79921; }
+  .admin_list_item:hover { background-color: #282828; }
+  .admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name { color: #f9f5d7; }
+  .admin_list_item .admin_member_type, .admin_list_item .admin_member_caret { color: #d79921; }
+  .admin_list_item .pill.group { background: #282828; }
+  .admin_list_item .two_factor_auth_badge:hover { background: #282828; }
+  .admin_list_item .inline_email:hover, .admin_list_item .inline_name:hover, .admin_list_item .inline_username:hover { background: none !important; }
+  .admin_list_item.invite_item.bouncing { background: #ebdbb2; }
+  .admin_list_item.invite_item.bouncing .email { color: #cc241d; }
+  .admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success { background-color: #1d2021; }
+  .admin_list_item.expanded .btn_outline { border-color: #1d2021; color: #f9f5d7 !important; }
+  .admin_list_item.expanded .btn_outline:hover { border-color: #282828; color: #f9f5d7 !important; }
+  .admin_list_item.expanded .sub_action { color: #689d6a; }
+  .admin_list_item.expanded .sub_action:hover { color: #cc241d; }
+  @media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #689d6a; } }
+  .billing_selection { border-color: #282828; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection:hover { border-color: #ebdbb2; }
+  .billing_selection.active { background: #1d2021; border-color: #ebdbb2; }
+  .billing_selection.billing_selection--refactor { border-color: #1d2021; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection.billing_selection--refactor:hover { border-color: #ebdbb2; }
+  .billing_selection.billing_selection--refactor.active { background: #1d2021; border-color: #ebdbb2; }
+  .billing_selection .billing_selection__price { color: #f9f5d7; }
+  #billing_contacts_container { background: #282828; border-top: 1px solid #282828; }
+  .billing_contact { border-bottom: 1px solid #1d2021; }
+  table.billing tr:hover td { background: #282828; }
+  .link_billing_statement { color: #f9f5d7 !important; }
+  .link_invoice_id, .link_statement_id { color: #689d6a !important; }
+  .billing_invoice tbody tbody tr { color: #f9f5d7 !important; }
+  .billing_settings_label_name { color: #f9f5d7; }
+  table tr { border-bottom-color: #1d2021; }
+  table tr:first-child th:not(:only-of-type) { border-bottom-color: #282828; }
+  .slackbot_response_fieldset .delete_response { color: #d79921; }
+  .slackbot_response_fieldset .delete_response:hover { color: #cc241d; }
+  .author_cell { color: #f9f5d7; }
+  .message_cell.disabled { color: #d79921; }
+  #message_container #msg_limit { color: #f9f5d7; }
+  .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #1d2021; }
+  .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #1d2021; }
+  .inactive { background-image: none; }
+  .c3 line, .c3 path { stroke: #ebdbb2; }
+  .c3-chart-arc .c3-gauge-value { fill: #ebdbb2; }
+  .c3-chart-arc path { stroke: #282828; }
+  .c3-chart-arc text { fill: #282828; }
+  .c3-chart-arcs .c3-chart-arcs-background { fill: #1d2021; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #282828; }
+  .c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #ebdbb2; }
+  .c3-circle._expanded_ { stroke: #282828; }
+  .c3-grid line { stroke: #ebdbb2; }
+  .c3-grid text { fill: #f9f5d7; }
+  .c3-legend-background { fill: #282828; stroke: #1d2021; }
+  .c3-region { fill: #1d2021; }
+  .c3-selected-circle { fill: #282828; }
+  .c3-tooltip { background-color: #282828; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
+  .c3-tooltip td { background-color: #282828; border-left-color: #1d2021; }
+  .c3-tooltip th { background-color: #282828; color: #f9f5d7; }
+  .c3-tooltip tr { border-color: #1d2021; }
+  .ent_alert a { color: #689d6a; }
+  .ent_alert a:link, .ent_alert a:visited { color: #cc241d; }
+  .ent_alert_page.ent_alert_error { background: #cc241d; }
+  .ent_alert_page.ent_alert_success { background: #98971a; }
+  .ent_analytics__disclaimer { border-top-color: #ebdbb2; color: #d79921; }
+  .ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
+  .ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
+  .ent_avatar { background-color: #1d2021; }
+  .ent_callout__difference--increase { color: #98971a; }
+  .ent_callout__icon_border { background-color: #282828; border-color: #ebdbb2; }
+  .ent_callout__icon_image, .ent_callout__icon--filled { border-color: #ebdbb2; }
+  .ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #1d2021; }
+  .ent_callout__icon--limit_reached { border-color: #ebdbb2; }
+  .ent_callout__insight { color: #d79921; }
+  .ent_callout__limit { color: #d79921; }
+  .ent_callout__meter_bar_container { background: #1d2021; }
+  .ent_callout__meter_bar_border { border-color: #1d2021; }
+  .ent_callout__meter_bar_fill--empty { background: #ebdbb2; border-color: #ebdbb2; }
+  .ent_callout__meter_bar_fill--filled { background: #ebdbb2; border-color: #ebdbb2; }
+  .ent_callout__meter_bar_fill--limit_reached { background: #cc241d; border-color: #cc241d; }
+  .ent_callout__meter_bar_gleam { background: rgba(235, 219, 178, 0.5); }
+  .ent_callout__title { color: #f9f5d7; }
+  .ent_copy_muted { color: #d79921; }
+  .ent_copy { color: #f9f5d7; }
+  .ent_csv_popover__footer_text { color: #d79921; }
+  .ent_csv_popover__footer { background: #282828; border-top-color: #ebdbb2; }
+  .ent_csv_popover__subtitle { color: #d79921; }
+  .ent_csv_popover__title { color: #f9f5d7; }
+  .ent_data_table__cell--header { color: #d79921; }
+  .ent_data_table__cell--positive { color: #f9f5d7; }
+  .ent_data_table__cell--sortable:hover { background-color: #282828; }
+  .ent_data_table__cell--sorting { color: #d79921; }
+  .ent_data_table__cell { border-bottom-color: #ebdbb2; color: #f9f5d7; }
+  .ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border { border-right-color: #ebdbb2; }
+  .ent_data_table__column_group { background-color: #282828; }
+  .ent_data_table__data_link, a.ent_data_table__data_link { color: #f9f5d7; }
+  .ent_data_table__row--hovered { background-color: #1d2021; }
+  .ent_data_table__scrollable--left_shadow::before { box-shadow: inset -14px 0 14px -14px transparent, inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--left_shadow.ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px rgba(0, 0, 0, 0.25); }
+  .ent_data_table__scrollable--right_shadow::before { box-shadow: inset -14px 0 14px -14px rgba(0, 0, 0, 0.25), inset 14px 0 14px -14px transparent; }
+  .ent_data_table__secondary_text { color: #d79921; }
+  .ent_data_table__thead, .ent_data_table--empty_state_wrapper { background-color: #282828; }
+  .ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead { border-bottom-color: #ebdbb2; }
+  .ent_data_table--rounded_top { border-top-color: #ebdbb2; }
+  .ent_data_table { border-bottom-color: #ebdbb2; border-left-color: #ebdbb2; border-right-color: #ebdbb2; }
+  .ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading { color: #f9f5d7; }
+  .ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after { color: #d79921; }
+  .ent_graph__legend_item--defocus { fill: #d79921 !important; }
+  .ent_graph__legend_text { fill: #f9f5d7; }
+  .ent_graph__svg_container .c3-axis path { stroke: #ebdbb2; }
+  .ent_graph__svg_container .c3-grid line { stroke: #ebdbb2; }
+  .ent_graph__svg_container .c3-grid .ent_xgrid_month_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_week_divider line, .ent_graph__svg_container .c3-grid .ent_xgrid_year_divider line { stroke: #ebdbb2; }
+  .ent_graph__svg_container .c3-tooltip { border-color: #ebdbb2; box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5); }
+  .ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr { background-color: #282828; color: #f9f5d7; }
+  .ent_graph__svg_container .c3-tooltip th { border-bottom-color: #ebdbb2; }
+  .ent_graph__svg_container .c3-xgrid-focus line { stroke: #d79921; }
+  .ent_graph__svg_container .ent_graph__point:not(._expanded_) { fill: #282828 !important; }
+  .ent_graph__svg_container .ent_graph__point._expanded_ { stroke: #282828 !important; }
+  .ent_graph__svg_container text { fill: #d79921; }
+  .ent_graph__tooltip { color: #d79921; }
+  .ent_graph_empty__overlay { background: #282828; }
+  .ent_graph_empty__text { color: #f9f5d7; }
+  .ent_graph_header--primary { color: #f9f5d7; }
+  .ent_graph_header--secondary { color: #d79921; }
+  .ent_graph_tabs__tab--selected { color: #f9f5d7; }
+  .ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after { background-color: #ebdbb2; }
+  .ent_graph_tabs__tab { color: #d79921; }
+  .ent_graph_tabs { border-bottom-color: #ebdbb2; }
+  .ent_header { color: #f9f5d7; }
+  .ent_icon_button { color: #d79921; }
+  .ent_icon_button:hover { color: #f9f5d7; }
+  .ent_infographic_container { border-top-color: #ebdbb2; }
+  .ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(40, 40, 40, 0.8), #282828); }
+  .ent_modal__title--small { color: #f9f5d7; }
+  .ent_modal_background { background-color: #1d2021; }
+  .ent_modal_breadcrumb_animated_step { background: #1d2021; }
+  .ent_modal_breadcrumb_circle_icon { background: #1d2021; }
+  .ent_modal_breadcrumb_line { background: #1d2021; }
+  .ent_modal_breadcrumb_text { color: #d79921; }
+  .ent_modal_footer { background-color: #282828; }
+  .ent_modal_title { color: #f9f5d7; }
+  .ent_table__header--title { color: #f9f5d7; }
+  .ent_table__header { background-color: #1d2021; border-color: #ebdbb2; }
+  .ent_table_banner__contents { background: #1d2021; border-top-color: #ebdbb2; box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15); }
+  .ent_table_banner__header { color: #f9f5d7; }
+  .ent_table_banner__secondary_text { color: #d79921; }
+  .ent_table_customizer__header_subtitle { color: #d79921; }
+  .ent_table_customizer_disabled_list_header { color: #d79921; }
+  .ent_table_customizer_footer { background-color: #1d2021; border-top-color: #282828; color: #d79921; }
+  .ent_table_customizer_header { border-bottom-color: #1d2021; }
+  .ent_table_customizer_list_item--disabled { color: #d79921; }
+  .ent_updated_at { color: #d79921; }
+  .enterprise { background-color: #282828; }
+  .enterprise .btn.candy_red { color: #cc241d !important; }
+  .enterprise_analytics { background-color: #282828; }
+  .enterprise_org { background-color: #282828; }
+  .enterprise_search_bar .ent_clear_search_icon { color: #d79921; }
+  .enterprise_search_bar::before { color: #f9f5d7; }
+  @keyframes color_fade { from { color: #d79921; }
+    to { color: #f9f5d7; } }
+  .file_header .title a { color: #689d6a; }
+  .file_header .title a:hover { color: #cc241d; }
+  .file_actions_cog { color: #689d6a !important; }
+  .file_actions_cog:hover { color: #cc241d !important; }
+  .file_reference .icon, .file_list_item .icon, .file_preview { border: 2px solid #282828; }
+  .action_cog { color: #689d6a; }
+  .action_cog i { color: #689d6a; }
+  html.no_touch .action_cog:hover { color: #cc241d; }
+  html.no_touch .action_cog:hover i { color: #cc241d; }
+  .help_pages.help_pages p { color: #f9f5d7; }
+  .help_pages.help_pages a { border-bottom-color: #1d2021; }
+  .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #1d2021; }
+  .help_pages.help_pages .o-hero__header { color: #f9f5d7; }
+  .help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #1d2021; }
+  .help_pages.help_pages .c-form__container .c-form__feedback { color: #cc241d; }
+  .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; }
+  .help_pages.help_pages .drop_zone { background: #1d2021; border-color: #ebdbb2; }
+  .help_pages.help_pages .drop_zone_attachment { border-bottom-color: #1d2021; }
+  .help_pages.help_pages .drop_zone_remove_attachment { background-color: #1d2021; }
+  .help_pages.help_pages .c-form__notice { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  .help_pages.help_pages .c-form__notice.is-error { border-left-color: #cc241d; }
+  .help_pages.help_pages .c-nav--footer { border-top-color: #1d2021; }
+  @media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #1d2021; } }
+  .widescreen:not(.nav_open) { color: #f9f5d7; }
+  @media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(29, 32, 33, 0.9); } }
+  .widescreen:not(.nav_open) nav#site_nav h3 { color: #f9f5d7; }
+  .widescreen:not(.nav_open) nav#site_nav ul a { color: #689d6a; }
+  .widescreen:not(.nav_open) nav#site_nav ul a:link, .widescreen:not(.nav_open) nav#site_nav ul a:visited, .widescreen:not(.nav_open) nav#site_nav ul a:hover, .widescreen:not(.nav_open) nav#site_nav ul a:active { color: #cc241d; }
+  .widescreen:not(.nav_open) nav#site_nav #user_menu_name { color: #d79921; }
+  nav#site_nav { background: #282828; }
+  nav#site_nav #user_menu_contents:hover { background: #1d2021; color: #f9f5d7; }
+  header { background: #282828; }
+  header #header_team_nav li a { color: #f9f5d7; }
+  header #header_team_nav li a:hover { background: #1d2021; color: #f9f5d7; }
+  header #header_team_nav li a .team_icon.ts_icon_plus { background: #282828; color: #d79921; }
+  header #header_team_nav #add_team_option { border-top: 1px solid #282828; }
+  html.no_touch header #header_team_nav li a { color: #f9f5d7; }
+  html.no_touch header #header_team_nav li a:hover { background: #1d2021; color: #f9f5d7; }
+  html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover { color: #cc241d; }
+  html.no_touch header .header_btns a:hover { color: #cc241d; }
+  html.no_touch header .header_btns a:hover .label { color: #d79921; }
+  nav#site_nav h3, #header_team_name, header #header_team_name a { color: #689d6a; }
+  nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a { color: #cc241d; }
+  #home_footer a { color: #cc241d; }
+  .admin_pref:not(:first-of-type) { border-top-color: #1d2021; }
+  .admin_pref.locked { background-color: rgba(204, 36, 29, 0.2); }
+  .admin_pref .admin_pref_locked_label { color: #d79921; }
+  .tooltip-inner { background-color: #ebdbb2; color: #f9f5d7; }
+  .tooltip.top .tooltip-arrow, .tooltip.top-left .tooltip-arrow { border-top-color: #ebdbb2; }
+  .tooltip.right .tooltip-arrow { border-right-color: #ebdbb2; }
+  .tooltip.left .tooltip-arrow { border-left-color: #ebdbb2; }
+  .tooltip.bottom .tooltip-arrow { border-bottom-color: #ebdbb2; }
+  .api #header_logo img { display: none; }
+  body.api header .header_links a { color: #f9f5d7; }
+  body.api header .header_links a.active { background: #1d2021; }
+  body.api .reverse_header { background-color: #282828; color: #f9f5d7; }
+  body.api pre { overflow-x: auto; }
+  body.api pre code { color: #f9f5d7; }
+  body.api #page_contents .card { background: #282828; }
+  body.api .scopes_to_methods code { color: #f9f5d7; }
+  body.api .scopes_to_methods .selected code { color: #cc241d; }
+  body.api .scopes_to_methods li { color: #f9f5d7; }
+  body.api .scopes_to_methods .selected li { color: #f9f5d7; }
+  body.api .section_title { border-bottom: 2px solid #1d2021; }
+  body.api .example { border: 1px solid #282828; }
+  body.api .example h5 { background-color: #282828; color: #f9f5d7; }
+  body.api .alert { background: #1d2021; }
+  body.api .hljs { background-image: none; }
+  body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
+  body.api .hljs-number { color: #a5d6a7; }
+  body.api .hljs-literal, body.api .hljs-tag .hljs-attr { color: #536dfe; }
+  body.api .hljs-variable { color: #9fa8da; }
+  body.api .hljs-template-variable { color: #c5e1a5; }
+  body.api .hljs-comment { color: #ffcc80; }
+  body.api .hljs-doctag, body.api .hljs-string { color: #ef9a9a; }
+  body.api .hljs-section, body.api .hljs-selector-id, body.api .hljs-title { color: #ffab91; }
+  body.api .hljs-meta { color: #eee; }
+  body.api .hljs-class .hljs-title, body.api .hljs-type { color: #eee; }
+  body.api .hljs-built_in, body.api .hljs-builtin-name { color: #b39ddb; }
+  body.api .hljs-tag { color: #a5d6a7; }
+  body.api .hljs-attribute, body.api .hljs-name { color: #40c4ff; }
+  body.api .hljs-bullet, body.api .hljs-symbol { color: #9fa8da; }
+  body.api .hljs-quote { color: #b0bec5; }
+  body.api .hljs-link, body.api .hljs-regexp { color: #689d6a; }
+  body.api span.btn { background-color: #1d2021; }
+  body.api span.deprecation, body.api span.warning { background-color: #cc241d; border-color: #cc241d; }
+  nav#api_nav { background: transparent; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  #api_nav .footer_nav a { color: #689d6a; }
+  #api_nav .footer_nav a:hover { color: #cc241d; }
+  #api_nav .footer_nav .footer_signature { color: #cc241d; }
+  .api_articles .api_articles_section { border-bottom-color: #1d2021; }
+  .api_articles .article_tag_count { color: #d79921; }
+  .api.feature_related_content #api_related_content h2 { color: #f9f5d7; }
+  .api.feature_related_content #api_related_content .article_link_title_wrapper { color: #689d6a; }
+  .tab_menu { background-color: #282828; }
+  .tab_menu.grey { background-color: #282828; }
+  .tab_menu .tab { color: #f9f5d7; }
+  .tab_menu .tab:hover { box-shadow: inset 0 -4px 0 0 rgba(204, 36, 29, 0.4); }
+  .tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus { box-shadow: inset 0 -4px 0 0 #cc241d; color: #f9f5d7; }
+  .tab_menu .tab:disabled { color: #d79921; }
+  .page_faq h3, .page_scim h3 { background-color: #1d2021; }
+  .application_config aside { color: #d79921; }
+  .page_apps_directory_home { background-color: #1d2021 !important; }
+  .page_apps_directory_home .nav_title { color: #f9f5d7 !important; }
+  .page_apps_directory_home__search .apps_search_input::placeholder, .page_apps_directory_home__search .apps_search_input:focus::placeholder { color: #d79921; }
+  .page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #ebdbb2; }
+  .splash_container__background { background-color: #282828; }
+  .splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
+  .splash_interactive__button { border-color: #1d2021; }
+  .splash_interactive__button--active { box-shadow: 0 0 10px 1px #ebdbb2; }
+  .splash_interactive__window { background-color: #1d2021; border-color: #1d2021; }
+  .splash_interactive__window:hover .splash_interactive__window_headline { color: #f9f5d7; }
+  .splash_interactive__window::after { background: linear-gradient(to bottom, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+  .splash_interactive__window_response { background-color: #fff; }
+  a.splash_interactive__window_link { color: #f9f5d7; }
+  .splash_interactive__window_message_content_text--drive { color: #d79921; }
+  .search_input.apps_search_input { border-color: #ebdbb2; }
+  .menu_launcher, .menu_launcher_large { background-color: #1d2021; border-color: #1d2021 !important; color: #f9f5d7; }
+  .menu_launcher_large { border-color: #1d2021; }
+  .menu.avatar_menu ul li:hover ts-icon { background: #1d2021; color: #f9f5d7; }
+  .menu.avatar_menu ul li a { color: #f9f5d7; }
+  .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #1d2021; color: #d79921; }
+  .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
+  #page .media_list { background-color: #282828; border: 1px solid #1d2021; }
+  #page .media_list > li + li::before { border-top-color: #1d2021; }
+  #page .media_list > li.interactive a { color: #f9f5d7; }
+  #page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #1d2021; border-color: #ebdbb2; }
+  #page .media_list > li .media_list_text { color: #f9f5d7; }
+  #page .media_list.media_list_with_arrows a::before { color: #d79921; }
+  #page .media_list_title { color: #f9f5d7; }
+  #page .media_list_subtitle { color: #d79921; }
+  #page .sidebar_menu_list_item { color: #f9f5d7; }
+  #page .sidebar_menu_list_item.is_active { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  #page .sidebar_menu_list_item.is_active a { color: #f9f5d7; }
+  #page .sidebar_menu_list_item:not(.is_active):hover { background-color: #1d2021; border-color: #1d2021; }
+  #page .sidebar_menu_list_item a { color: #f9f5d7; }
+  #page ul.breadcrumbs li { color: #d79921; }
+  #page ul.breadcrumbs li:not(:first-child)::before { color: #d79921; }
+  #page ul.navigation_list li a { color: #f9f5d7; }
+  #page ul.navigation_list li a:hover { background-color: #1d2021; }
+  #page ul.navigation_list li a::after { color: #f9f5d7; }
+  #page ul.navigation_list li + li a { border-top: 1px solid transparent; }
+  #page .tag { background-color: #282828; border: 1px solid #282828; }
+  #page .tag:hover { background-color: #1d2021 !important; }
+  #page .app_desc_btn { background-color: #1d2021; color: #f9f5d7; }
+  #page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
+  #page .service_panel { background-color: #282828; }
+  #page .service_card { background-color: #1d2021; border: 1px solid #282828; }
+  .app_card, .large_app_card { background-color: #1d2021; border: 1px solid #282828; }
+  nav.top.persistent ul a { color: #f9f5d7; }
+  nav.top.apps_nav { background: transparent; }
+  nav.top.apps_nav.persistent .nav_title { border-color: #ebdbb2; }
+  nav.top.apps_nav.clear_nav .nav_title a { color: #f9f5d7; }
+  nav.top.apps_nav .nav_title a { color: #f9f5d7; }
+  nav.top.apps_nav ul a.active { color: #cc241d; }
+  .plastic_typeahead { background: #282828; border: 1px solid #282828; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
+  .plastic_typeahead_item { color: #f9f5d7; }
+  .plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #1d2021; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #1d2021; border-top-color: #282828; color: #f9f5d7; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #d79921; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #1d2021; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #1d2021; }
+  a.plastic_typeahead_item { color: #f9f5d7; }
+  .apps_typeahead_item_media { background: #282828; }
+  .search_input_container .search_input:focus ~ .icon_search_input { color: #f9f5d7; }
+  .icon_search_input { color: #d79921; }
+  .quote_block { color: #f9f5d7; }
+  .quote_block::before { background-color: #1d2021; }
+  .well { background: #282828; border-color: #232323; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #d79921; }
+  .c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+  .c-tabs__tab { color: #d79921; }
+  .c-tabs__tab:hover { color: #f9f5d7; }
+  .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
+  .c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+  a.c-tabs__tab--plastic { color: #d79921; }
+  a.c-tabs__tab--plastic:hover { color: #f9f5d7; }
+  a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
+  .p-detail_scope { box-shadow: inset 0 1px 0 0 #1d2021; }
+  .p-detail_scope:last-child { border-bottom-color: #1d2021; }
+  .p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #1d2021; }
+  .p-detail_arrow_icon { color: #d79921; }
+  .p-detail_arrow_icon:hover { color: #f9f5d7; }
+  .p-detail_permissions { background: #282828; border-color: #1d2021; }
+  table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #1d2021; }
+  .section_rollup { border-bottom-color: #1d2021; }
+  .section_rollup:first-of-type { border-top-color: #1d2021; }
+  .section_rollup:hover:not(.is_active) { background: rgba(29, 32, 33, 0.5); color: #f9f5d7; }
+  .is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #98971a; color: #282828; }
+  .developer_apps_functionality_link:hover { border-color: #1d2021; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
+  .developer_apps_functionality_link::before { background-color: #1d2021; }
+  .developer_apps_functionality_link_enabled::before { background-color: #98971a; }
+  .legal-hero { background-color: #1d2021; }
+  .legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #1d2021; }
+  .legal-hero .o-hero__header__headline--larger { color: #f9f5d7; }
+  .legal-main { background-color: #282828; }
+  .legal-main.v--no-switch { background-color: #282828; border-bottom-color: #1d2021; border-top-color: #1d2021; }
+  .legal-main p { color: #f9f5d7; }
+  .legal-main a { border-bottom-color: #1d2021; }
+  @media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #f9f5d7; }
+    .legal-main .c-nav--sidebar__listitem a.is-selected { color: #d79921; } }
+  .legal-main .t-contains-subtle-links a:not(.c-button) { color: #f9f5d7; }
+  .legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover { color: #d79921; }
+  @media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #282828; } }
+  .t-no-header .legal-hero.o-hero.v--short { background-color: #282828; }
+  .c-oauth_scope_info__spacer_icon { color: #cc241d; }
+  .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #1d2021; }
+  .c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #1d2021; border-top-color: #1d2021; }
+  .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #1d2021; }
+  a.p-oauth_nav__anchor { color: #d79921; }
+  .p-oauth_nav__team-switcher .menu_launcher { border-color: #282828; }
+  .p-oauth_nav__team-switcher .menu_launcher:hover { border: #1d2021; }
+  .p-oauth_page, .p-oauth_page--error { background: #1d2021; }
+  .p-oauth_page__title { color: #f9f5d7; }
+  .p-oauth_page_single_channel_picker { border-bottom-color: #282828; }
+  ts-rocket { color: #f9f5d7; }
+  ts-rocket a { color: #689d6a; }
+  ts-rocket a caret::before { background-color: #282828; border-color: #282828; }
+  ts-rocket hr { border-color: #282828; }
+  ts-rocket code, ts-rocket .pre.text, ts-rocket > div > pre { background-color: #282828; }
+  ts-rocket .blockquote.text::before, ts-rocket > div > blockquote::before { background-color: #282828; }
+  ts-rocket .cl.text { background-color: #282828; border-bottom: 1px solid #282828; }
+  ts-rocket .cl.text .checkbox.checked + li { color: #d79921; }
+  ts-rocket > div > .checklist { background-color: #282828; border-bottom: 1px solid #282828; }
+  ts-rocket > div > .checklist .checkbox.checked + li { color: #d79921; }
+  ts-rocket > div > .checklist li::before { background: #282828; }
+  ts-rocket > div > .checklist li.checked { color: #d79921; }
+  ts-rocket .unfurl .unfurl-container { background-color: #282828; }
+  ts-rocket .unfurl .unfurl-container.unfurl-render-failed { background-color: rgba(204, 36, 29, 0.1); }
+  ts-rocket .unfurl .attachment_bar { background-color: #282828 !important; }
+  ts-rocket .unfurl .unfurl-remove::before { color: #d79921; }
+  ts-rocket .unfurl .unfurl-remove:hover::before { color: #f9f5d7; }
+  ts-rocket .unfurl.selected .unfurl-container { background-color: rgba(235, 219, 178, 0.5); }
+  ts-rocket .unfurl.selected .unfurl-container .attachment_bar { background-color: rgba(235, 219, 178, 0.5) !important; }
+  ts-rocket caret::before { background-color: #282828; border: 1px solid #282828; }
+  ts-rocket carriage { background-color: rgba(235, 219, 178, 0.5); }
+  ts-rocket selection { background-color: rgba(235, 219, 178, 0.5); }
+  ts-rocket selection::after, ts-rocket selection::before { background-color: rgba(235, 219, 178, 0.5); }
+  ts-rocket ime { background-color: rgba(235, 219, 178, 0.5); }
+  ts-rocket .hr.selected hr { box-shadow: 0 0 0 5px rgba(235, 219, 178, 0.5); }
+  .focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #282828; }
+  nav { background: #282828; }
+  nav .space { background-color: #282828; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
+  nav .space::after { border-left: 1px solid #1d2021; }
+  nav .comments { background-color: #282828; }
+  nav .space_buttons .btn_outline { background-color: #282828; }
+  nav .space_buttons .btn_outline::after { border-color: #1d2021; }
+  nav .space_btn_star { background: none; border: 0; }
+  nav .space_btn_star:hover { background: none !important; }
+  nav .space_btn_edit { background: #1d2021; }
+  nav .space_btn_edit.editing { background: #ebdbb2; }
+  nav .star_info { color: #d79921; }
+  nav #space_status { border-left: 1px solid #1d2021; color: #d79921; }
+  nav #space_status.slightly_concerned { color: #cc241d; }
+  nav #edit_status { color: #d79921; }
+  nav .comments_open.unread span.notif { background-color: #cc241d; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
+  nav .comments_close { color: #d79921; }
+  nav .comments_close:hover::before { color: #689d6a !important; }
+  ts-space header { background: transparent; }
+  ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit { color: #f9f5d7; }
+  ts-space header .owner_detail .inline-edit { background: none; }
+  ts-space header .owner_detail .inline-edit::-webkit-input-placeholder { color: #f9f5d7; }
+  ts-space header .owner_detail .inline-edit::-moz-placeholder { color: #f9f5d7; }
+  ts-space header .owner_detail .inline-edit:focus::-webkit-input-placeholder { color: #d79921; }
+  ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #d79921; }
+  ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(235, 219, 178, 0.5); }
+  ts-space header .owner_detail small { color: #d79921; }
+  ts-space header .divider { border-top: 1px solid #1d2021; }
+  ts-space a.feedback { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+  ts-space a.feedback:hover { background-color: #282828; color: #f9f5d7; }
+  comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
+  #space_alert { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.25); }
+  #space_alert.error { background-color: #cc241d; }
+  #space_alert span#space_alert_text { color: #f9f5d7; }
+  #space_alert a { color: #689d6a; }
+  #space_alert button#space_alert_close::before { color: #d79921; }
+  #space_alert button#space_alert_close:hover::before { color: #d79921; }
+  #space_alert .btn_outline.btn_transparent { background-color: #282828 !important; color: #f9f5d7 !important; }
+  #space_alert .btn_outline.btn_transparent::after { border-color: #1d2021; }
+  #space_find_bar { background-color: #282828; border-bottom: 1px solid rgba(235, 219, 178, 0.1); border-left: 1px solid rgba(235, 219, 178, 0.07); border-right: 1px solid rgba(235, 219, 178, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  #space_find_bar #space_find_info.no_matches { color: #cc241d; }
+  #space_find_bar #space_find_next .ts_icon { background-color: #1d2021; }
+  #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #f9f5d7; }
+  #space_find_bar #space_find_next:hover .ts_icon { background-color: #ebdbb2; }
+  #space_find_bar #space_find_close::before { color: #d79921; }
+  #space_find_bar #space_find_close:hover::before { color: #d79921; }
+  #connected_members .connected_members_count { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+  #connected_members .toggle_more_members_popover { background: #1d2021; color: #d79921; }
+  #connected_members_overflow_popover { border-bottom: 1px solid #282828; border-left: 1px solid rgba(40, 40, 40, 0.11); border-right: 1px solid rgba(40, 40, 40, 0.11); border-top: 1px solid rgba(40, 40, 40, 0.11); box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .arrow::after { background-color: #282828; }
+  #connected_members_overflow_popover .arrow_shadow::after { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5); }
+  #connected_members_overflow_popover .monkey_scroll_wrapper { background: #282828; }
+  #connection_status #connection_label { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
+  #shortcuts_spaces_dialog { background-color: rgba(40, 40, 40, 0.8); text-shadow: 0 1px 1px rgba(40, 40, 40, 0.7); }
+  #shortcuts_spaces_dialog .modal-body { color: #f9f5d7; }
+  #shortcuts_spaces_dialog .col .keyboard { background-color: #ebdbb2; border-bottom: 2px solid #282828; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+  #shortcuts_spaces_dialog .close:hover { background-color: #ebdbb2; }
+  #shortcuts_spaces_dialog .close .ts_icon::before { color: #d79921 !important; }
+  .textstyle_menu .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #282828; }
+  .textstyle_menu .arrow::after { background-color: #282828; }
+  .textstyle_menu .content { background-color: #282828; box-shadow: 0 0 0 1px #282828, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .arrow-shadow::after { background-color: #282828; }
+  .textstyle_menu.link .arrow::after { background-color: #282828; }
+  .textstyle_menu.link .content { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .textstyle_menu.link .content input[type=text] { background-color: #1d2021; }
+  .textstyle_menu.link .content > a.link { color: #689d6a; }
+  .textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #d79921; }
+  .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #282828; }
+  .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #1d2021; }
+  .textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #1d2021; border: 1px solid #ebdbb2; }
+  .textstyle_menu.style a.deformat::before { border-left: 1px solid #1d2021; }
+  .textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #d79921; }
+  .para_menu .insert .tip { color: #d79921; }
+  .para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+  .para_menu .insert .tooltip .arrow::after { background-color: #282828; }
+  .para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+  .para_menu .format .options .arrow::after { background-color: #282828; }
+  .para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #1d2021; }
+  .para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .content ul:first-child { border-bottom: 1px solid #282828; }
+  .para_menu .format .options.show .tooltip > div { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #f9f5d7; }
+  .para_menu .format .options.show .tooltip span { background-color: #1d2021; }
+  .para_menu .options a:hover { border: 1px solid #1d2021; }
+  .para_menu .options a.active { background-color: #282828; border: 1px solid #282828; }
+  .para_menu .options a.active span { filter: grayscale(2) brightness(2); }
+  .para_menu .options a span { filter: grayscale(2) brightness(5); }
+  .para_menu a.trigger.pilcrow { filter: grayscale(2) brightness(1.8); }
+  .para_menu a.trigger.pilcrow:hover, .para_menu a.trigger.pilcrow.active { filter: grayscale(2) brightness(2); } }

--- a/css/variants/gruvbox-dark.css
+++ b/css/variants/gruvbox-dark.css
@@ -17,16 +17,16 @@
   .alert-info { background-color: #282828; border-color: #282828; color: #f9f5d7; }
   .alert-info h4 { color: #f9f5d7; }
   ::-webkit-scrollbar-track { background: #282828 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #282828 !important; }
-  ::-webkit-scrollbar-thumb { background: #1d2021 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
+  ::-webkit-scrollbar-thumb { background: #504945 !important; border-left-color: #282828 !important; border-right-color: #282828 !important; color: #1d2021 !important; }
   ::-webkit-scrollbar-corner { background: #1d2021 !important; }
   .supports_custom_scrollbar #messages_container::after { background: none !important; }
   .monkey_scroll_bar { background: #282828; }
-  .monkey_scroll_handle_inner { background: #1d2021; border: 1px solid #ebdbb2; }
+  .monkey_scroll_handle_inner { background: #504945; border: 1px solid #ebdbb2; }
   .monkey_scroll_bar_native_scrollbar_shim { background: transparent; }
   #client-ui .monkey_scroll_bar { background: #282828; }
-  #client-ui .monkey_scroll_handle_inner { background: #1d2021; border: 3px solid #1d2021; }
+  #client-ui .monkey_scroll_handle_inner { background: #504945; border: 3px solid #1d2021; }
   .c-scrollbar--monkey .c-scrollbar__track { background: #282828; }
-  .c-scrollbar--monkey .c-scrollbar__bar { background: #1d2021; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
+  .c-scrollbar--monkey .c-scrollbar__bar { background: #504945; box-shadow: 0 3px 0 #1d2021, 0 -3px 0 #1d2021; }
   .client_channels_list_container { background-color: #282828; border-right-color: #1d2021; }
   #col_channels { color: #f9f5d7; }
   .p-channel_sidebar { background-color: #282828; color: #f9f5d7; }
@@ -36,12 +36,12 @@
   .p-channel_sidebar__header { color: #f9f5d7 !important; }
   .p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before { color: #f9f5d7; }
   .p-channel_sidebar__channel--im .c-presence--away { color: #d79921; }
-  .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #1d2021 !important; }
-  .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #1d2021 !important; }
+  .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected { background: #504945 !important; }
+  .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover { background: #504945 !important; }
   .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after { color: #f9f5d7; }
   .p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after { color: #f9f5d7; }
   .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions { background: #cc241d; }
-  .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #1d2021; }
+  .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar { background: #504945; }
   .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover { color: #fdfcf2 !important; }
   .p-channel_sidebar__close_container:hover { background: #282828; }
   .p-channel_sidebar__jumper { background: transparent !important; }
@@ -84,11 +84,11 @@
   .infinite_spinner_bg, .infinite_spinner_blue { stroke: #f9f5d7; }
   body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels { background-color: #282828; }
   .p-degraded_list__loading { background-color: #1d2021; color: #f9f5d7; }
-  input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #1d2021; border-color: #282828; color: #f9f5d7; }
+  input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] { background-color: #504945; border-color: #282828; color: #f9f5d7; }
   input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus { border-color: rgba(40, 40, 40, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
   input[type=file]:focus { outline: #f9f5d7 dotted thin; }
   input[type=radio]:focus, input[type=checkbox]:focus { outline: #f9f5d7 dotted thin; }
-  select { background: #1d2021; }
+  select { background: #504945; }
   select, textarea { border: 1px solid #282828; color: #f9f5d7; }
   select:active, select:focus, textarea:active, textarea:focus { border-color: #282828; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
   input:disabled, input:disabled:active, select:disabled, textarea:disabled { border-color: #282828 !important; }
@@ -100,7 +100,7 @@
   legend small { color: #d79921; }
   .uneditable-input, .uneditable-textarea { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
   .uneditable-input:focus, .uneditable-textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
-  textarea { background-color: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  textarea { background-color: #504945; border: 1px solid #282828; color: #f9f5d7; }
   textarea:focus { border-color: rgba(235, 219, 178, 0.8); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(235, 219, 178, 0.6); }
   ::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
   ::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
@@ -110,12 +110,12 @@
   input::-moz-placeholder, textarea::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
   input::placeholder, textarea::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
   input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before { color: #f9f5d7 !important; }
-  input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #1d2021 !important; }
+  input[disabled], input[readonly], textarea[disabled], textarea[readonly] { background-color: #504945 !important; }
   .form-actions { background-color: #282828; border-top: 1px solid #282828; }
   .help-block, .help-inline { color: #d79921; }
-  .input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #1d2021; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
-  .btn { background-color: #1d2021; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
-  .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #1d2021; color: #f9f5d7; }
+  .input-append .add-on, .input-prepend .add-on { background-color: #ebdbb2; border: 1px solid #504945; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .btn { background-color: #504945; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
+  .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active { background-color: #504945; color: #f9f5d7; }
   .btn.btn_border { border: 2px solid #282828; }
   .btn.disabled, .btn:disabled { background-color: #282828 !important; }
   .btn.disabled:active, .btn.disabled:hover, .btn:disabled:active, .btn:disabled:hover { background-color: #282828 !important; }
@@ -123,7 +123,7 @@
   .btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover { background-color: #1d2021 !important; border-color: #cc241d !important; color: #cc241d !important; }
   .btn.btn_outline.disabled { background: #282828 !important; color: #689d6a !important; }
   .btn.btn_outline.disabled:hover { background: #282828 !important; color: #689d6a !important; }
-  .btn.btn_attachment { border-color: #1d2021; }
+  .btn.btn_attachment { border-color: #504945; }
   .btn.btn_attachment:hover, .btn.btn_attachment:focus { background-color: #282828; border-color: #ebdbb2; }
   .btn.btn_attachment.btn_danger { border-color: #cc241d; }
   .btn.btn_attachment.btn_danger:hover, .btn.btn_attachment.btn_danger:focus { border-color: #e34039; }
@@ -132,30 +132,30 @@
   .btn_basic:focus, .btn_basic:hover { color: #f9f5d7; }
   .btn_outline { background: #1d2021; color: #689d6a !important; }
   .btn_outline::after { border: 1px solid #282828; }
-  .btn_outline.btn_transparent { color: rgba(29, 32, 33, 0.9) !important; }
+  .btn_outline.btn_transparent { color: rgba(80, 73, 69, 0.9) !important; }
   .btn_outline.btn_transparent::after { border: 1px solid rgba(29, 32, 33, 0.5); }
-  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(29, 32, 33, 0.9) !important; color: #cc241d !important; }
-  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(29, 32, 33, 0.8) !important; }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover { background-color: rgba(80, 73, 69, 0.9) !important; color: #cc241d !important; }
+  .btn_outline.btn_transparent.active, .btn_outline.btn_transparent:active { background-color: rgba(80, 73, 69, 0.8) !important; }
   .btn_outline.hover, .btn_outline:focus, .btn_outline:hover { background: #1d2021; color: #cc241d !important; }
   .btn_outline:active { color: #cc241d; }
   .btn_outline.active { color: #cc241d !important; }
   .btn_link { color: #689d6a; }
   .btn_link:hover, .btn_link:focus { color: #cc241d; }
-  .btn-group.open .btn.dropdown-toggle { background-color: #1d2021; }
+  .btn-group.open .btn.dropdown-toggle { background-color: #504945; }
   .btn-group.open .btn-primary.dropdown-toggle { background-color: #282828; }
   .btn-group > .btn + .dropdown-toggle { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.125), inset 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 2px rgba(255, 255, 255, 0.05); }
   .btn_info, .btn.btn_success { background-color: #1d2021 !important; }
   .btn_warning, .btn_danger { background-color: #cc241d !important; }
   .btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret { border-bottom-color: #f9f5d7; border-top-color: #f9f5d7; }
   .input_note { color: #f9f5d7; }
-  .c-enhanced_text_input { background-color: #1d2021; border-color: #282828; color: #d79921; }
-  .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #1d2021; }
-  .c-filter_input { background: #1d2021; }
+  .c-enhanced_text_input { background-color: #504945; border-color: #282828; color: #d79921; }
+  .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active { border-color: #504945; }
+  .c-filter_input { background: #504945; }
   .p-share_dialog_message_input { color: #f9f5d7; }
   .c-texty_input .ql-placeholder { color: #f9f5d7; }
   .lazy_filter_select.disabled { background: #282828; }
   .lazy_filter_select.disabled input.lfs_input { background: #ebdbb2; }
-  .lazy_filter_select .lfs_input_container { background-color: #1d2021; border-color: #282828; }
+  .lazy_filter_select .lfs_input_container { background-color: #504945; border-color: #282828; }
   .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover { border-color: #282828; }
   .lazy_filter_select .lfs_input_container.active { box-shadow: 0 0 7px rgba(29, 32, 33, 0.15); }
   .lazy_filter_select .lfs_list_container { background: #1d2021; border-color: #282828; box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
@@ -177,11 +177,11 @@
   #message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button { background-color: #282828 !important; }
   #message_edit_form.offline #primary_file_button { border-color: #282828; color: #d79921; }
   #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) { border-color: #282828; }
-  #msg_form #msg_input { background: padding-box #1d2021; border-color: #282828; border-left: 0; color: #f9f5d7; }
+  #msg_form #msg_input { background: padding-box #504945; border-color: #282828; border-left: 0; color: #f9f5d7; }
   #msg_form #msg_input.focus ~ .msg_mentions_button:not(.hover) { color: #f9f5d7; }
   #msg_form .msg_mentions_button { color: #d79921; }
   #msg_form .msg_mentions_button:hover { color: #f9f5d7; }
-  #msg_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  #msg_input { background: #504945; border-color: #282828; color: #f9f5d7; }
   #msg_input::-webkit-input-placeholder { color: #f9f5d7 !important; -webkit-filter: none; filter: none; opacity: 0.5; }
   #msg_input::-moz-placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
   #msg_input::placeholder { color: #f9f5d7 !important; filter: none; opacity: 0.5; }
@@ -193,7 +193,7 @@
   #msg_input.offline:not(.pretend-to-be-online) { background-color: #282828 !important; color: #d79921; }
   #msg_input.disabled, #msg_input.ql-disabled { background-color: #282828; border-color: #282828; color: #d79921; }
   #msg_input_message { background-color: #282828; color: #f9f5d7; }
-  #primary_file_button { background: padding-box #1d2021; border-color: #282828; color: #d79921; }
+  #primary_file_button { background: padding-box #504945; border-color: #282828; color: #d79921; }
   #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover { background: #282828; border-color: #282828; color: #f9f5d7; }
   #footer, #footer.footer_msg_input { background: #1d2021; box-shadow: inset 1px 0 0 0 #1d2021; }
   #footer.disabled #message-input, #footer.disabled #msg_input { background: padding-box #282828 !important; border-color: #282828 !important; }
@@ -201,33 +201,33 @@
   #typing_text { color: #d79921; filter: none; }
   #notification_bar.wide #typing_text.overflow_ellipsis { -webkit-filter: none; filter: none; }
   #special_formatting_text { color: #d79921; }
-  #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #1d2021; border-color: #282828; color: #f9f5d7; }
-  .inline_message_input_container .ql-container { border-color: #1d2021; color: #f9f5d7; }
+  #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload { background: #504945; border-color: #282828; color: #f9f5d7; }
+  .inline_message_input_container .ql-container { border-color: #504945; color: #f9f5d7; }
   .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover { border-color: #ebdbb2; }
   .c-message--editing { background: #282828; border-color: #282828; color: #f9f5d7; }
-  .c-message__editor__input, .c-message__editor__input--legacy { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-message__editor__input, .c-message__editor__input--legacy { background: #504945; border-color: #282828; color: #f9f5d7; }
   .c-message__editor__input.focus, .c-message__editor__input--legacy.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
   .c-message__editor__warning { color: #cc241d; }
   .c-message .c-button { border-color: #282828; }
   .c-message .c-button--outline { background-color: #282828; color: #689d6a; }
   .c-message .c-button--outline:hover { color: #cc241d; }
-  .c-message .c-button--primary { background-color: #1d2021; color: #f9f5d7; }
-  #message_edit_container .message_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-message .c-button--primary { background-color: #504945; color: #f9f5d7; }
+  #message_edit_container .message_input { background: #504945; border-color: #282828; color: #f9f5d7; }
   #message_edit_container .message_input.focus { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
-  .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(29, 32, 33, 0.5); color: #1d2021; }
-  .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(29, 32, 33, 0.8); }
+  .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(80, 73, 69, 0.5); color: #1d2021; }
+  .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(80, 73, 69, 0.8); }
   .ql-placeholder, .texty_legacy .ql-placeholder { color: #f9f5d7; filter: none; }
-  .ql-container.texty_single_line_input { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
+  .ql-container.texty_single_line_input { background: #504945; border: 1px solid #282828; color: #f9f5d7; }
   .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover { border-color: #282828; box-shadow: 0 0 7px rgba(0, 0, 0, 0.15); }
-  .c-input_select { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-input_select { background: #504945; border-color: #282828; color: #f9f5d7; }
   .p-file_list__file_type_select .c-input_select__selected_value--placeholder { color: #f9f5d7; }
-  .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) { background: #504945; border-color: #282828; color: #f9f5d7; }
   .c-input_select_options_list__option { color: #f9f5d7; }
   .c-label__text { color: #f9f5d7; }
   .c-date_picker__dropdown { background-color: #282828; }
   .c-calendar_view_header__stepper_btn:disabled, .c-calendar_view_header__title_btn:disabled { color: #d79921; }
   .c-calendar_view_header__stepper_btn, .c-calendar_view_header__title_btn { color: #f9f5d7; }
-  .c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #1d2021; }
+  .c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover { background-color: #504945; }
   .c-date_picker_calendar__date--disabled, .c-date_picker_calendar__date--disabled:hover { background-color: #282828; }
   .c-mini_calendar__month_button:disabled, .c-mini_calendar__month_button:disabled:hover { background-color: #282828; }
   .c-calendar_month__day_of_week_heading { color: #f9f5d7; }
@@ -235,7 +235,7 @@
   .menu .menu_content { background: #282828 !important; }
   .menu .menu_filter_container { background: #1d2021; }
   .menu .menu_filter_container input.menu_filter { border: 1px solid #282828; }
-  .menu .menu_filter_container input.menu_filter:focus { border-color: #1d2021; }
+  .menu .menu_filter_container input.menu_filter:focus { border-color: #504945; }
   .menu .menu_filter_container .icon_search { color: #d79921; }
   .menu .menu_filter_container .icon_close { color: #d79921 !important; }
   .menu #menu_header .menu_simple_header { background: #282828; border-color: #282828; color: #f9f5d7; }
@@ -257,12 +257,12 @@
   .menu:not(.keyboard_active) ul li:hover:not(.disabled) a { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
   .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
   .menu:not(.keyboard_active) ul li:hover:not(.disabled) a.delete_link { color: #cc241d; }
-  .menu input { background: #282828; border: 1px solid #1d2021; }
-  .menu textarea { background: #282828; border: 1px solid #1d2021; }
+  .menu input { background: #282828; border: 1px solid #504945; }
+  .menu textarea { background: #282828; border: 1px solid #504945; }
   .menu #menu_footer .menu_footer { background: #282828; border-top: 1px solid #282828; }
   .menu #monkey_scroll_wrapper_for_menu_items_scroller { background: #282828; }
   .menu #menu_list_container #menu_list .menu_list_item a { color: #f9f5d7; }
-  .menu #menu_list_container #menu_list .menu_list_item.active a { background: #1d2021; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
+  .menu #menu_list_container #menu_list .menu_list_item.active a { background: #504945; color: #f9f5d7; text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15); }
   .c-menu { background-color: #282828; }
   .c-menu_item__label { color: #fff; }
   .c-menu_item__header { color: #d79921; }
@@ -275,7 +275,7 @@
   #autocomplete_menu .keyword_match .modifier { color: #d79921; }
   #autocomplete_menu .boxed { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15); }
   #autocomplete_menu .pickmeup { border-bottom: 1px solid #282828; }
-  #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #1d2021; }
+  #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before { background-color: #504945; }
   #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header { color: #f9f5d7; }
   #autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before { background-color: #282828; }
   #autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header { background-color: transparent; }
@@ -299,54 +299,54 @@
   #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text { color: #f9f5d7; }
   #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token { background-color: #282828; color: #f9f5d7; }
   #autocomplete_menu.search_menu .action_btn, #autocomplete_menu.search_menu .modifier_icon, #autocomplete_menu.search_menu.unified .action_btn, #autocomplete_menu.search_menu.unified .modifier_icon { color: #d79921; }
-  #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
-  #autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(29, 32, 33, 0.25); border: #ebdbb2; }
+  #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
+  #autocomplete_menu.search_menu footer .selected .keyword::before, #autocomplete_menu.search_menu footer .selected .modifier::before, #autocomplete_menu.search_menu footer.unified .selected .keyword::before, #autocomplete_menu.search_menu footer.unified .selected .modifier::before, #autocomplete_menu.search_menu.unified footer .selected .keyword::before, #autocomplete_menu.search_menu.unified footer .selected .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .selected .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .selected .modifier::before { background: rgba(80, 73, 69, 0.25); border: #ebdbb2; }
   #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
   .search_light_grey { color: #f9f5d7 !important; }
-  .highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
-  .highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
+  .highlighter_underlay .keyword::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
+  .highlighter_underlay .modifier::before { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
   .highlighter_underlay .modifier.incomplete::before { background: #282828; border: 1px solid #282828; }
-  .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #1d2021; }
+  .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before { background: rgba(235, 219, 178, 0.25); border: #504945; }
   .highlighter_underlay .ghost_text { color: #f9f5d7; }
   .pickmeup { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15); }
   .pickmeup .pmu-instance .pmu-button { color: #f9f5d7; }
   .pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover { background: #282828 !important; }
   .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border { background: #ebdbb2; color: #f9f5d7 !important; }
-  .pickmeup .pmu-instance .pmu-today-border { border: 2px solid #1d2021 !important; color: #ebdbb2 !important; }
-  .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #1d2021; color: #f9f5d7; }
+  .pickmeup .pmu-instance .pmu-today-border { border: 2px solid #504945 !important; color: #ebdbb2 !important; }
+  .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover { background: #504945; color: #f9f5d7; }
   .pickmeup .pmu-instance .pmu-not-in-month { background: #1d2021; color: #d79921; }
-  .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #1d2021; }
+  .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected { background: #504945; }
   .pickmeup .pmu-instance .pmu-disabled { background: #1d2021; color: #d79921; }
   .pickmeup .pmu-instance .pmu-disabled:hover { background: #1d2021; color: #d79921; }
-  .pickmeup .pmu-instance .pmu-selected { background: #1d2021; color: #f9f5d7; }
+  .pickmeup .pmu-instance .pmu-selected { background: #504945; color: #f9f5d7; }
   .pickmeup .pmu-instance nav { color: #689d6a; }
   .pickmeup .pmu-instance nav :first-child :hover { color: #cc241d; }
   .pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * { border: 1px solid #282828; }
   .pickmeup .pmu-instance .pmu-day-of-week { color: #f9f5d7; }
   .pickmeup .pmu-instance .pmu-day-of-week * { border: 1px solid #282828; }
   .pickmeup .pmu-instance .pmu-days * { border: 1px solid #282828; }
-  .p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #1d2021; color: #f9f5d7; }
-  .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #1d2021; border-color: #282828; color: #f9f5d7; }
-  .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #1d2021; color: #ebdbb2; }
-  #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #1d2021; }
+  .p-block_kit_date_picker_calendar_wrapper { background: #282828; border-color: #504945; color: #f9f5d7; }
+  .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn { background: #504945; border-color: #282828; color: #f9f5d7; }
+  .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled { background: #504945; color: #ebdbb2; }
+  #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected { background: #504945; }
   #menu.date_picker li.date_picker_item a { color: #f9f5d7; }
   #menu.date_picker li.date_picker_item a:hover { color: #f9f5d7; }
   #menu.date_picker li.date_picker_item.highlighted a { color: #d79921; }
   #file_member_filter { background: #282828; }
-  #client-ui .member_filter { border: 1px solid #1d2021; }
+  #client-ui .member_filter { border: 1px solid #504945; }
   #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row { background: #1d2021; }
   #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member { color: #f9f5d7; }
   #client-ui #team_list_container #team_filter .member_filter { background-color: #1d2021; border-left: 1px solid #282828; }
-  #client-ui #file_member_filter { border-color: #1d2021; }
-  #client-ui #file_member_filter .member_filter { border-color: #1d2021; }
+  #client-ui #file_member_filter { border-color: #504945; }
+  #client-ui #file_member_filter .member_filter { border-color: #504945; }
   #client-ui .team_tabs_container { border-bottom: 1px solid #282828; }
   #team_filter .icon_search { color: #d79921; }
   #team_filter a.icon_close { color: #689d6a; }
   #team_filter a.icon_close:hover { color: #cc241d; }
   .filter_header { background-color: #1d2021; }
-  .popover_menu { background-color: #1d2021; border-top: 1px solid #1d2021; }
+  .popover_menu { background-color: #1d2021; border-top: 1px solid #504945; }
   .popover_menu .arrow::after { background-color: #282828; }
-  .popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #1d2021, 0 0 3px rgba(0, 0, 0, 0.08); }
+  .popover_menu .arrow_shadow::after { background-color: #1d2021; box-shadow: 0 0 0 1px #504945, 0 0 3px rgba(0, 0, 0, 0.08); }
   .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after { background-color: #1d2021 !important; }
   .popover_menu .content { background-color: #1d2021; }
   .tab_complete_ui { background: #1d2021; border: 1px solid #282828; box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5); }
@@ -361,7 +361,7 @@
   .tab_complete_ui ul.type_cmds .cmdname { color: #f9f5d7; }
   .tab_complete_ui ul.type_cmds .cmddesc { color: #d79921; }
   .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group { border-bottom: 1px solid #282828; }
-  .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #1d2021; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active { background: #504945; border-bottom-color: #282828; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span { color: #f9f5d7 !important; }
   .tab_complete_ui .not_in_channel { color: #d79921; }
   #team_menu { background: #282828; border-bottom: 2px solid #282828; color: #f9f5d7; }
@@ -400,9 +400,9 @@
   #flex_menu_toggle.unread #help_icon_circle_count { background-color: #cc241d; color: #fff; }
   #flex_menu_toggle.open #help_icon_circle_count { background-color: #282828; color: #f9f5d7; }
   #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active { background: #282828; color: #f9f5d7; }
-  #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #1d2021; color: #f9f5d7; }
+  #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover { background: #504945; color: #f9f5d7; }
   #recent_mentions_toggle:hover { color: #cc241d; }
-  #rxn_toast_div { background: #282828; border: 1px solid #1d2021; }
+  #rxn_toast_div { background: #282828; border: 1px solid #504945; }
   .presence { color: #d79921; }
   #edit_topic_inner:not(.unable_to_post)::before { background: #1d2021; border-color: #282828; }
   #edit_topic_trigger { color: #689d6a; }
@@ -416,7 +416,7 @@
   .day_container.unread_day_container .day_msgs { border-color: #ebdbb2; }
   .day_container .day_divider { background: none; color: #d79921; }
   .day_container .day_divider .day_divider_label { background: #1d2021; }
-  .search_form { border-color: #1d2021; }
+  .search_form { border-color: #504945; }
   .search_form .search_input { background: transparent; }
   .search_form:hover { border-color: #ebdbb2; }
   .search_focused .search_form { border-color: #ebdbb2; }
@@ -432,10 +432,10 @@
   .c-search_message__body { color: #f9f5d7; }
   .p-search_filter__more_link { color: #f9f5d7; }
   .p-search_filter__title_text { background: #282828; color: #f9f5d7; }
-  .p-search_filter__datepicker_trigger { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .p-search_filter__datepicker_trigger { background: #282828; border-color: #504945; color: #f9f5d7; }
   .p-search_filter__datepicker_trigger:hover { color: #d79921; }
-  .c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #1d2021; color: #f9f5d7; }
-  .c-search_autocomplete footer { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .c-search_modal .popover > div, .c-search_modal .c-search__input_box, .c-search_modal:not(.c-search_modal--primarysearch) .popover > div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box { background: #282828; border-color: #504945; color: #f9f5d7; }
+  .c-search_autocomplete footer { background: #282828; border-color: #504945; color: #f9f5d7; }
   .c-search_autocomplete__suggestion_item { color: #f9f5d7; }
   .c-search_autocomplete__suggestion_item--selected { background-color: #282828; }
   .c-search_autocomplete__suggestion_item .token { background-color: #222222; color: #f9f5d7; }
@@ -459,14 +459,14 @@
   .c-message--sli_highlight_negative .c-message__label { background: rgba(40, 40, 40, 0.1); }
   .c-message--resend .c-message__body { color: #d79921; }
   .c-message--deleting { background: rgba(204, 36, 29, 0.6); }
-  .c-message--standalone { border-color: rgba(29, 32, 33, 0.1); }
+  .c-message--standalone { border-color: rgba(80, 73, 69, 0.1); }
   .c-message--unprocessed .c-message__body { animation: to-grey 50ms linear 10s forwards; }
   .c-message__broadcast_preamble_outer, .c-message__broadcast_preamble { color: #d79921; }
   .c-message__sender { color: #f9f5d7; }
   .c-message__sender a { color: #f9f5d7; }
   .c-message__sender .c-emoji__text_mode_icon { color: #d79921; }
   .c-message__body { color: #f9f5d7; }
-  .c-message__body--unknown { background: rgba(29, 32, 33, 0.1); }
+  .c-message__body--unknown { background: rgba(80, 73, 69, 0.1); }
   .c-message__body--automated { color: #d79921; }
   .c-message__body--tombstone { color: #d79921; }
   .c-message__label { color: #d79921; }
@@ -474,13 +474,13 @@
   .c-message__label__highlight_positive, .c-message__label__highlight_negative { color: #d79921; }
   .c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active { color: #f9f5d7; }
   .c-message__resend_controls { color: #d79921; }
-  .c-message__resend_column { background-color: rgba(29, 32, 33, 0.1); }
+  .c-message__resend_column { background-color: rgba(80, 73, 69, 0.1); }
   .c-message__resend, .c-message__cancel { color: #f9f5d7; }
   .c-message__edited_label { color: #d79921; }
-  .c-message__tombstone_icon { background: rgba(29, 32, 33, 0.1); color: #d79921; }
-  .c-message__bot_label { background: rgba(29, 32, 33, 0.1); color: #d79921; }
+  .c-message__tombstone_icon { background: rgba(80, 73, 69, 0.1); color: #d79921; }
+  .c-message__bot_label { background: rgba(80, 73, 69, 0.1); color: #d79921; }
   .c-message__comment:before { color: #d79921; }
-  .c-message__call_attachment { background: #1d2021; border-color: rgba(29, 32, 33, 0.1); }
+  .c-message__call_attachment { background: #1d2021; border-color: rgba(80, 73, 69, 0.1); }
   .c-message__call_icon { color: #f9f5d7; }
   .c-message__call--ended .c-message__call_icon { color: #d79921; }
   .c-message__call_info { color: #f9f5d7; }
@@ -488,7 +488,7 @@
   .c-message__call_name + .c-message__call_description::before { color: #d79921; }
   .c-message__call_sub { color: #d79921; }
   .c-message_actions__container { background: #1d2021; border-color: #282828; }
-  .c-message_actions__container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  .c-message_actions__container:hover { border-color: #504945; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
   .c-message_actions__button { border-right-color: #282828; color: #689d6a; }
   .c-message_actions__button:hover { color: #f9f5d7; }
   .c-message_actions__button:active { background: #282828; }
@@ -496,8 +496,8 @@
   .c-message_group:hover .c-message_group__header { color: #d79921; }
   .c-message_group__header { color: #f9f5d7; }
   .c-message_group__divider_text { background-color: #1d2021; color: #f9f5d7; }
-  .c-message_list__unread_divider__separator { border-color: #1d2021; }
-  .c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #1d2021; }
+  .c-message_list__unread_divider__separator { border-color: #504945; }
+  .c-message_list__unread_divider__label { background: #1d2021; box-shadow: 0 0 2px rgba(0, 0, 0, 0.25); color: #504945; }
   .c-message_list__spinner { color: #d79921; }
   .c-message_list .c-scrollbar__bar { background: #282828; }
   .c-virtual_list__item--focus:focus .c-message_list__focus_indicator { box-shadow: inset 0 0 0 3px rgba(235, 219, 178, 0.8); }
@@ -529,8 +529,8 @@
   ts-message.delete_mode, ts-message.multi_delete_mode { background: rgba(204, 36, 29, 0.75); }
   ts-message.automated .message_body { color: rgba(249, 245, 215, 0.8); }
   ts-message .action_hover_container { border: 1px solid #282828; }
-  ts-message .action_hover_container:hover { border-color: #1d2021; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
-  ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #1d2021; }
+  ts-message .action_hover_container:hover { border-color: #504945; box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
+  ts-message .action_hover_container:hover a { background: #282828; border-right: 1px solid #504945; }
   ts-message .action_hover_container .btn_msg_action { background: #1d2021; border-right: 1px solid #282828; color: #689d6a; }
   ts-message .action_hover_container .btn_msg_action:hover { color: #f9f5d7; }
   ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active { background: #282828; color: #f9f5d7; }
@@ -551,20 +551,20 @@
   .selecting_messages ts-message:hover { background: #282828; }
   .selecting_messages ts-message.multi_delete_mode:hover { background: rgba(204, 36, 29, 0.75); }
   #convo_container { background-color: #1d2021; }
-  #convo_container #message_edit_container { border-bottom: 1px solid #1d2021; border-top: 1px solid #1d2021; }
+  #convo_container #message_edit_container { border-bottom: 1px solid #504945; border-top: 1px solid #504945; }
   #convo_container ts-conversation::after { background: rgba(40, 40, 40, 0.08); background: -webkit-gradient(linear, left bottom, left top, color-stop(0, transparent), color-stop(1, rgba(40, 40, 40, 0.08))); background: -moz-linear-gradient(center bottom, transparent 0, rgba(40, 40, 40, 0.08) 100%); }
   #convo_container ts-conversation::before { background: transparent; background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(40, 40, 40, 0.08)), color-stop(1, transparent)); background: -moz-linear-gradient(center bottom, rgba(40, 40, 40, 0.08) 0, transparent 100%); }
   #convo_container ts-conversation ts-message.selected { background: #1d2021; }
-  #convo_container ts-conversation ts-relatives::after { background: #1d2021; }
-  #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #1d2021; color: #d79921; }
+  #convo_container ts-conversation ts-relatives::after { background: #504945; }
+  #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i { background-color: #504945; color: #d79921; }
   #convo_container ts-conversation ts-relatives ts-message.deleted .message_content { color: #f9f5d7; }
   #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) { background-color: #1d2021; }
   #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new { background-color: #292d2f; }
-  #msgs_div .unread_divider hr { border-top: 1px solid #1d2021; }
-  #msgs_div .unread_divider .divider_label { background: #1d2021; color: #1d2021; }
+  #msgs_div .unread_divider hr { border-top: 1px solid #504945; }
+  #msgs_div .unread_divider .divider_label { background: #1d2021; color: #504945; }
   #msgs_div .unread_divider.no_unreads hr { border-top-color: #282828; }
   #msgs_div .unread_divider.no_unreads .divider_label { color: #d79921; }
-  .channel_archive_messages.card .col:first-child { border-right: 1px solid #1d2021; }
+  .channel_archive_messages.card .col:first-child { border-right: 1px solid #504945; }
   .star { color: #d79921; }
   .star_item { border-bottom: 1px solid #282828; }
   .star_item .star_meta { color: #d79921; }
@@ -585,16 +585,16 @@
   .bot_label { background: #282828; color: #d79921; }
   @keyframes to-grey { 0% { color: inherit; }
     100% { color: #d79921; } }
-  @keyframes fade-background-highlight { 0% { background: #1d2021; }
+  @keyframes fade-background-highlight { 0% { background: #504945; }
     100% { background: transparent; } }
-  @keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #1d2021, 0 0 0 0.5px #ebdbb2; }
-    100% { box-shadow: 0 0 4px 0 #1d2021, 0 0 0 0 #ebdbb2; } }
+  @keyframes border_focus_animation { 0% { box-shadow: 0 0 4px 0.25px #504945, 0 0 0 0.5px #ebdbb2; }
+    100% { box-shadow: 0 0 4px 0 #504945, 0 0 0 0 #ebdbb2; } }
   .c-message_attachment { color: #f9f5d7; }
-  .c-message_attachment__border { background-color: #1d2021; }
+  .c-message_attachment__border { background-color: #504945; }
   .c-message_attachment__delete { color: #689d6a; }
   .c-message_attachment__delete:hover { color: #cc241d; }
   .c-message_attachment__pretext { color: #f9f5d7; }
-  .c-message_attachment__part + .c-message_attachment__part::before { color: #1d2021; }
+  .c-message_attachment__part + .c-message_attachment__part::before { color: #504945; }
   .c-message_attachment__author .c-message_attachment__autor--distinct { color: #689d6a; }
   .c-message_attachment__author_link + .c-message_attachment__author_link { color: #689d6a; }
   .c-message_attachment__title_link span { color: #f9f5d7; }
@@ -609,10 +609,10 @@
   .c-message_attachment__media_trigger .c-expandable_trigger { color: #689d6a; }
   .c-message_attachment__media_trigger--too_large { color: #689d6a; }
   .c-message_attachment__select { border-color: #282828; }
-  .c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #1d2021; }
+  .c-message_attachment__select:hover, .c-message_attachment__select:active { border-color: #504945; }
   .c-message__reply_bar:hover, .c-message__reply_bar--focus { background-color: #1d2021; border-color: #282828; }
   .c-message__reply_bar:hover .c-message__reply_bar_arrow, .c-message__reply_bar--focus .c-message__reply_bar_arrow { color: #d79921; }
-  .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #1d2021; }
+  .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread { background-color: #504945; }
   .c-message__reply_bar_description { color: #d79921; }
   .c-message__file_meta { color: #d79921; }
   .c-message__image_container { background: rgba(40, 40, 40, 0.1); }
@@ -632,11 +632,11 @@
   .attachment_group .delete_attachment_link ts-icon::before { color: #689d6a; }
   .attachment_group .delete_attachment_link:hover ts-icon::before { color: #cc241d; }
   .attachment_still_pending ts-inline-saver { color: #d79921; }
-  .msg_inline_attachment_column.column_border { background-color: #1d2021; }
+  .msg_inline_attachment_column.column_border { background-color: #504945; }
   .msg_inline_img_holder .msg_inline_img { box-shadow: inset 0 0 0 1px #282828; }
   .msg_inline_attachment_collapser, .msg_inline_attachment_expander, .msg_inline_img_collapser, .msg_inline_img_expander, .msg_inline_media_toggler, .msg_inline_room_preview_collapser, .msg_inline_room_preview_expander { color: #689d6a; }
   .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover { color: #cc241d; }
-  .msg_inline_img { background: #1d2021; }
+  .msg_inline_img { background: #504945; }
   .msg_inline_room_preview_collapser { color: #d79921; }
   .msg_inline_room_preview_collapser:hover { color: #d79921; }
   .inline_attachment span.attachment_author_name { color: #689d6a; }
@@ -677,30 +677,30 @@
   .file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn { background-color: rgba(235, 219, 178, 0.9); }
   .file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover { background-color: #282828; }
   .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions { background: rgba(235, 219, 178, 0.9); border: 1px solid rgba(40, 40, 40, 0.1); }
-  .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(29, 32, 33, 0.8), rgba(29, 32, 33, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
-  .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(29, 32, 33, 0.8); color: #f9f5d7; }
+  .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn { background: linear-gradient(rgba(80, 73, 69, 0.8), rgba(80, 73, 69, 0.8)), linear-gradient(rgba(235, 219, 178, 0.3), rgba(235, 219, 178, 0.3)); color: #f9f5d7; }
+  .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn { background: rgba(80, 73, 69, 0.8); color: #f9f5d7; }
   .file_container .c-file__title, .c-file_container .c-file__title { color: #f9f5d7; }
   .c-file_container--has_thumb .c-file__actions::before { background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), #282828 20px); }
-  .message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #1d2021; color: #f9f5d7; }
+  .message--focus .file_container .preview_show.preview_show_less .preview_show_btn { background: #504945; color: #f9f5d7; }
   .msg_inline_video_buttons_div { background-color: rgba(29, 32, 33, 0.4); }
   .msg_inline_video_buttons_div a { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
   .msg_inline_video_buttons_div a:visited { color: #f9f5d7; text-shadow: 0 1px 1px rgba(40, 40, 40, 0.5); }
   .post_body ul.checklist { background-color: #282828; }
   .post_body ul.checklist li::before { background: #282828; }
   .post_body ul.checklist li.checked { color: #d79921; }
-  .post_body ul.list.checklist li { border-bottom: 1px solid #1d2021; }
+  .post_body ul.list.checklist li { border-bottom: 1px solid #504945; }
   .post_body ul.list.checklist li.checked { color: #d79921; }
   .post_body .message { background-color: #f9f5d7; }
   .post_body code, .post_body pre { background: #282828; }
   ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at { color: #d79921; }
   ts-message .reply_bar:hover { background: #1d2021; border-color: #282828; }
-  .inline_color_block { border-color: #1d2021; }
+  .inline_color_block { border-color: #504945; }
   .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider { background: #1d2021; }
   .p-message_pane .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider::before { background: #1d2021; border-bottom: 1px solid #1d2021; }
   .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty) + div .c-message_list.c-virtual_list--scrollbar > .c-scrollbar__hider:before { box-shadow: 0 32px #1d2021; }
   .p-message_pane__foreword__description, .p-message_pane__limited_history_alert { color: #f9f5d7; }
   .p-message_pane__limited_history_foreword { background: #282828; background-image: none; color: #f9f5d7; }
-  .p-message_pane__unread_banner__banner { background: #1d2021; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
+  .p-message_pane__unread_banner__banner { background: #504945; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   .messages_banner { color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   .messages_banner a { color: #f9f5d7; }
   .messages_banner a:hover { color: #f9f5d7; }
@@ -709,10 +709,10 @@
   #archives_return.warning { background: #cc241d; }
   #archives_return a { color: #f9f5d7; }
   #archives_return a:hover { color: rgba(249, 245, 215, 0.8); }
-  #messages_unread_status { background: #1d2021; }
+  #messages_unread_status { background: #504945; }
   #messages_unread_status:hover { background: #ebdbb2; }
   #messages_unread_status:hover .clear_unread_messages { background: #ebdbb2; }
-  #messages_unread_status:hover .clear_unread_messages:hover { background: #1d2021; }
+  #messages_unread_status:hover .clear_unread_messages:hover { background: #504945; }
   #messages_unread_status.quiet { background: #ebdbb2; color: #f9f5d7; text-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   #messages_unread_status.quiet a { color: #f9f5d7; }
   .clear_unread_messages { border-left: 1px solid rgba(0, 0, 0, 0.15); }
@@ -721,7 +721,7 @@
   #archives_end_div_msg_lim h1, #end_display_msg_lim h1 { color: #f9f5d7; }
   #archives_end_div_msg_lim h2, #end_display_msg_lim h2 { color: rgba(249, 245, 215, 0.8); }
   code { background-color: #282828; border: 1px solid #282828; color: #f9f5d7; }
-  code a.app_preview_link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+  code a.app_preview_link { background: #282828; border: 1px solid #504945; color: #f9f5d7; }
   .file_list_item.snippet .snippet_preview { background: #282828; }
   .snippet_preview, .snippet_body { background: #282828; }
   .snippet_preview pre, .snippet_body pre { color: #f9f5d7 !important; }
@@ -808,17 +808,17 @@
   pre span.mention { padding: 2px 0 !important; }
   #page pre, body > pre { background: #282828; color: #f9f5d7 !important; }
   body > pre { background: #ebdbb2; }
-  .special_formatting_quote .quote_bar { background-color: #1d2021; }
+  .special_formatting_quote .quote_bar { background-color: #504945; }
   #threads_msgs_scroller_div { background: #1d2021; }
   #threads_msgs_scroller_div:not(.loading)::before { background: #1d2021; }
   #threads_msgs_scroller_div.loading::before { color: #d79921; }
   #threads_msgs_scroller_div .threads_caught_up_divider .divider_line { border-top: 1px solid #282828; }
-  #threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #1d2021; color: #f9f5d7; }
+  #threads_msgs_scroller_div .threads_caught_up_divider .divider_label { background: #504945; color: #f9f5d7; }
   #threads_msgs_scroller_div.loading { background: none; }
   #threads_msgs_scroller_div.loading::before { color: #f9f5d7; }
   #threads_view_banner.messages_banner { background: #282828; }
-  #threads_view_banner.messages_banner:hover { background: #1d2021; }
-  #threads_view_banner.messages_banner:hover .clear_unread_messages { background: #1d2021; }
+  #threads_view_banner.messages_banner:hover { background: #504945; }
+  #threads_view_banner.messages_banner:hover .clear_unread_messages { background: #504945; }
   #threads_msgs.new_banner_is_showing::before { background: #1d2021; }
   .p-threads_footer__input .p-message_input_field, .p-threads_footer__input--legacy .p-message_input_field { background: #282828; }
   .p-threads_footer__input .p-message_input_file_button, .p-threads_footer__input--legacy .p-message_input_file_button { background: #282828; }
@@ -833,7 +833,7 @@
   ts-thread .new_reply_indicator .blue_dot { color: #cc241d; }
   #convo_tab .thread_participants, ts-thread .thread_participants { color: #d79921; }
   #convo_loading_indicator { background-image: none; }
-  .reply_input_container .inline_message_input_container .ql-container { background-color: #1d2021; border: 1px solid #282828; }
+  .reply_input_container .inline_message_input_container .ql-container { background-color: #504945; border: 1px solid #282828; }
   .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb { background-color: rgba(0, 0, 0, 0.15); }
   .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb:hover { background-color: rgba(0, 0, 0, 0.25); }
   .reply_input_container .inline_message_input_container .ql-container.focus { border-color: rgba(0, 0, 0, 0.15); }
@@ -845,11 +845,11 @@
   #unread_msgs_scroller_div.loading::before { color: #d79921; }
   #unread_msgs_div .day_divider .day_divider_line { border-top-color: #282828; }
   .unread_group.marked_as_read .unread_group_header { background: #1d2021; }
-  .unread_group .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+  .unread_group .unread_group_header { background: #282828; border-top-color: #504945; color: #f9f5d7; }
   .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon { color: #f9f5d7; }
   .unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down { color: #d79921; }
   .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard { background: #1d2021; }
-  .unread_group.active .unread_group_header { background: #282828; border-top-color: #1d2021; color: #f9f5d7; }
+  .unread_group.active .unread_group_header { background: #282828; border-top-color: #504945; color: #f9f5d7; }
   .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right { color: #d79921; }
   .mark_as_read_checkmark { color: #d79921; }
   .bottom_mark_all_read { border-top-color: #282828; }
@@ -889,7 +889,7 @@
   .toolbar_container { background: #1d2021; border-bottom: 1px solid #282828; color: #f9f5d7; }
   .msg_right_link { color: #689d6a; }
   .message_location_label { color: #d79921; }
-  .p-flexpane_header { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .p-flexpane_header { background: #282828; border-color: #504945; color: #f9f5d7; }
   #client_body:not(.onboarding):not(.feature_global_nav_layout):before { background: #282828; }
   #details_tab .heading { background: #111313; }
   #details_tab .heading a.close_flexpane { color: #689d6a; }
@@ -897,7 +897,7 @@
   #details_tab hr { border-top-color: #282828; }
   #details_tab .conversation_details .member_name:hover { color: #d79921; }
   #details_tab .conversation_details .member_username:hover { color: #f9f5d7; }
-  #details_tab .conversation_details .member_info_timezone { border-top-color: #1d2021; }
+  #details_tab .conversation_details .member_info_timezone { border-top-color: #504945; }
   #details_tab .channel_page_section { background: #1d2021; border-top: 1px solid #282828; }
   #details_tab .channel_page_section .section_header:hover .disclosure_triangle { color: #cc241d; }
   #details_tab .channel_page_section .section_header a { color: #689d6a; }
@@ -906,7 +906,7 @@
   #details_tab .channel_page_section .channel_page_members_highlighter, #details_tab .channel_page_section .channel_page_pinned_items_highlighter { background: rgba(204, 36, 29, 0.25) !important; }
   #details_tab .created_by { color: #f9f5d7; }
   #details_tab .channel_page_member_tabs .icon_member_header { color: #d79921; }
-  #details_tab .pinned_item:hover { border-color: #1d2021; }
+  #details_tab .pinned_item:hover { border-color: #504945; }
   #details_tab .channel_page_action .leave_link { color: #689d6a; }
   #details_tab .channel_page_action .leave_link:hover { color: #cc241d; }
   #details_tab .channel_section_label .ts_icon_info_circle { color: #d79921; }
@@ -915,7 +915,7 @@
   .channel_page_member_row a { color: #689d6a; }
   .channel_page_member_row.away { color: #f9f5d7; }
   .channel_page_member_row.away a { color: #689d6a; }
-  .channel_page_member_row:hover { background-color: #1d2021; border-color: #282828; }
+  .channel_page_member_row:hover { background-color: #504945; border-color: #282828; }
   .pinned_item { color: #f9f5d7; }
   .pinned_item .pin_file_title { color: #689d6a; }
   .pinned_item .pin_member_name a { color: #689d6a !important; }
@@ -926,20 +926,20 @@
   .pinned_item.delete_mode { border-color: #cc241d !important; }
   .p-channel_insights .c-member__title { color: #d79921; }
   .p-channel_insights_activity_bar_container:hover { background-color: rgba(40, 40, 40, 0.05); }
-  .p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #1d2021; }
-  .p-channel_insights__activity { border-color: #1d2021; }
-  .p-channel_insights__activity_bar { background-color: rgba(29, 32, 33, 0.5); }
+  .p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar { background-color: #504945; }
+  .p-channel_insights__activity { border-color: #504945; }
+  .p-channel_insights__activity_bar { background-color: rgba(80, 73, 69, 0.5); }
   .p-channel_insights__channel .channel_link { color: #f9f5d7; }
   .p-channel_insights__date_heading span { background-color: #1d2021; color: #f9f5d7; }
-  .p-channel_insights__date_heading::before { background-color: #1d2021; }
+  .p-channel_insights__date_heading::before { background-color: #504945; }
   .p-channel_insights__drawer_title { color: #d79921; }
   .p-channel_insights__highlights_description { color: #d79921; }
   .p-channel_insights__item--user .member_preview_link, .p-channel_insights__item--user .message_sender { color: #f9f5d7 !important; }
   .p-channel_insights__member_count { color: #d79921; }
   .p-channel_insights__member_count .ts_icon_user { color: #d79921; }
   .p-channel_insights__message--truncate::before { background: linear-gradient(180deg, transparent, #1d2021 90%); }
-  .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #1d2021; }
-  .p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #1d2021; }
+  .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) { background-color: #1d2021; border-color: #504945; }
+  .p-channel_insights__section:not(.p-channel_insights__section--no_border) { border-color: #504945; }
   .p-channel_insights__title { color: #f9f5d7; }
   .p-channel_insights__user_title { color: #d79921; }
   .p-download_item { padding: 12px 12px 4px 16px; margin: 0; }
@@ -950,19 +950,19 @@
   #file_list_toggle_users { color: #689d6a; }
   #file_list_toggle_users.active:hover, #file_list_toggle_users:hover { color: #cc241d; }
   #file_list_toggle_users.active { color: #d79921; }
-  .file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
-  .filetype_button { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7 !important; }
+  .file_list_item .icon, .file_reference .icon { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7 !important; }
+  .filetype_button { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7 !important; }
   .filetype_button:hover { background: #ebdbb2; }
-  .filetype_button:hover .file_download_label { background: #1d2021; color: #f9f5d7; }
+  .filetype_button:hover .file_download_label { background: #504945; color: #f9f5d7; }
   .filetype_button .file_title { color: #f9f5d7; }
-  .filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #1d2021; }
-  a.filetype_button_web { background: #ebdbb2; border: 1px solid #1d2021; color: #f9f5d7; }
-  a.filetype_button_web .filetype_icon { background-color: #1d2021; }
+  .filetype_button .file_download_label { background: #ebdbb2; border-top: 1px solid #504945; }
+  a.filetype_button_web { background: #ebdbb2; border: 1px solid #504945; color: #f9f5d7; }
+  a.filetype_button_web .filetype_icon { background-color: #504945; }
   a.file_download_link { color: #689d6a; }
   a.file_download_link:hover { color: #cc241d; }
   a:hover .file_inline_icon { color: #d79921; }
   a.gsheet img, a.pdf img { background: #1d2021 !important; }
-  html.no_touch a.filetype_button_web:hover { border-color: #1d2021; }
+  html.no_touch a.filetype_button_web:hover { border-color: #504945; }
   html.no_touch a.filetype_button_web:hover .file_title { color: #f9f5d7; }
   .file_header_detailed { color: #d79921; }
   .file_header_detailed .member { color: #f9f5d7 !important; }
@@ -980,7 +980,7 @@
   .file_list_item a { color: #689d6a; }
   .file_list_item a.member { color: #cc241d; }
   .file_list_item .bullet { color: #d79921; }
-  .file_list_item .icon { background: #ebdbb2; border-color: #1d2021; }
+  .file_list_item .icon { background: #ebdbb2; border-color: #504945; }
   .file_list_item .ts_icon_comment { color: #d79921; }
   .file_list_item .file_comment_link:hover { color: #689d6a; }
   .file_list_item .file_comment_link:hover .ts_icon_comment { color: #d79921; }
@@ -990,7 +990,7 @@
   .file_list_item .actions a, .file_list_item .actions span { background-color: #282828; border: 1px solid #ebdbb2; color: #689d6a; }
   .file_list_item .actions a:hover { background-color: #1d2021 !important; border-color: #ebdbb2; color: #cc241d; }
   .file_list_item.post .preview, .file_list_item.space .preview { color: #f9f5d7; }
-  .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #1d2021; }
+  .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover { background-color: #282828; border-color: #504945; }
   .file_list_item #share_dialog .title a, .file_list_item.active .title a, .file_list_item:active .title a, .file_list_item:hover .title a { color: #689d6a; }
   .file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions { background-color: transparent; }
   .file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span { background-color: #282828; }
@@ -1011,7 +1011,7 @@
   .comment_actions { color: #d79921; }
   .comment_actions:hover { color: #f9f5d7; }
   .icon_quote { color: #f9f5d7; }
-  .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
+  .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input { background: #504945; border-color: #282828; color: #f9f5d7; }
   .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover { border-color: #282828; }
   .tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump { background-color: #1d2021; }
   .tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after { border-color: #282828; }
@@ -1025,7 +1025,7 @@
   .tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time { color: #d79921; }
   .tab_container .file_list_item .filetype_image { background-color: #282828; }
   .active .tab_container .file_list_item { background-color: #1d2021; }
-  .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #1d2021; border-color: #282828; color: #fff; }
+  .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover { background: #504945; border-color: #282828; color: #fff; }
   .c-file__meta { color: #f9f5d7; }
   .c-file__slide--meta { background-color: #282828; }
   .p-file_details__name, .p-file_details__share_channel { color: #f9f5d7; }
@@ -1036,18 +1036,18 @@
   .p-file_list, .p-file_list__filters { background: #282828; }
   .p-file_list__filters { border-color: #282828; }
   .p-file_list__file.c-pillow_file_container, .p-file_list__file.c-pillow_file_container--full_width { background: #282828; border-color: #282828; color: #f9f5d7; }
-  .p-file_list__file.c-pillow_file_container--full_width:hover { background: #1d2021; border-color: #1d2021; }
+  .p-file_list__file.c-pillow_file_container--full_width:hover { background: #504945; border-color: #504945; }
   .p-downloads_list__shift_hint { background: linear-gradient(180deg, rgba(255, 255, 255, 0), #1d2021 25%, #1d2021); color: #f9f5d7; }
   .p-download_item__container .p-download_item__actions { background-color: #1d2021; }
   .p-download_item__container .p-download_item__link__open, .p-download_item__container .p-download_item__link__retry, .p-download_item__container .p-download_item__link__show { color: #689d6a; }
   .p-download_item__container .p-download_item__name_row { color: #f9f5d7; }
   #user_groups_pane .mention { background: rgba(204, 36, 29, 0.25); border: 0; border-radius: 3px; padding: 2px; }
-  #user_groups_container .info_panel { background: #1d2021; border: 1px solid #1d2021; }
+  #user_groups_container .info_panel { background: #1d2021; border: 1px solid #504945; }
   #user_groups_container .mention { background-color: rgba(204, 36, 29, 0.25) !important; }
   #user_groups_header .user_groups_search .icon_search { color: #d79921; }
   #user_groups_header a.icon_close { color: #689d6a; }
   #user_groups_header a.icon_close:hover { color: #cc241d; }
-  .user_group_item { border-bottom: 1px solid #1d2021; }
+  .user_group_item { border-bottom: 1px solid #504945; }
   .user_group_item a { color: #689d6a; }
   #flex_contents .user_group_item:hover { background-color: #1d2021; }
   #flex_contents .user_group_item:hover h4 { color: #f9f5d7; }
@@ -1059,7 +1059,7 @@
   .mention_day_container_div .day_divider::before { background: none; border-color: #282828; }
   #member_mentions h3 a { color: #689d6a; }
   a.internal_member_link { background: #282828; color: #f9f5d7; }
-  a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #1d2021; color: #f9f5d7; }
+  a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link { background: #282828; border: 1px solid #504945; color: #f9f5d7; }
   a.c-member_slug.active, a.c-member_slug:hover, .c-member_slug--link.active, .c-member_slug--link:hover, .c-mrkdwn__subteam--link.active, .c-mrkdwn__subteam--link:hover { background: #282828; color: #f9f5d7; }
   .mention_rxn .mention_rxn_summary { color: #f9f5d7; }
   .mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members { color: #d79921; }
@@ -1075,13 +1075,13 @@
   #search_file_list_toggle_users.active:hover { border: 2px solid #cc241d; color: #cc241d !important; }
   .no_results { color: #f9f5d7; }
   #search_results_team .team_results_heading { color: #f9f5d7; }
-  #search_results_team .team_result { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  #search_results_team .team_result { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
   #search_results_team .team_result a { color: #689d6a; }
   #search_results_team .team_result:hover a { color: #cc241d; }
   #search_results_team .team_result a:hover { color: #cc241d; }
   #search_results_team .member_name { color: #f9f5d7 !important; }
   .suggestion { color: #f9f5d7; }
-  .suggestion.active, .suggestion:hover { background: #1d2021; }
+  .suggestion.active, .suggestion:hover { background: #504945; }
   #paging_in_options .search_paging { color: #d79921; }
   #search_results_items .search_paging { color: #f9f5d7; }
   .search_paging i.disabled { color: #d79921; }
@@ -1091,31 +1091,31 @@
   .search_segmented_control { border-color: #282828; color: #689d6a !important; }
   .search_segmented_control:hover { color: #cc241d !important; }
   .search_segmented_control.active { background: #282828; color: #cc241d !important; }
-  .search_result_with_extract { background: #282828; border-color: #1d2021; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
+  .search_result_with_extract { background: #282828; border-color: #504945; box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15); }
   .search_result_with_extract:hover { border-color: #ebdbb2; }
   .search_result_for_context::after { background: rgba(29, 32, 33, 0.1); }
   .extract_expand_text, .extract_expand_icons { color: #689d6a; }
   .search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons { color: #cc241d; }
   .search_module_header { color: #f9f5d7; }
-  .search_module_footer { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+  .search_module_footer { background-color: #282828; border-bottom-color: #504945; border-left-color: #504945; border-right-color: #504945; }
   .search_module_footer p { color: #f9f5d7; }
   .search_module_footer #see_more { color: #f9f5d7; }
   .search_module_footer #see_more a { color: #f9f5d7; }
   .search_module_footer .top_results_feedback a { color: #f9f5d7; }
   .search_module_footer ts-icon { color: #f9f5d7; }
-  .top_results_search_message_result { background-color: #282828; border-bottom-color: #1d2021; border-left-color: #1d2021; border-right-color: #1d2021; }
+  .top_results_search_message_result { background-color: #282828; border-bottom-color: #504945; border-left-color: #504945; border-right-color: #504945; }
   .top_results_search_message_result.duplicate { background-color: #282828; }
   .top_results_search_message_result .timestamp { color: #d79921; }
   .top_results_search_message_result .channel { color: #d79921; }
   .top_results_search_message_result .channel a { color: #d79921; }
   .top_results_search_message_result .jump { color: #f9f5d7; }
-  .top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #1d2021 !important; }
-  .top_results_search_message_result:first-child { border-top: 2px solid #1d2021; }
+  .top_results_search_message_result:hover { border-color: rgba(235, 219, 178, 0.6) !important; border-top: 2px solid #504945 !important; }
+  .top_results_search_message_result:first-child { border-top: 2px solid #504945; }
   .sli_expert_search { background-color: #1d2021; color: #f9f5d7; }
-  .sli_expert_search__result { border-color: #1d2021; }
+  .sli_expert_search__result { border-color: #504945; }
   .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link { color: #f9f5d7 !important; }
   .sli_expert_search__fg_face::before { background-color: #1d2021; }
-  .sli_expert_search_cta { border-color: #1d2021; }
+  .sli_expert_search_cta { border-color: #504945; }
   .sli_expert_search_cta:hover { border-color: #ebdbb2; }
   .sli_expert_search_cta__text { color: #f9f5d7; }
   .sli_expert_search_cta__text:hover { color: #f9f5d7; }
@@ -1124,30 +1124,30 @@
   .sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow { color: #d79921; }
   .sli_expert_search__partial_terms { color: #d79921; }
   .feature_sli_file_search #search_filters.all #filter_all { border-bottom-color: #282828; color: #f9f5d7; }
-  .feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results .file_list_item { background-color: #1d2021; border-color: #504945; }
   .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages { background-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result { background-color: #1d2021; border-color: #504945; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child { border-top-color: #504945; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover { border-top-color: #504945; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group { border-bottom-color: #504945; }
+  .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover { border-bottom-color: #504945; }
   .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta { color: #d79921; }
   .feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link { color: #d79921; }
   .feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link { color: #f9f5d7; }
   .feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link { color: #f9f5d7; }
   .feature_sli_file_search #search_results.all { background-color: #1d2021; }
-  .feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .top_search_results .search_message_result { background-color: #1d2021; border-color: #504945; }
   .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a { color: #d79921; }
-  .feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .sli_expert_search_cta { border-color: #504945; }
   .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover { border-color: #ebdbb2; }
   .feature_sli_file_search #search_results.all .sli_expert_search__result { border-color: #ebdbb2; }
-  .feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #1d2021; }
+  .feature_sli_file_search #search_results.all .team_result { background-color: #1d2021; border-color: #504945; }
   .feature_sli_file_search #search_results.files { background-color: #1d2021; }
   .feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading { color: #f9f5d7; }
   .feature_sli_file_search #search_results_loading { background-color: #1d2021; }
   .feature_sli_file_search #search_results_container #search_options { background-color: #1d2021; }
   .feature_sli_file_search #search_results_container .heading { background-color: #1d2021; }
-  #client-ui .file_list_item.file_list_item--redesign { border-color: #1d2021; }
+  #client-ui .file_list_item.file_list_item--redesign { border-color: #504945; }
   #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel { color: #d79921; }
   #client-ui .file_list_item.file_list_item--redesign .message_sender { color: #d79921; }
   .p-shortcuts_flexpane__shortcut { border-color: #282828; }
@@ -1158,7 +1158,7 @@
   .p-shortcuts_flexpane__tip { color: #d79921; }
   .p-shortcuts_flexpane__section_description { color: #d79921; }
   .p-shortcuts_flexpane__sub_heading { color: #d79921; }
-  .c-keyboard_key { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
+  .c-keyboard_key { background: #504945; border-color: #ebdbb2; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); color: #f9f5d7; }
   .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp { color: #d79921; }
   #member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) { color: #689d6a; }
   #member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover { color: #cc241d; }
@@ -1185,13 +1185,13 @@
   #disabled_members_tab a { color: #689d6a; }
   #disabled_members_tab a:hover { background: #282828; color: #cc241d; }
   #disabled_members_tab.active a { color: #689d6a; }
-  .team_list_item { border-top: 1px solid #1d2021; color: #689d6a; }
+  .team_list_item { border-top: 1px solid #504945; color: #689d6a; }
   .team_list_item .member_name { color: #f9f5d7; }
   #client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a { color: #f9f5d7 !important; }
   #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded { border-color: #282828 !important; }
-  #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #1d2021 !important; }
+  #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover { border-color: #504945 !important; }
   #client-ui .searchable_member_list .team_list_item { border-bottom-color: #282828; }
-  #client-ui .searchable_member_list .team_list_item:hover { background: #1d2021; }
+  #client-ui .searchable_member_list .team_list_item:hover { background: #504945; }
   .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title, .c-unified_member__other-names, .c-unified_member__other-names { color: #f9f5d7 !important; }
   #convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover { color: #f9f5d7; }
   #convo_tab textarea.message_input { color: #f9f5d7; }
@@ -1210,9 +1210,9 @@
   #whats_new_tab .flex_heading_controls label { color: #d79921; }
   .c-member__display-name, .c-team__display-name, .c-usergroup__handle { color: #f9f5d7; }
   .c-member__current-status--small::before, .c-member__secondary-name--large + .c-member__current-status--large::before, .c-member__secondary-name--medium + .c-member__current-status--medium::before { color: #f9f5d7; }
-  .c-member .external_team_badge { background-color: #1d2021; box-shadow: 0 0 0 2px #1d2021; }
+  .c-member .external_team_badge { background-color: #504945; box-shadow: 0 0 0 2px #504945; }
   .c-member .external_team_badge.default { background-color: #d79921; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15); }
-  .c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #1d2021; }
+  .c-member .external_team_badge::after { box-shadow: inset 0 0 0 1px #504945; }
   .c-member__name--small, .c-team__name--small, .c-usergroup__name--small { color: #f9f5d7; }
   .c-member--small .presence { color: #d79921; }
   .c-member--small .team_image.icon_16 { border-color: #282828; }
@@ -1247,7 +1247,7 @@
   .p-emoji_picker__group_tabs { border-bottom-color: #282828; }
   .p-emoji_picker__group_tab { color: #689d6a; }
   .p-emoji_picker__group_tab:hover { background: #282828; color: #cc241d; }
-  .p-emoji_picker__group_tab--active { background: #1d2021; border-bottom-color: #282828; color: #f9f5d7; }
+  .p-emoji_picker__group_tab--active { background: #504945; border-bottom-color: #282828; color: #f9f5d7; }
   .p-emoji_picker__icon_search { color: #d79921; }
   .p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container { background: #1d2021; border-color: #1d2021; }
   .p-emoji_picker__skintone_options { background: #1d2021; }
@@ -1258,7 +1258,7 @@
   .p-emoji_picker__footer { background: #282828; border-top-color: #282828; }
   .p-emoji_picker__footer .p-emoji_picker__heading { background: #282828; }
   .p-emoji_picker__emoji_deluxe_label { color: #d79921; }
-  input[type="text"].p-emoji_picker__input:focus { border-color: #1d2021; box-shadow: none; }
+  input[type="text"].p-emoji_picker__input:focus { border-color: #504945; box-shadow: none; }
   #message_edit_form .current_status_empty_emoji, #message_edit_form .current_status_empty_emoji_cover, #message_edit_form .emo_menu, #msg_form .current_status_empty_emoji, #msg_form .current_status_empty_emoji_cover, #msg_form .emo_menu, .current_status_container .current_status_empty_emoji, .current_status_container .current_status_empty_emoji_cover, .current_status_container .emo_menu, .current_status_input_container .current_status_empty_emoji, .current_status_input_container .current_status_empty_emoji_cover, .current_status_input_container .emo_menu, .inline_message_input_container .current_status_empty_emoji, .inline_message_input_container .current_status_empty_emoji_cover, .inline_message_input_container .emo_menu, .share_channel_modal_contents .current_status_empty_emoji, .share_channel_modal_contents .current_status_empty_emoji_cover, .share_channel_modal_contents .emo_menu { color: #d79921; }
   #message_edit_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus ~ .current_status_emoji_picker .current_status_empty_emoji { color: #f9f5d7; }
   #message_edit_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus ~ .emo_menu, #message_edit_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus ~ .emo_menu, #msg_form #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus ~ .emo_menu, #msg_form #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus ~ .emo_menu, .current_status_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus ~ .emo_menu, .current_status_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus ~ .emo_menu, .current_status_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus ~ .emo_menu, .current_status_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus ~ .emo_menu, .inline_message_input_container #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus ~ .emo_menu, .inline_message_input_container #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus ~ .emo_menu, .share_channel_modal_contents #msg_input.focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus ~ .emo_menu, .share_channel_modal_contents #msg_input:focus ~ #primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus ~ .emo_menu { color: #f9f5d7; }
@@ -1266,7 +1266,7 @@
   .current_status_emoji_picker { border-right-color: #282828; }
   .current_status_input_for_team_menu .current_status_presets { border-top: 1px solid #282828; }
   .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label { color: #d79921; }
-  .rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #1d2021; }
+  .rxn, .c-reaction, .c-reaction_add, .c-member_slug { background: #282828; border: 1px solid #504945; }
   .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover { background: #282828; }
   .rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count { color: #f9f5d7; }
   .rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted { background-color: rgba(40, 40, 40, 0.08); border-color: rgba(235, 219, 178, 0.4) !important; }
@@ -1293,13 +1293,13 @@
   #fs_modal.fs_modal_header .fs_modal_btn:active { color: #f9f5d7; }
   #fs_modal #fs_modal_footer { background-color: #282828; }
   .p-apps_browser__apps_list--loading::before { background-color: #282828; }
-  .p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #1d2021; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
+  .p-apps_browser__category_section--tutorial .p-apps_browser__app { border-color: #504945; box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15); }
   .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected { background: #282828; box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25); }
   .p-apps_browser__category_header { background: #1d2021; color: #d79921; }
-  .p-apps_browser__app { border-top-color: #1d2021; }
+  .p-apps_browser__app { border-top-color: #504945; }
   .p-apps_browser__app--selected { background: #282828; border-color: #ebdbb2; }
   .p-apps_browser__app_info { color: #f9f5d7; }
-  .p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  .p-apps_browser__browse_apps, .p-apps_browser__app_action { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
   .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus { background-color: #ebdbb2; color: #f9f5d7; }
   .p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active { box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.15); }
   .p-apps_browser__app_description { color: #d79921; }
@@ -1325,7 +1325,7 @@
   .channel_prefs_body__section_header_icon::before { color: #f9f5d7; }
   .channel_prefs_body__mute_help_text { color: #d79921; }
   .channel_prefs_notifications_table { border-bottom-color: #282828; color: #f9f5d7; }
-  .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #1d2021 !important; }
+  .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title { border-bottom-color: #504945 !important; }
   .channel_prefs__muting_checkbox_label { color: #f9f5d7; }
   .channel_prefs__muting_checkbox_label:not(.subtle_silver) { color: #f9f5d7 !important; }
   .notification_prefs_icon::before { color: #f9f5d7; }
@@ -1334,35 +1334,35 @@
   #channel_browser .channel_browser_row_header { color: #f9f5d7; }
   #channel_browser .channel_browser_creator_name { color: #d79921; }
   #channel_browser .channel_browser_open, #channel_browser .channel_browser_preview { color: #d79921; }
-  #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #1d2021; }
+  #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted { background: #282828; border: 1px solid #504945; }
   #channel_browser .channel_browser_divider { background: transparent; color: #d79921; }
   #channel_browser .channel_browser_sort_container::after { color: #f9f5d7; }
   #channel_browser .channel_browser_channel_purpose { color: #f9f5d7; }
   .channel_invite_member .add_icon, .channel_invite_member_small .add_icon { color: #689d6a; }
   .channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token { color: #d79921 !important; }
   .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar { background-color: #282828; color: #f9f5d7; }
-  #invite_members_container .lfs_input_container { background: #1d2021; }
+  #invite_members_container .lfs_input_container { background: #504945; }
   #notifications_not_working p.highlight_yellow_bg a { color: #f9f5d7; }
   .c-dialog__header { background: #282828; }
   .c-dialog__header .c-dialog__title, .c-dialog__header .c-dialog__close { color: #f9f5d7; }
   .c-dialog__header .c-dialog__close:hover { color: #689d6a; }
   .c-dialog__body { background: #222222; }
   .c-dialog__body .p-share_dialog_message_input { background-color: #282828; border-color: #282828; color: #f9f5d7; }
-  .c-dialog__body .p-share_dialog_message_input.focus { border-color: #1d2021; box-shadow: unset; }
+  .c-dialog__body .p-share_dialog_message_input.focus { border-color: #504945; box-shadow: unset; }
   .c-dialog__body .p-file_upload_dialog__preview, .c-dialog__body .p-file_upload_dialog__preview_image { background-color: #282828; border-color: #282828; }
   .c-dialog__body input.c-input_text { border-color: #282828; }
   .c-dialog__body input.c-input_text .c-input_character_count { background-color: #282828; color: #f9f5d7; }
-  .c-dialog__body input.c-input_text:focus { border-color: #1d2021; box-shadow: unset; }
+  .c-dialog__body input.c-input_text:focus { border-color: #504945; box-shadow: unset; }
   .c-dialog__footer { background: #222222; }
-  .c-dialog__footer .c-button { background-color: #1d2021; color: #f9f5d7; }
+  .c-dialog__footer .c-button { background-color: #504945; color: #f9f5d7; }
   .c-dialog__footer .p-file_upload_dialog__footer_share_inputs { color: #f9f5d7; }
-  #im_browser .im_browser_row { border-top: 1px solid #1d2021; }
+  #im_browser .im_browser_row { border-top: 1px solid #504945; }
   #im_browser .im_browser_row.multiparty { color: #f9f5d7; }
   #im_browser .im_browser_row.multiparty .member_image + .member_image:not(.ra):not(.ura) { border: 2px solid #282828; }
   #im_browser .im_browser_row .im_unread_cnt { background: #cc241d; color: #f9f5d7; }
   #im_browser .im_browser_row.disabled { color: #d79921; }
-  #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #1d2021 !important; }
-  #im_browser_tokens { background: #1d2021; border: 1px solid #ebdbb2; }
+  #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted { background: #282828 !important; border: 1px solid #504945 !important; }
+  #im_browser_tokens { background: #504945; border: 1px solid #ebdbb2; }
   #im_browser_tokens.active { border-color: #ebdbb2; box-shadow: 0 0 7px rgba(235, 219, 178, 0.15); }
   #im_browser_tokens .member_token { background: #1d2021; border: 1px solid #282828; color: #f9f5d7; }
   #im_browser_tokens .member_token.ra { background: #cc241d; }
@@ -1372,11 +1372,11 @@
   .fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn { color: #f9f5d7; }
   .fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited { color: #f9f5d7; }
   .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover { color: #d79921; }
-  .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #1d2021; }
+  .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active { background: #504945; }
   .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info { color: #d79921; }
-  .fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #1d2021; }
+  .fs_modal_file_viewer_header .close_btn::after { border-right: 1px solid #504945; }
   .fs_modal_file_viewer_content .viewer { background-color: #282828; color: #f9f5d7 !important; }
-  .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #1d2021; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
+  .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon { background: #504945; box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25); }
   .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) { background: rgba(235, 219, 178, 0.25); color: #f9f5d7; }
   .fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover { color: rgba(215, 153, 33, 0.8); }
   .fs_modal_file_viewer_content .aside_panel { background-color: #1d2021; box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25); }
@@ -1387,7 +1387,7 @@
   #file_comment_textarea.texty_comment_input { background: #1d2021; border-color: #282828; color: #f9f5d7; }
   #file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover { border-color: #282828; }
   #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues { color: #d79921; }
-  #fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #1d2021; }
+  #fs_modal.help_modal .help_modal_header { background-color: #282828; border-color: #504945; }
   #fs_modal.help_modal .help_modal_header a { color: #f9f5d7; }
   #fs_modal.help_modal .help_modal_divider { color: #d79921; }
   #fs_modal.help_modal .help_modal_article_row { border-top: 1px solid #282828; }
@@ -1403,20 +1403,20 @@
   .admin_invite_row .delete_row:hover, .admin_invite_row .hide_custom_message:hover, .admin_invites_custom_message_container .delete_row:hover, .admin_invites_custom_message_container .hide_custom_message:hover { color: #cc241d; }
   .admin_invite_row.delete_highlight, .admin_invites_custom_message_container.delete_highlight { background: rgba(204, 36, 29, 0.4); }
   #admin_invites_channel_picker_container { border-bottom: 1px solid #282828; }
-  #admin_invites_add_row { background: #1d2021; border: 1px solid #282828; }
-  #admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #1d2021; }
-  #channel_invite_tokens { background-color: #1d2021; border-color: #ebdbb2; }
+  #admin_invites_add_row { background: #504945; border: 1px solid #282828; }
+  #admin_invites_workflow .lazy_filter_select .lfs_input_container { background-color: #504945; }
+  #channel_invite_tokens { background-color: #504945; border-color: #ebdbb2; }
   #channel_invite_tokens.active { border-color: #d79921; box-shadow: 0 0 7px rgba(215, 153, 33, 0.15); }
   #channel_invite_tokens .member_token { background: #1d2021; color: #f9f5d7; }
   #channel_invite_tokens .member_token.ra { background: rgba(204, 36, 29, 0.4); }
-  #admin_invites_alert { background: #1d2021; border-color: #ebdbb2; }
+  #admin_invites_alert { background: #504945; border-color: #ebdbb2; }
   .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon { color: #f9f5d7; }
   .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar { background-color: #1d2021; color: #f9f5d7; }
   #shortcuts_dialog { background: rgba(29, 32, 33, 0.95); text-shadow: 0 1px 1px rgba(40, 40, 40, 0.7); }
   #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 { color: #f9f5d7; }
-  #shortcuts_dialog.modal ul ul { border-left-color: #1d2021; }
+  #shortcuts_dialog.modal ul ul { border-left-color: #504945; }
   #shortcuts_dialog.modal .info_block { color: #d79921; }
-  #shortcuts_dialog.modal .close { background: #1d2021; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
+  #shortcuts_dialog.modal .close { background: #504945; border-color: #ebdbb2; box-shadow: 0 1px 2px rgba(40, 40, 40, 0.5); color: #f9f5d7; }
   #shortcuts_dialog.modal .close:hover { box-shadow: 0 1px 2px rgba(40, 40, 40, 0.9); }
   #fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon { color: #d79921; }
   #fs_modal.prefs_modal #prefs_sidebar .theme_thumb { box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25); }
@@ -1440,9 +1440,9 @@
   .sidebar_menu_list_item:not(.is_active):hover { background-color: #282828; }
   .jumbomoji_pref_disabled { color: #d79921; }
   .jumbomoji_disabled_note { color: rgba(215, 153, 33, 0.6); }
-  #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #1d2021; border: 1px solid #282828; }
-  #edit_team_profile_container .lazy_filter_select.disabled { background: #1d2021; }
-  #edit_team_profile_container .lazy_filter_select.disabled input { background: #1d2021; }
+  #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled { background: #504945; border: 1px solid #282828; }
+  #edit_team_profile_container .lazy_filter_select.disabled { background: #504945; }
+  #edit_team_profile_container .lazy_filter_select.disabled input { background: #504945; }
   #edit_team_profile_add .row, #edit_team_profile_list .row { border-top: 1px solid #282828; }
   #edit_team_profile_list .row:nth-last-child(2):hover { border-color: #282828 !important; }
   #edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover { background: #282828; border: 1px solid #282828; }
@@ -1450,8 +1450,8 @@
   #edit_team_profile_list .edit_team_profile_list_controls i { color: #f9f5d7; }
   #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover { color: #d79921; }
   #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_grabby_patty:hover { color: #d79921; }
-  #edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #1d2021; }
-  #edit_team_profile_add .row:last-child { border-bottom: 1px solid #1d2021; }
+  #edit_team_profile_list .sortable-placeholder::before { border-top: 1px solid #504945; }
+  #edit_team_profile_add .row:last-child { border-bottom: 1px solid #504945; }
   #edit_team_profile_add .row:not(.header_row):hover { background: #282828; border: 1px solid #282828; }
   #edit_team_profile_add .row:not(.header_row):hover .col:first-child { color: #f9f5d7; }
   #edit_team_profile_add .row:not(.header_row):hover i { border-color: #282828; color: #f9f5d7; }
@@ -1463,13 +1463,13 @@
   #edit_team_profile_custom .row .col .profile_field_preview { background: #282828; border: 2px solid #282828; }
   #edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover { border-color: #282828; }
   #edit_team_profile_custom .row .col .profile_field_preview:active span, #edit_team_profile_custom .row .col .profile_field_preview:hover span { color: #d79921; }
-  #edit_team_profile_custom .row .col input { background: #1d2021; border: 1px solid #282828; }
+  #edit_team_profile_custom .row .col input { background: #504945; border: 1px solid #282828; }
   #edit_team_profile_custom .row .col[data-type=options_list] span::after { color: #d79921; }
   #edit_team_profile_custom .row .col[data-type=options_list] input { border-right: 1px solid #282828; }
-  .profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #1d2021; }
+  .profile_field_preview_protector .profile_field_preview { background: #1d2021; border: 1px solid #504945; }
   .profile_field_preview_protector .profile_field_preview::after { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
   .profile_field_preview_protector .profile_field_preview::before { background-color: #1d2021; box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25); }
-  .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #1d2021; color: #d79921; }
+  .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled { background: #504945; color: #d79921; }
   .profile_field_preview_protector .profile_field_preview .profile_field_preview_fade_out_mask { background: linear-gradient(to left, #282828, rgba(255, 255, 255, 0)); }
   .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::before { border-color: transparent transparent transparent #282828; }
   .profile_field_preview_protector .profile_field_preview .profile_field_preview_ribbon::after { border-color: #282828 transparent transparent; }
@@ -1490,35 +1490,35 @@
   #share_dialog .file_list_item { border-color: #282828; }
   #generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) { color: #d79921; }
   #share_dialog_input_container #file_comment_textarea.ql-container { border-color: #282828; }
-  #share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #1d2021; }
+  #share_dialog_input_container #file_comment_textarea.ql-container.focus { border-color: #504945; }
   #share_dialog_input_container #file_comment_textarea.ql-container.focus ~ .emo_menu { color: #f9f5d7; }
-  .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #1d2021; }
+  .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip { background: #504945; }
   .ts_tip .ts_tip_tip { color: #f9f5d7; }
-  .ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #1d2021; }
-  .ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #1d2021; }
-  .ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #1d2021; }
-  .ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #1d2021; }
+  .ts_tip.ts_tip_left .ts_tip_tip::after { border-left-color: #504945; }
+  .ts_tip.ts_tip_right .ts_tip_tip::after { border-right-color: #504945; }
+  .ts_tip.ts_tip_top .ts_tip_tip::after { border-top-color: #504945; }
+  .ts_tip.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #504945; }
   .ts_tip.success .ts_tip_tip { background: #ebdbb2; }
   .ts_tip.success.ts_tip_left .ts_tip_tip::after { border-left-color: #ebdbb2; }
   .ts_tip.success.ts_tip_right .ts_tip_tip::after { border-right-color: #ebdbb2; }
   .ts_tip.success.ts_tip_top .ts_tip_tip::after { border-top-color: #ebdbb2; }
   .ts_tip.success.ts_tip_bottom .ts_tip_tip::after { border-bottom-color: #ebdbb2; }
-  .c-tooltip__tip { background-color: #1d2021; color: #f9f5d7; }
-  .c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #1d2021; }
-  .c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #1d2021; }
-  .c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #1d2021; }
-  .c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #1d2021; }
-  .c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
-  .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
-  .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #1d2021; }
-  .c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #1d2021; }
+  .c-tooltip__tip { background-color: #504945; color: #f9f5d7; }
+  .c-tooltip__tip--top .c-tooltip__tip__arrow { border-top-color: #504945; }
+  .c-tooltip__tip--top-left .c-tooltip__tip__arrow { border-top-color: #504945; }
+  .c-tooltip__tip--top-right .c-tooltip__tip__arrow { border-top-color: #504945; }
+  .c-tooltip__tip--right .c-tooltip__tip__arrow { border-right-color: #504945; }
+  .c-tooltip__tip--bottom .c-tooltip__tip__arrow { border-bottom-color: #504945; }
+  .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow { border-bottom-color: #504945; }
+  .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow { border-bottom-color: #504945; }
+  .c-tooltip__tip--left .c-tooltip__tip__arrow { border-left-color: #504945; }
   .c-tooltip__tip--success { background-color: #98971a; }
   .c-tooltip__tip--success.c-tooltip__tip--top::after, .c-tooltip__tip--success.c-tooltip__tip--top-left::after, .c-tooltip__tip--success.c-tooltip__tip--top-right::after { border-top-color: #98971a; }
   .c-tooltip__tip--success.c-tooltip__tip--right::after { border-right-color: #98971a; }
   .c-tooltip__tip--success.c-tooltip__tip--bottom::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-left::after, .c-tooltip__tip--success.c-tooltip__tip--bottom-right::after { border-bottom-color: #98971a; }
   .c-tooltip__tip--success.c-tooltip__tip--left::after { border-left-color: #98971a; }
-  #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #1d2021; }
-  #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #1d2021; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div { background: #504945; }
+  #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior { background: #504945; }
   #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok { background: rgba(235, 219, 178, 0.5) !important; }
   #coachmark_interior { color: #f9f5d7; }
   #coachmark_interior .coachmark_close_btn { color: #f9f5d7; }
@@ -1530,8 +1530,8 @@
   .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value { color: #d79921; }
   .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a { color: #689d6a; }
   .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover { color: #cc241d; }
-  .menu_member_header .member_details_divider { border-color: #1d2021; }
-  .menu_member_footer { background: #282828; border-top: 1px solid #1d2021; }
+  .menu_member_header .member_details_divider { border-color: #504945; }
+  .menu_member_footer { background: #282828; border-top: 1px solid #504945; }
   .menu_member_footer p { color: #d79921; }
   .menu_member_footer #menu_member_dm_input p { color: #f9f5d7; }
   .member_meta { color: #689d6a; }
@@ -1543,7 +1543,7 @@
   .candy_red_bg { background-color: #cc241d !important; }
   .off_white_bg, .neutral_white_bg { background-color: #282828 !important; }
   .yolk_orange_bg, .burnt_violet_bg, .flexpane_grey_bg { background-color: #282828 !important; }
-  .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #1d2021 !important; }
+  .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg { background-color: #504945 !important; }
   .sk_black { color: inherit; }
   .monkey_scroll_bar { z-index: 99; }
   .client_header_icon { -moz-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); -webkit-filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); filter: brightness(0.6) contrast(3) invert(1) sepia(0.5); }
@@ -1599,14 +1599,14 @@
   .icon_search_close:hover { color: #cc241d; }
   .help { border-top-color: #282828; color: #d79921; }
   .two_factor_option_app, .two_factor_option_sms, .configure-step1, .configure-step3 { display: none; }
-  .two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  .two_factor_choice { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
   .two_factor_choice:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
   .two_factor_choice:hover .two_factor_link { color: #f9f5d7; }
-  a.two_factor_choice { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
-  a.two_factor_choice:link { background-color: #282828; border: 1px solid #1d2021; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
+  a.two_factor_choice:link { background-color: #282828; border: 1px solid #504945; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25); }
   a.two_factor_choice:hover, a.two_factor_choice:link:hover { box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.15); }
   a.two_factor_choice:hover .two_factor_link, a.two_factor_choice:link:hover .two_factor_link { color: #f9f5d7; }
-  .backup_codes { background: #282828; border-color: #1d2021; color: #f9f5d7; }
+  .backup_codes { background: #282828; border-color: #504945; color: #f9f5d7; }
   #channel_specific_settings tr { border-top-color: #1d2021; }
   #channel_specific_settings tr.channel_override_row.muted td { background: rgba(29, 32, 33, 0.5); }
   #channel_specific_settings .extra_left_border { border-left-color: #1d2021; }
@@ -1630,10 +1630,10 @@
   @media screen and (max-width: 768px) { .admin_list_item.expanded .sub_action + .sub_action:hover::before, .admin_list_item.expanded .sub_action + .sub_action:hover::after { color: #689d6a; } }
   .billing_selection { border-color: #282828; color: #f9f5d7 !important; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
   .billing_selection:hover { border-color: #ebdbb2; }
-  .billing_selection.active { background: #1d2021; border-color: #ebdbb2; }
-  .billing_selection.billing_selection--refactor { border-color: #1d2021; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
+  .billing_selection.active { background: #504945; border-color: #ebdbb2; }
+  .billing_selection.billing_selection--refactor { border-color: #504945; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
   .billing_selection.billing_selection--refactor:hover { border-color: #ebdbb2; }
-  .billing_selection.billing_selection--refactor.active { background: #1d2021; border-color: #ebdbb2; }
+  .billing_selection.billing_selection--refactor.active { background: #504945; border-color: #ebdbb2; }
   .billing_selection .billing_selection__price { color: #f9f5d7; }
   #billing_contacts_container { background: #282828; border-top: 1px solid #282828; }
   .billing_contact { border-bottom: 1px solid #1d2021; }
@@ -1649,26 +1649,26 @@
   .author_cell { color: #f9f5d7; }
   .message_cell.disabled { color: #d79921; }
   #message_container #msg_limit { color: #f9f5d7; }
-  .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #1d2021; }
-  .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #1d2021; }
+  .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover { border-color: #504945; }
+  .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover { border-right: 1px solid #504945; }
   .inactive { background-image: none; }
   .c3 line, .c3 path { stroke: #ebdbb2; }
   .c3-chart-arc .c3-gauge-value { fill: #ebdbb2; }
   .c3-chart-arc path { stroke: #282828; }
   .c3-chart-arc text { fill: #282828; }
-  .c3-chart-arcs .c3-chart-arcs-background { fill: #1d2021; }
+  .c3-chart-arcs .c3-chart-arcs-background { fill: #504945; }
   .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min { fill: #282828; }
   .c3-chart-arcs .c3-chart-arcs-gauge-unit { fill: #ebdbb2; }
   .c3-circle._expanded_ { stroke: #282828; }
   .c3-grid line { stroke: #ebdbb2; }
   .c3-grid text { fill: #f9f5d7; }
-  .c3-legend-background { fill: #282828; stroke: #1d2021; }
-  .c3-region { fill: #1d2021; }
+  .c3-legend-background { fill: #282828; stroke: #504945; }
+  .c3-region { fill: #504945; }
   .c3-selected-circle { fill: #282828; }
   .c3-tooltip { background-color: #282828; box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5); }
-  .c3-tooltip td { background-color: #282828; border-left-color: #1d2021; }
+  .c3-tooltip td { background-color: #282828; border-left-color: #504945; }
   .c3-tooltip th { background-color: #282828; color: #f9f5d7; }
-  .c3-tooltip tr { border-color: #1d2021; }
+  .c3-tooltip tr { border-color: #504945; }
   .ent_alert a { color: #689d6a; }
   .ent_alert a:link, .ent_alert a:visited { color: #cc241d; }
   .ent_alert_page.ent_alert_error { background: #cc241d; }
@@ -1676,11 +1676,11 @@
   .ent_analytics__disclaimer { border-top-color: #ebdbb2; color: #d79921; }
   .ent_analytics_overview__header { box-shadow: 0 1px rgba(0, 0, 0, 0.25); }
   .ent_avatar--bordered::before { box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.15); }
-  .ent_avatar { background-color: #1d2021; }
+  .ent_avatar { background-color: #504945; }
   .ent_callout__difference--increase { color: #98971a; }
   .ent_callout__icon_border { background-color: #282828; border-color: #ebdbb2; }
   .ent_callout__icon_image, .ent_callout__icon--filled { border-color: #ebdbb2; }
-  .ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #1d2021; }
+  .ent_callout__icon--empty, .ent_callout__icon--hidden { border-color: #504945; }
   .ent_callout__icon--limit_reached { border-color: #ebdbb2; }
   .ent_callout__insight { color: #d79921; }
   .ent_callout__limit { color: #d79921; }
@@ -1744,9 +1744,9 @@
   .ent_loading__overlay { background-image: linear-gradient(to bottom, rgba(40, 40, 40, 0.8), #282828); }
   .ent_modal__title--small { color: #f9f5d7; }
   .ent_modal_background { background-color: #1d2021; }
-  .ent_modal_breadcrumb_animated_step { background: #1d2021; }
+  .ent_modal_breadcrumb_animated_step { background: #504945; }
   .ent_modal_breadcrumb_circle_icon { background: #1d2021; }
-  .ent_modal_breadcrumb_line { background: #1d2021; }
+  .ent_modal_breadcrumb_line { background: #504945; }
   .ent_modal_breadcrumb_text { color: #d79921; }
   .ent_modal_footer { background-color: #282828; }
   .ent_modal_title { color: #f9f5d7; }
@@ -1779,18 +1779,18 @@
   html.no_touch .action_cog:hover { color: #cc241d; }
   html.no_touch .action_cog:hover i { color: #cc241d; }
   .help_pages.help_pages p { color: #f9f5d7; }
-  .help_pages.help_pages a { border-bottom-color: #1d2021; }
+  .help_pages.help_pages a { border-bottom-color: #504945; }
   .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header { background-color: #1d2021; }
   .help_pages.help_pages .o-hero__header { color: #f9f5d7; }
-  .help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #1d2021; }
+  .help_pages.help_pages .o-section--feature { background-color: #282828; border-top-color: #504945; }
   .help_pages.help_pages .c-form__container .c-form__feedback { color: #cc241d; }
-  .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #1d2021; color: #f9f5d7; }
+  .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input { background-color: #1d2021; border-color: #504945; color: #f9f5d7; }
   .help_pages.help_pages .drop_zone { background: #1d2021; border-color: #ebdbb2; }
-  .help_pages.help_pages .drop_zone_attachment { border-bottom-color: #1d2021; }
+  .help_pages.help_pages .drop_zone_attachment { border-bottom-color: #504945; }
   .help_pages.help_pages .drop_zone_remove_attachment { background-color: #1d2021; }
-  .help_pages.help_pages .c-form__notice { background-color: #1d2021; border-color: #ebdbb2; color: #f9f5d7; }
+  .help_pages.help_pages .c-form__notice { background-color: #504945; border-color: #ebdbb2; color: #f9f5d7; }
   .help_pages.help_pages .c-form__notice.is-error { border-left-color: #cc241d; }
-  .help_pages.help_pages .c-nav--footer { border-top-color: #1d2021; }
+  .help_pages.help_pages .c-nav--footer { border-top-color: #504945; }
   @media screen and (min-width: 48rem) { .help_pages.help_pages .o-hero { background-color: #1d2021; } }
   .widescreen:not(.nav_open) { color: #f9f5d7; }
   @media only screen and (min-width: 1441px) { .widescreen:not(.nav_open) nav#site_nav { background: rgba(29, 32, 33, 0.9); } }
@@ -1823,7 +1823,7 @@
   .tooltip.bottom .tooltip-arrow { border-bottom-color: #ebdbb2; }
   .api #header_logo img { display: none; }
   body.api header .header_links a { color: #f9f5d7; }
-  body.api header .header_links a.active { background: #1d2021; }
+  body.api header .header_links a.active { background: #504945; }
   body.api .reverse_header { background-color: #282828; color: #f9f5d7; }
   body.api pre { overflow-x: auto; }
   body.api pre code { color: #f9f5d7; }
@@ -1835,7 +1835,7 @@
   body.api .section_title { border-bottom: 2px solid #1d2021; }
   body.api .example { border: 1px solid #282828; }
   body.api .example h5 { background-color: #282828; color: #f9f5d7; }
-  body.api .alert { background: #1d2021; }
+  body.api .alert { background: #504945; }
   body.api .hljs { background-image: none; }
   body.api .hljs-keyword, body.api .hljs-selector-tag, body.api .hljs-subst { color: #ce93d8; }
   body.api .hljs-number { color: #a5d6a7; }
@@ -1877,25 +1877,25 @@
   .page_apps_directory_home__search .apps_search_input__body { box-shadow: 0 1px 10px #ebdbb2; }
   .splash_container__background { background-color: #282828; }
   .splash_container__background--left, .splash_container__background--center, .splash_container__background--right { display: none; }
-  .splash_interactive__button { border-color: #1d2021; }
+  .splash_interactive__button { border-color: #504945; }
   .splash_interactive__button--active { box-shadow: 0 0 10px 1px #ebdbb2; }
-  .splash_interactive__window { background-color: #1d2021; border-color: #1d2021; }
+  .splash_interactive__window { background-color: #1d2021; border-color: #504945; }
   .splash_interactive__window:hover .splash_interactive__window_headline { color: #f9f5d7; }
   .splash_interactive__window::after { background: linear-gradient(to bottom, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
   .splash_interactive__window_response { background-color: #fff; }
   a.splash_interactive__window_link { color: #f9f5d7; }
   .splash_interactive__window_message_content_text--drive { color: #d79921; }
   .search_input.apps_search_input { border-color: #ebdbb2; }
-  .menu_launcher, .menu_launcher_large { background-color: #1d2021; border-color: #1d2021 !important; color: #f9f5d7; }
+  .menu_launcher, .menu_launcher_large { background-color: #504945; border-color: #1d2021 !important; color: #f9f5d7; }
   .menu_launcher_large { border-color: #1d2021; }
-  .menu.avatar_menu ul li:hover ts-icon { background: #1d2021; color: #f9f5d7; }
+  .menu.avatar_menu ul li:hover ts-icon { background: #504945; color: #f9f5d7; }
   .menu.avatar_menu ul li a { color: #f9f5d7; }
-  .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #1d2021; color: #d79921; }
+  .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon { background-color: #504945; color: #d79921; }
   .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon { color: #f9f5d7; }
-  #page .media_list { background-color: #282828; border: 1px solid #1d2021; }
-  #page .media_list > li + li::before { border-top-color: #1d2021; }
+  #page .media_list { background-color: #282828; border: 1px solid #504945; }
+  #page .media_list > li + li::before { border-top-color: #504945; }
   #page .media_list > li.interactive a { color: #f9f5d7; }
-  #page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #1d2021; border-color: #ebdbb2; }
+  #page .media_list > li.interactive a:focus, #page .media_list > li.interactive a:hover { background: #504945; border-color: #ebdbb2; }
   #page .media_list > li .media_list_text { color: #f9f5d7; }
   #page .media_list.media_list_with_arrows a::before { color: #d79921; }
   #page .media_list_title { color: #f9f5d7; }
@@ -1908,12 +1908,12 @@
   #page ul.breadcrumbs li { color: #d79921; }
   #page ul.breadcrumbs li:not(:first-child)::before { color: #d79921; }
   #page ul.navigation_list li a { color: #f9f5d7; }
-  #page ul.navigation_list li a:hover { background-color: #1d2021; }
+  #page ul.navigation_list li a:hover { background-color: #504945; }
   #page ul.navigation_list li a::after { color: #f9f5d7; }
   #page ul.navigation_list li + li a { border-top: 1px solid transparent; }
   #page .tag { background-color: #282828; border: 1px solid #282828; }
-  #page .tag:hover { background-color: #1d2021 !important; }
-  #page .app_desc_btn { background-color: #1d2021; color: #f9f5d7; }
+  #page .tag:hover { background-color: #504945 !important; }
+  #page .app_desc_btn { background-color: #504945; color: #f9f5d7; }
   #page .app_desc_expand_showing .app_profile_desc_fade { background: linear-gradient(180deg, rgba(29, 32, 33, 0) 0, #1d2021 100%); }
   #page .service_panel { background-color: #282828; }
   #page .service_card { background-color: #1d2021; border: 1px solid #282828; }
@@ -1926,48 +1926,48 @@
   nav.top.apps_nav ul a.active { color: #cc241d; }
   .plastic_typeahead { background: #282828; border: 1px solid #282828; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25); }
   .plastic_typeahead_item { color: #f9f5d7; }
-  .plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #1d2021; }
+  .plastic_typeahead_item + .plastic_typeahead_item { border-top: 1px solid #504945; }
   .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active { background-color: #1d2021; border-top-color: #282828; color: #f9f5d7; }
   .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon { color: #d79921; }
-  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #1d2021; }
-  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #1d2021; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover { background: #282828; border-color: #504945; }
+  .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover + .plastic_typeahead_item { border-color: #504945; }
   a.plastic_typeahead_item { color: #f9f5d7; }
   .apps_typeahead_item_media { background: #282828; }
   .search_input_container .search_input:focus ~ .icon_search_input { color: #f9f5d7; }
   .icon_search_input { color: #d79921; }
   .quote_block { color: #f9f5d7; }
-  .quote_block::before { background-color: #1d2021; }
+  .quote_block::before { background-color: #504945; }
   .well { background: #282828; border-color: #232323; color: #f9f5d7; text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5); }
   .service_breadcrumbs li .ts_icon, .service_breadcrumbs li span { color: #d79921; }
-  .c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+  .c-tabs__tab_menu { background-color: transparent; box-shadow: inset 0 -2px 0 0 #504945; }
   .c-tabs__tab { color: #d79921; }
   .c-tabs__tab:hover { color: #f9f5d7; }
   .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
-  .c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #1d2021; }
+  .c-tabs__tab_menu--plastic { background-color: transparent; box-shadow: inset 0 -2px 0 0 #504945; }
   a.c-tabs__tab--plastic { color: #d79921; }
   a.c-tabs__tab--plastic:hover { color: #f9f5d7; }
   a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus { box-shadow: inset 0 -2px 0 0 #ebdbb2; color: #f9f5d7; }
-  .p-detail_scope { box-shadow: inset 0 1px 0 0 #1d2021; }
-  .p-detail_scope:last-child { border-bottom-color: #1d2021; }
-  .p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #1d2021; }
+  .p-detail_scope { box-shadow: inset 0 1px 0 0 #504945; }
+  .p-detail_scope:last-child { border-bottom-color: #504945; }
+  .p-detail_dangerous_scope { border-left-color: #cc241d; border-right-color: #504945; }
   .p-detail_arrow_icon { color: #d79921; }
   .p-detail_arrow_icon:hover { color: #f9f5d7; }
-  .p-detail_permissions { background: #282828; border-color: #1d2021; }
-  table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #1d2021; }
+  .p-detail_permissions { background: #282828; border-color: #504945; }
+  table.gray_header_border tr:first-child th:not(:only-of-type) { border-bottom-color: #504945; }
   .section_rollup { border-bottom-color: #1d2021; }
   .section_rollup:first-of-type { border-top-color: #1d2021; }
   .section_rollup:hover:not(.is_active) { background: rgba(29, 32, 33, 0.5); color: #f9f5d7; }
   .is_completed_section .section_rollup_header::before, .is_failed_section .section_rollup_header::before { background-color: #98971a; color: #282828; }
-  .developer_apps_functionality_link:hover { border-color: #1d2021; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
-  .developer_apps_functionality_link::before { background-color: #1d2021; }
+  .developer_apps_functionality_link:hover { border-color: #504945; box-shadow: 0 0 6px 0 rgba(235, 219, 178, 0.25); }
+  .developer_apps_functionality_link::before { background-color: #504945; }
   .developer_apps_functionality_link_enabled::before { background-color: #98971a; }
   .legal-hero { background-color: #1d2021; }
   .legal-hero.v--no-switch, .legal-hero .o-hero__header { background-color: #1d2021; }
   .legal-hero .o-hero__header__headline--larger { color: #f9f5d7; }
   .legal-main { background-color: #282828; }
-  .legal-main.v--no-switch { background-color: #282828; border-bottom-color: #1d2021; border-top-color: #1d2021; }
+  .legal-main.v--no-switch { background-color: #282828; border-bottom-color: #504945; border-top-color: #504945; }
   .legal-main p { color: #f9f5d7; }
-  .legal-main a { border-bottom-color: #1d2021; }
+  .legal-main a { border-bottom-color: #504945; }
   @media screen and (min-width: 67.8125rem) { .legal-main .c-nav--sidebar__listheader { color: #f9f5d7; }
     .legal-main .c-nav--sidebar__listitem a.is-selected { color: #d79921; } }
   .legal-main .t-contains-subtle-links a:not(.c-button) { color: #f9f5d7; }
@@ -1975,12 +1975,12 @@
   @media screen and (min-width: 67.8125rem) { .t-no-header .legal-main { background-color: #282828; } }
   .t-no-header .legal-hero.o-hero.v--short { background-color: #282828; }
   .c-oauth_scope_info__spacer_icon { color: #cc241d; }
-  .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #1d2021; }
-  .c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #1d2021; border-top-color: #1d2021; }
-  .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #1d2021; }
+  .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes { border-bottom-color: #504945; }
+  .c-oauth_scope_info__dangerous_scopes { border-left-color: #cc241d; border-right-color: #504945; border-top-color: #504945; }
+  .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope { border-top-color: #504945; }
   a.p-oauth_nav__anchor { color: #d79921; }
   .p-oauth_nav__team-switcher .menu_launcher { border-color: #282828; }
-  .p-oauth_nav__team-switcher .menu_launcher:hover { border: #1d2021; }
+  .p-oauth_nav__team-switcher .menu_launcher:hover { border: #504945; }
   .p-oauth_page, .p-oauth_page--error { background: #1d2021; }
   .p-oauth_page__title { color: #f9f5d7; }
   .p-oauth_page_single_channel_picker { border-bottom-color: #282828; }
@@ -2012,16 +2012,16 @@
   .focusing_input_field space.inactive .unfurl.selected .unfurl-container { background-color: #282828; }
   nav { background: #282828; }
   nav .space { background-color: #282828; box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15); }
-  nav .space::after { border-left: 1px solid #1d2021; }
+  nav .space::after { border-left: 1px solid #504945; }
   nav .comments { background-color: #282828; }
   nav .space_buttons .btn_outline { background-color: #282828; }
-  nav .space_buttons .btn_outline::after { border-color: #1d2021; }
+  nav .space_buttons .btn_outline::after { border-color: #504945; }
   nav .space_btn_star { background: none; border: 0; }
   nav .space_btn_star:hover { background: none !important; }
-  nav .space_btn_edit { background: #1d2021; }
+  nav .space_btn_edit { background: #504945; }
   nav .space_btn_edit.editing { background: #ebdbb2; }
   nav .star_info { color: #d79921; }
-  nav #space_status { border-left: 1px solid #1d2021; color: #d79921; }
+  nav #space_status { border-left: 1px solid #504945; color: #d79921; }
   nav #space_status.slightly_concerned { color: #cc241d; }
   nav #edit_status { color: #d79921; }
   nav .comments_open.unread span.notif { background-color: #cc241d; box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15); }
@@ -2036,7 +2036,7 @@
   ts-space header .owner_detail .inline-edit:focus::-moz-placeholder { color: #d79921; }
   ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection { background-color: rgba(235, 219, 178, 0.5); }
   ts-space header .owner_detail small { color: #d79921; }
-  ts-space header .divider { border-top: 1px solid #1d2021; }
+  ts-space header .divider { border-top: 1px solid #504945; }
   ts-space a.feedback { color: #f9f5d7; text-shadow: -1px -1px 0 #282828, -1px 1px 0 #282828, 1px 1px 0 #282828, 1px -1px 0 #282828; }
   ts-space a.feedback:hover { background-color: #282828; color: #f9f5d7; }
   comments { box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.25); }
@@ -2047,10 +2047,10 @@
   #space_alert button#space_alert_close::before { color: #d79921; }
   #space_alert button#space_alert_close:hover::before { color: #d79921; }
   #space_alert .btn_outline.btn_transparent { background-color: #282828 !important; color: #f9f5d7 !important; }
-  #space_alert .btn_outline.btn_transparent::after { border-color: #1d2021; }
+  #space_alert .btn_outline.btn_transparent::after { border-color: #504945; }
   #space_find_bar { background-color: #282828; border-bottom: 1px solid rgba(235, 219, 178, 0.1); border-left: 1px solid rgba(235, 219, 178, 0.07); border-right: 1px solid rgba(235, 219, 178, 0.07); box-shadow: 0 1px rgba(0, 0, 0, 0.15); }
   #space_find_bar #space_find_info.no_matches { color: #cc241d; }
-  #space_find_bar #space_find_next .ts_icon { background-color: #1d2021; }
+  #space_find_bar #space_find_next .ts_icon { background-color: #504945; }
   #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before { color: #f9f5d7; }
   #space_find_bar #space_find_next:hover .ts_icon { background-color: #ebdbb2; }
   #space_find_bar #space_find_close::before { color: #d79921; }
@@ -2073,26 +2073,26 @@
   .textstyle_menu.link .arrow-shadow::after { background-color: #282828; }
   .textstyle_menu.link .arrow::after { background-color: #282828; }
   .textstyle_menu.link .content { background-color: #282828; box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
-  .textstyle_menu.link .content input[type=text] { background-color: #1d2021; }
+  .textstyle_menu.link .content input[type=text] { background-color: #504945; }
   .textstyle_menu.link .content > a.link { color: #689d6a; }
   .textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder { color: #d79921; }
   .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover { background-color: #282828; }
-  .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #1d2021; }
-  .textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #1d2021; border: 1px solid #ebdbb2; }
-  .textstyle_menu.style a.deformat::before { border-left: 1px solid #1d2021; }
+  .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover { border: 1px solid #504945; }
+  .textstyle_menu .buttons a.active, .textstyle_menu.style a.active { background-color: #504945; border: 1px solid #ebdbb2; }
+  .textstyle_menu.style a.deformat::before { border-left: 1px solid #504945; }
   .textstyle_menu .buttons a.link_unfurl:not(.unfurl_pending) span::before { color: #d79921; }
   .para_menu .insert .tip { color: #d79921; }
-  .para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+  .para_menu .insert .tooltip .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #504945; }
   .para_menu .insert .tooltip .arrow::after { background-color: #282828; }
-  .para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
-  .para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #1d2021; }
+  .para_menu .insert .tooltip .content { background-color: #282828; box-shadow: 0 0 0 1px #504945, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .arrow-shadow::after { background-color: #282828; box-shadow: 0 0 0 1px #504945; }
   .para_menu .format .options .arrow::after { background-color: #282828; }
-  .para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #1d2021; }
-  .para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #1d2021, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
+  .para_menu .format .options .arrow-shadow.bottom::after { box-shadow: 1px 1px 0 0 #504945; }
+  .para_menu .format .options .content { background-color: #282828; box-shadow: 0 0 0 1px #504945, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25); }
   .para_menu .format .options .content ul:first-child { border-bottom: 1px solid #282828; }
   .para_menu .format .options.show .tooltip > div { background-color: #282828; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15); color: #f9f5d7; }
-  .para_menu .format .options.show .tooltip span { background-color: #1d2021; }
-  .para_menu .options a:hover { border: 1px solid #1d2021; }
+  .para_menu .format .options.show .tooltip span { background-color: #504945; }
+  .para_menu .options a:hover { border: 1px solid #504945; }
   .para_menu .options a.active { background-color: #282828; border: 1px solid #282828; }
   .para_menu .options a.active span { filter: grayscale(2) brightness(2); }
   .para_menu .options a span { filter: grayscale(2) brightness(5); }

--- a/scss/themes/_gruvbox-dark.scss
+++ b/scss/themes/_gruvbox-dark.scss
@@ -1,0 +1,42 @@
+$dark0:   #1d2021;
+$dark1:   #282828;
+$dark2:   #3c3836;
+$dark3:   #504945;
+$dark4:   #665c54;
+
+$light0:  #f9f5d7;
+$light1:  #ebdbb2;
+$light2:  #d5c4a1;
+$light3:  #bdae93;
+$light4:  #a89984;
+
+$red:     #cc241d;
+$green:   #98971a;
+$yellow:  #d79921;
+$blue:    #458588;
+$purple:  #b16286;
+$aqua:    #689d6a;
+$orange:  #d65d0e;
+
+// Theme Colors
+$color-base: $dark0;
+$color-highlight: $yellow;
+
+$color-red: $red;
+$color-green: $green;
+$color-yellow: $yellow;
+
+$black: $dark0;
+$white: $light0;
+
+$color-shade-darkest: $dark1;
+$color-shade-dark: $dark1;
+$color-shade-mid: $dark1;
+$color-shade-light: $dark0;
+$color-shade-lightest: $light1;
+
+// Font Colors
+$base-font-color: $light0;
+
+$base-link-color: $aqua;
+$base-link-color-active: $red;

--- a/scss/themes/_gruvbox-dark.scss
+++ b/scss/themes/_gruvbox-dark.scss
@@ -32,7 +32,7 @@ $white: $light0;
 $color-shade-darkest: $dark1;
 $color-shade-dark: $dark1;
 $color-shade-mid: $dark1;
-$color-shade-light: $dark0;
+$color-shade-light: $dark3;
 $color-shade-lightest: $light1;
 
 // Font Colors

--- a/scss/themes/build-variants/gruvbox-dark--main.scss
+++ b/scss/themes/build-variants/gruvbox-dark--main.scss
@@ -1,0 +1,3 @@
+@import "../gruvbox-dark";
+
+@import "../../main";

--- a/scss/themes/build-variants/gruvbox-dark--styles.scss
+++ b/scss/themes/build-variants/gruvbox-dark--styles.scss
@@ -1,0 +1,3 @@
+@import "../gruvbox-dark";
+
+@import "../../styles";


### PR DESCRIPTION
Adding some retro groovy goodness. Tested on desktop and web.

Screenshot:
<img width="1269" alt="Screen Shot 2019-04-23 at 12 40 58 PM" src="https://user-images.githubusercontent.com/32886847/56603304-1eba4f80-65c5-11e9-8330-24dcc8f7ab7a.png">


Sidebar theme:
`#282828,#504945,#98971a,#1D2021,#504945,#FBF1C7,#b8bb26,#FB4934`